### PR TITLE
fix: remove PYSEC-2022-42969 pip-audit suppression

### DIFF
--- a/scripts/security.sh
+++ b/scripts/security.sh
@@ -75,16 +75,11 @@ if $VERBOSE; then
     echo "Running pip-audit dependency checker..."
 fi
 
-# Known vulnerability ignores (deps with no fix available):
-#   PYSEC-2022-42969: py 1.11.0 - deprecated package, transitive dep from pytest tooling
-#   Issue #3: Remove once pytest ecosystem drops the py transitive dependency
-PIP_AUDIT_ARGS=("--ignore-vuln" "PYSEC-2022-42969")
-
 VENV_PYTHON="${VIRTUAL_ENV:-$PROJECT_ROOT/.venv}/bin/python"
 if [ -x "$VENV_PYTHON" ]; then
-    PIPAPI_PYTHON_LOCATION="$VENV_PYTHON" pip-audit "${PIP_AUDIT_ARGS[@]}" || { echo "✗ pip-audit found issues" >&2; exit 1; }
+    PIPAPI_PYTHON_LOCATION="$VENV_PYTHON" pip-audit || { echo "✗ pip-audit found issues" >&2; exit 1; }
 else
-    pip-audit "${PIP_AUDIT_ARGS[@]}" || { echo "✗ pip-audit found issues" >&2; exit 1; }
+    pip-audit || { echo "✗ pip-audit found issues" >&2; exit 1; }
 fi
 
 if $FULL; then


### PR DESCRIPTION
## Summary
- Removes the `--ignore-vuln PYSEC-2022-42969` suppression from `scripts/security.sh`
- The `py` transitive dependency is no longer present in our environment
- Simplifies the pip-audit invocation by removing the `PIP_AUDIT_ARGS` bash array

Closes #3

## Test plan
- [x] `./scripts/security.sh` passes without suppression
- [x] `./scripts/check-all.sh` passes all 7 gates (629 tests, 96.93% coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)