### PR TITLE
feat: add Claude-assisted product selection with brand preferences

### DIFF
--- a/grocery_butler/product_selector.py
+++ b/grocery_butler/product_selector.py
@@ -1,0 +1,455 @@
+"""Claude-assisted product selection with brand preference support.
+
+Selects the best Safeway product from search results using Claude,
+respecting brand preferences (preferred/avoided) and price sensitivity.
+
+Selection flow:
+1. Filter out products from avoided brands
+2. Load brand preferences (ingredient-level overrides category-level)
+3. Ask Claude to select the best product given preferences
+4. Return the selected product with reasoning
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from grocery_butler.models import (
+    BrandPreference,
+    BrandPreferenceType,
+    PriceSensitivity,
+    SafewayProduct,
+    ShoppingListItem,
+)
+from grocery_butler.prompt_loader import load_prompt
+
+if TYPE_CHECKING:
+    from grocery_butler.recipe_store import RecipeStore
+
+logger = logging.getLogger(__name__)
+
+_MODEL = "claude-sonnet-4-20250514"
+_MAX_TOKENS = 1024
+
+
+class ProductSelectionError(Exception):
+    """Raised when product selection fails."""
+
+
+@dataclass
+class SelectionResult:
+    """The outcome of product selection for one shopping list item.
+
+    Attributes:
+        item: The original shopping list item.
+        product: The selected product, or None if no match found.
+        reasoning: Claude's explanation for the selection.
+    """
+
+    item: ShoppingListItem
+    product: SafewayProduct | None
+    reasoning: str
+
+
+class ProductSelector:
+    """Claude-assisted product selector with brand preferences.
+
+    Args:
+        claude_client: Anthropic API client.
+        recipe_store: Database access for brand preferences.
+    """
+
+    def __init__(
+        self,
+        claude_client: Any,
+        recipe_store: RecipeStore,
+    ) -> None:
+        """Initialize the product selector.
+
+        Args:
+            claude_client: Anthropic API client (typed as Any for flexibility).
+            recipe_store: Database access for brand preferences.
+        """
+        self._client = claude_client
+        self._store = recipe_store
+
+    def select_product(
+        self,
+        item: ShoppingListItem,
+        candidates: list[SafewayProduct],
+    ) -> SelectionResult:
+        """Select the best product for a shopping list item.
+
+        Filters out avoided brands, then uses Claude to pick the
+        best option respecting brand preferences and price sensitivity.
+
+        Args:
+            item: The shopping list item needing a product.
+            candidates: Search results from Safeway.
+
+        Returns:
+            SelectionResult with chosen product and reasoning.
+        """
+        if not candidates:
+            return SelectionResult(
+                item=item,
+                product=None,
+                reasoning="No products available",
+            )
+
+        brand_prefs = self._get_brand_preferences(item)
+        filtered = _filter_avoided_brands(candidates, brand_prefs)
+
+        if not filtered:
+            return SelectionResult(
+                item=item,
+                product=None,
+                reasoning="All available products are from avoided brands",
+            )
+
+        price_sensitivity = self._get_price_sensitivity()
+        return self._ask_claude(item, filtered, brand_prefs, price_sensitivity)
+
+    def select_products(
+        self,
+        items_and_candidates: list[tuple[ShoppingListItem, list[SafewayProduct]]],
+    ) -> list[SelectionResult]:
+        """Select products for multiple shopping list items.
+
+        Args:
+            items_and_candidates: List of (item, candidates) tuples.
+
+        Returns:
+            List of SelectionResult for each item.
+        """
+        return [
+            self.select_product(item, candidates)
+            for item, candidates in items_and_candidates
+        ]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _get_brand_preferences(
+        self,
+        item: ShoppingListItem,
+    ) -> list[BrandPreference]:
+        """Get brand preferences for a shopping list item.
+
+        Checks ingredient-level first, falls back to category-level.
+
+        Args:
+            item: The shopping list item.
+
+        Returns:
+            List of relevant brand preferences.
+        """
+        return self._store.get_brands_for_ingredient(
+            item.ingredient,
+            category=item.category.value,
+        )
+
+    def _get_price_sensitivity(self) -> str:
+        """Get the user's price sensitivity setting.
+
+        Returns:
+            Price sensitivity string, defaults to "moderate".
+        """
+        value = self._store.get_preference("price_sensitivity")
+        if value is not None:
+            try:
+                return PriceSensitivity(value).value
+            except ValueError:
+                pass
+        return PriceSensitivity.MODERATE.value
+
+    def _ask_claude(
+        self,
+        item: ShoppingListItem,
+        candidates: list[SafewayProduct],
+        brand_prefs: list[BrandPreference],
+        price_sensitivity: str,
+    ) -> SelectionResult:
+        """Ask Claude to select the best product.
+
+        Args:
+            item: The shopping list item.
+            candidates: Filtered product candidates.
+            brand_prefs: Relevant brand preferences.
+            price_sensitivity: User's price sensitivity setting.
+
+        Returns:
+            SelectionResult with Claude's selection.
+        """
+        prompt = self._build_prompt(item, candidates, brand_prefs, price_sensitivity)
+        response_text = self._call_claude(prompt)
+        if response_text is None:
+            return self._fallback_selection(item, candidates, brand_prefs)
+
+        result = _parse_selection_response(response_text, candidates)
+        if result is not None:
+            return SelectionResult(item=item, product=result[0], reasoning=result[1])
+
+        return self._fallback_selection(item, candidates, brand_prefs)
+
+    def _build_prompt(
+        self,
+        item: ShoppingListItem,
+        candidates: list[SafewayProduct],
+        brand_prefs: list[BrandPreference],
+        price_sensitivity: str,
+    ) -> str:
+        """Build the product selection prompt.
+
+        Args:
+            item: The shopping list item.
+            candidates: Filtered product candidates.
+            brand_prefs: Relevant brand preferences.
+            price_sensitivity: User's price sensitivity.
+
+        Returns:
+            Formatted prompt string.
+        """
+        products_json = json.dumps(
+            [_product_to_dict(p) for p in candidates],
+            indent=2,
+        )
+        brand_text = _format_brand_preferences(brand_prefs)
+
+        return load_prompt(
+            "product_selection",
+            ingredient=item.ingredient,
+            quantity=str(item.quantity),
+            unit=str(item.unit),
+            search_term=item.search_term,
+            category=item.category.value,
+            products_json=products_json,
+            brand_preferences=brand_text,
+            price_sensitivity=price_sensitivity,
+        )
+
+    def _call_claude(self, prompt: str) -> str | None:
+        """Send a prompt to Claude and return the text response.
+
+        Args:
+            prompt: The formatted prompt string.
+
+        Returns:
+            Response text or None on failure.
+        """
+        try:
+            response = self._client.messages.create(
+                model=_MODEL,
+                max_tokens=_MAX_TOKENS,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            return str(response.content[0].text)
+        except Exception:
+            logger.exception("Claude product selection call failed")
+            return None
+
+    @staticmethod
+    def _fallback_selection(
+        item: ShoppingListItem,
+        candidates: list[SafewayProduct],
+        brand_prefs: list[BrandPreference],
+    ) -> SelectionResult:
+        """Select a product without Claude using simple heuristics.
+
+        Prefers preferred-brand in-stock products, then cheapest.
+
+        Args:
+            item: The shopping list item.
+            candidates: Filtered product candidates.
+            brand_prefs: Relevant brand preferences.
+
+        Returns:
+            SelectionResult from heuristic selection.
+        """
+        preferred = _get_preferred_brands(brand_prefs)
+        best = _heuristic_select(candidates, preferred)
+        return SelectionResult(
+            item=item,
+            product=best,
+            reasoning="Selected via fallback heuristic (Claude unavailable)",
+        )
+
+
+# ------------------------------------------------------------------
+# Pure helper functions
+# ------------------------------------------------------------------
+
+
+def _filter_avoided_brands(
+    products: list[SafewayProduct],
+    brand_prefs: list[BrandPreference],
+) -> list[SafewayProduct]:
+    """Remove products whose name contains an avoided brand.
+
+    Args:
+        products: Candidate products.
+        brand_prefs: Brand preferences to check.
+
+    Returns:
+        Products not matching any avoided brand.
+    """
+    avoided = {
+        pref.brand.lower()
+        for pref in brand_prefs
+        if pref.preference_type == BrandPreferenceType.AVOID
+    }
+    if not avoided:
+        return products
+    return [
+        p for p in products if not any(brand in p.name.lower() for brand in avoided)
+    ]
+
+
+def _get_preferred_brands(
+    brand_prefs: list[BrandPreference],
+) -> set[str]:
+    """Extract preferred brand names (lowercased).
+
+    Args:
+        brand_prefs: Brand preferences to check.
+
+    Returns:
+        Set of preferred brand names in lowercase.
+    """
+    return {
+        pref.brand.lower()
+        for pref in brand_prefs
+        if pref.preference_type == BrandPreferenceType.PREFERRED
+    }
+
+
+def _heuristic_select(
+    candidates: list[SafewayProduct],
+    preferred_brands: set[str],
+) -> SafewayProduct:
+    """Select a product using simple heuristics.
+
+    Priority: in-stock preferred brand > in-stock any > cheapest.
+
+    Args:
+        candidates: Non-empty list of product candidates.
+        preferred_brands: Lowercased preferred brand names.
+
+    Returns:
+        The best candidate by heuristic ranking.
+    """
+    in_stock = [p for p in candidates if p.in_stock]
+    pool = in_stock if in_stock else candidates
+
+    if preferred_brands:
+        preferred_matches = [
+            p for p in pool if any(b in p.name.lower() for b in preferred_brands)
+        ]
+        if preferred_matches:
+            return min(preferred_matches, key=lambda p: p.price)
+
+    return min(pool, key=lambda p: p.price)
+
+
+def _product_to_dict(product: SafewayProduct) -> dict[str, Any]:
+    """Convert a SafewayProduct to a dict for JSON serialization.
+
+    Args:
+        product: The product to convert.
+
+    Returns:
+        Dict with product fields.
+    """
+    return {
+        "product_id": product.product_id,
+        "name": product.name,
+        "price": product.price,
+        "unit_price": product.unit_price,
+        "size": product.size,
+        "in_stock": product.in_stock,
+    }
+
+
+def _format_brand_preferences(prefs: list[BrandPreference]) -> str:
+    """Format brand preferences as human-readable text.
+
+    Args:
+        prefs: List of brand preferences.
+
+    Returns:
+        Formatted string describing preferences.
+    """
+    if not prefs:
+        return "No brand preferences set."
+
+    lines: list[str] = []
+    for pref in prefs:
+        action = (
+            "PREFER"
+            if pref.preference_type == BrandPreferenceType.PREFERRED
+            else "AVOID"
+        )
+        lines.append(
+            f"- {action}: {pref.brand} (for {pref.match_type}: {pref.match_target})"
+        )
+    return "\n".join(lines)
+
+
+def _parse_selection_response(
+    text: str,
+    candidates: list[SafewayProduct],
+) -> tuple[SafewayProduct | None, str] | None:
+    """Parse Claude's product selection response.
+
+    Args:
+        text: Raw response text from Claude.
+        candidates: The product candidates that were presented.
+
+    Returns:
+        Tuple of (selected_product, reasoning) or None on parse failure.
+    """
+    cleaned = _extract_json_text(text)
+    try:
+        data = json.loads(cleaned)
+    except json.JSONDecodeError:
+        logger.warning("Failed to parse product selection response as JSON")
+        return None
+
+    if not isinstance(data, dict):
+        return None
+
+    index = data.get("selected_index")
+    reasoning = str(data.get("reasoning", "No reasoning provided"))
+
+    if not isinstance(index, int):
+        return None
+
+    if index == -1:
+        return (None, reasoning)
+
+    if 0 <= index < len(candidates):
+        return (candidates[index], reasoning)
+
+    return None
+
+
+def _extract_json_text(raw: str) -> str:
+    """Extract JSON from a Claude response, stripping markdown fences.
+
+    Args:
+        raw: Raw text from Claude's response.
+
+    Returns:
+        Cleaned string ready for JSON parsing.
+    """
+    text = raw.strip()
+    if text.startswith("```"):
+        first_newline = text.index("\n")
+        text = text[first_newline + 1 :]
+    if text.endswith("```"):
+        text = text[: -len("```")]
+    return text.strip()

--- a/grocery_butler/prompts/brand_selection.txt
+++ b/grocery_butler/prompts/brand_selection.txt
@@ -1,2 +1,16 @@
-# Future use: Safeway brand selection
-This prompt will be implemented in Phase 3.
+You are a grocery shopping assistant. Given a list of products, filter and rank them based on brand preferences.
+
+## Products
+{products_json}
+
+## Brand Rules
+Avoided brands (MUST exclude): {avoided_brands}
+Preferred brands (rank higher): {preferred_brands}
+
+## Output Format
+Return ONLY a JSON array of 0-based product indices, ordered from best to worst choice.
+Exclude any products from avoided brands entirely.
+
+Example: [2, 0, 3]
+
+Return ONLY valid JSON — no markdown fences, no explanation.

--- a/grocery_butler/prompts/product_selection.txt
+++ b/grocery_butler/prompts/product_selection.txt
@@ -1,2 +1,37 @@
-# Future use: Safeway product selection
-This prompt will be implemented in Phase 3.
+You are a grocery shopping assistant selecting the best product from Safeway search results for a shopping list item.
+
+## Shopping List Item
+- Ingredient: {ingredient}
+- Quantity needed: {quantity} {unit}
+- Search term: {search_term}
+- Category: {category}
+
+## Available Products
+{products_json}
+
+## Brand Preferences
+{brand_preferences}
+
+## Price Sensitivity
+{price_sensitivity}
+
+## Rules
+1. NEVER select a product from an avoided brand
+2. Prefer products from preferred brands when available
+3. Consider price sensitivity:
+   - "budget": choose the lowest price option that meets quality requirements
+   - "moderate": balance price and quality, prefer preferred brands
+   - "premium": choose the highest quality option, price is secondary
+4. Prefer in-stock products over out-of-stock
+5. Match the size/quantity to what the recipe needs
+6. If no suitable product exists, set "selected_index" to -1
+
+## Output Format
+Return ONLY valid JSON:
+{{
+  "selected_index": 0,
+  "reasoning": "Brief explanation of why this product was chosen"
+}}
+
+Where "selected_index" is the 0-based index into the products list, or -1 if none are suitable.
+Return ONLY valid JSON — no markdown fences, no explanation.

--- a/tests/test_product_selector.py
+++ b/tests/test_product_selector.py
@@ -1,0 +1,543 @@
+"""Tests for grocery_butler.product_selector module."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from grocery_butler.models import (
+    BrandMatchType,
+    BrandPreference,
+    BrandPreferenceType,
+    IngredientCategory,
+    SafewayProduct,
+    ShoppingListItem,
+)
+from grocery_butler.product_selector import (
+    ProductSelector,
+    _extract_json_text,
+    _filter_avoided_brands,
+    _format_brand_preferences,
+    _get_preferred_brands,
+    _heuristic_select,
+    _parse_selection_response,
+    _product_to_dict,
+)
+
+# ------------------------------------------------------------------
+# Fixtures
+# ------------------------------------------------------------------
+
+
+def _make_item(
+    ingredient: str = "whole milk",
+    quantity: float = 1.0,
+    unit: str = "gal",
+    category: IngredientCategory = IngredientCategory.DAIRY,
+    search_term: str = "whole milk gallon",
+) -> ShoppingListItem:
+    """Create a test ShoppingListItem.
+
+    Args:
+        ingredient: Ingredient name.
+        quantity: Amount needed.
+        unit: Unit of measurement.
+        category: Grocery category.
+        search_term: Safeway search term.
+
+    Returns:
+        A ShoppingListItem for testing.
+    """
+    return ShoppingListItem(
+        ingredient=ingredient,
+        quantity=quantity,
+        unit=unit,
+        category=category,
+        search_term=search_term,
+        from_meals=["Test Meal"],
+    )
+
+
+def _make_product(
+    product_id: str = "UPC001",
+    name: str = "Organic Whole Milk",
+    price: float = 5.99,
+    size: str = "1 gal",
+    in_stock: bool = True,
+) -> SafewayProduct:
+    """Create a test SafewayProduct.
+
+    Args:
+        product_id: Product identifier.
+        name: Product name.
+        price: Product price.
+        size: Product size.
+        in_stock: Availability.
+
+    Returns:
+        A SafewayProduct for testing.
+    """
+    return SafewayProduct(
+        product_id=product_id,
+        name=name,
+        price=price,
+        size=size,
+        in_stock=in_stock,
+    )
+
+
+def _make_pref(
+    brand: str = "Organic Valley",
+    pref_type: BrandPreferenceType = BrandPreferenceType.PREFERRED,
+    match_target: str = "milk",
+    match_type: BrandMatchType = BrandMatchType.INGREDIENT,
+) -> BrandPreference:
+    """Create a test BrandPreference.
+
+    Args:
+        brand: Brand name.
+        pref_type: Preferred or avoid.
+        match_target: Ingredient or category name.
+        match_type: Whether this targets an ingredient or category.
+
+    Returns:
+        A BrandPreference for testing.
+    """
+    return BrandPreference(
+        match_target=match_target,
+        match_type=match_type,
+        brand=brand,
+        preference_type=pref_type,
+    )
+
+
+# ------------------------------------------------------------------
+# Tests: _filter_avoided_brands
+# ------------------------------------------------------------------
+
+
+class TestFilterAvoidedBrands:
+    """Tests for _filter_avoided_brands."""
+
+    def test_no_prefs_returns_all(self) -> None:
+        """Test all products returned when no preferences."""
+        products = [_make_product(name="Brand A"), _make_product(name="Brand B")]
+        result = _filter_avoided_brands(products, [])
+        assert len(result) == 2
+
+    def test_filters_avoided_brand(self) -> None:
+        """Test that avoided brand products are removed."""
+        products = [
+            _make_product(product_id="1", name="Great Value Milk"),
+            _make_product(product_id="2", name="Organic Valley Milk"),
+        ]
+        prefs = [_make_pref("Great Value", BrandPreferenceType.AVOID)]
+        result = _filter_avoided_brands(products, prefs)
+
+        assert len(result) == 1
+        assert result[0].product_id == "2"
+
+    def test_case_insensitive_matching(self) -> None:
+        """Test that brand matching is case-insensitive."""
+        products = [_make_product(name="GREAT VALUE Milk")]
+        prefs = [_make_pref("great value", BrandPreferenceType.AVOID)]
+        result = _filter_avoided_brands(products, prefs)
+        assert result == []
+
+    def test_preferred_brands_not_filtered(self) -> None:
+        """Test that preferred brands are NOT filtered out."""
+        products = [_make_product(name="Organic Valley Milk")]
+        prefs = [_make_pref("Organic Valley", BrandPreferenceType.PREFERRED)]
+        result = _filter_avoided_brands(products, prefs)
+        assert len(result) == 1
+
+
+# ------------------------------------------------------------------
+# Tests: _get_preferred_brands
+# ------------------------------------------------------------------
+
+
+class TestGetPreferredBrands:
+    """Tests for _get_preferred_brands."""
+
+    def test_empty_prefs(self) -> None:
+        """Test empty preferences returns empty set."""
+        assert _get_preferred_brands([]) == set()
+
+    def test_extracts_preferred_only(self) -> None:
+        """Test only preferred brands are extracted."""
+        prefs = [
+            _make_pref("Organic Valley", BrandPreferenceType.PREFERRED),
+            _make_pref("Great Value", BrandPreferenceType.AVOID),
+        ]
+        result = _get_preferred_brands(prefs)
+        assert result == {"organic valley"}
+
+    def test_lowercased(self) -> None:
+        """Test that brand names are lowercased."""
+        prefs = [_make_pref("Organic Valley", BrandPreferenceType.PREFERRED)]
+        result = _get_preferred_brands(prefs)
+        assert "organic valley" in result
+
+
+# ------------------------------------------------------------------
+# Tests: _heuristic_select
+# ------------------------------------------------------------------
+
+
+class TestHeuristicSelect:
+    """Tests for _heuristic_select."""
+
+    def test_cheapest_when_no_prefs(self) -> None:
+        """Test cheapest product selected without preferences."""
+        products = [
+            _make_product(product_id="1", price=5.99),
+            _make_product(product_id="2", price=3.49),
+        ]
+        result = _heuristic_select(products, set())
+        assert result.product_id == "2"
+
+    def test_prefers_in_stock(self) -> None:
+        """Test in-stock products preferred over out-of-stock."""
+        products = [
+            _make_product(product_id="1", price=2.99, in_stock=False),
+            _make_product(product_id="2", price=5.99, in_stock=True),
+        ]
+        result = _heuristic_select(products, set())
+        assert result.product_id == "2"
+
+    def test_prefers_preferred_brand(self) -> None:
+        """Test preferred brand chosen over cheaper generic."""
+        products = [
+            _make_product(product_id="1", name="Generic Milk", price=2.99),
+            _make_product(product_id="2", name="Organic Valley Milk", price=5.99),
+        ]
+        result = _heuristic_select(products, {"organic valley"})
+        assert result.product_id == "2"
+
+    def test_cheapest_preferred_brand(self) -> None:
+        """Test cheapest among preferred brands is selected."""
+        products = [
+            _make_product(product_id="1", name="Organic Valley 1gal", price=6.99),
+            _make_product(product_id="2", name="Organic Valley 0.5gal", price=4.49),
+        ]
+        result = _heuristic_select(products, {"organic valley"})
+        assert result.product_id == "2"
+
+    def test_falls_back_to_out_of_stock(self) -> None:
+        """Test fallback to out-of-stock when all are unavailable."""
+        products = [
+            _make_product(product_id="1", price=5.99, in_stock=False),
+            _make_product(product_id="2", price=3.49, in_stock=False),
+        ]
+        result = _heuristic_select(products, set())
+        assert result.product_id == "2"
+
+
+# ------------------------------------------------------------------
+# Tests: _product_to_dict
+# ------------------------------------------------------------------
+
+
+class TestProductToDict:
+    """Tests for _product_to_dict."""
+
+    def test_converts_product(self) -> None:
+        """Test product is converted to dict with all fields."""
+        product = SafewayProduct(
+            product_id="UPC001",
+            name="Organic Whole Milk",
+            price=5.99,
+            unit_price=0.05,
+            size="1 gal",
+            in_stock=True,
+        )
+        result = _product_to_dict(product)
+
+        assert result["product_id"] == "UPC001"
+        assert result["name"] == "Organic Whole Milk"
+        assert result["price"] == 5.99
+        assert result["unit_price"] == 0.05
+        assert result["size"] == "1 gal"
+        assert result["in_stock"] is True
+
+
+# ------------------------------------------------------------------
+# Tests: _format_brand_preferences
+# ------------------------------------------------------------------
+
+
+class TestFormatBrandPreferences:
+    """Tests for _format_brand_preferences."""
+
+    def test_no_prefs(self) -> None:
+        """Test empty preferences message."""
+        assert _format_brand_preferences([]) == "No brand preferences set."
+
+    def test_formats_prefs(self) -> None:
+        """Test preferences are formatted correctly."""
+        prefs = [
+            _make_pref("Organic Valley", BrandPreferenceType.PREFERRED),
+            _make_pref("Great Value", BrandPreferenceType.AVOID),
+        ]
+        result = _format_brand_preferences(prefs)
+        assert "PREFER: Organic Valley" in result
+        assert "AVOID: Great Value" in result
+
+
+# ------------------------------------------------------------------
+# Tests: _parse_selection_response
+# ------------------------------------------------------------------
+
+
+class TestParseSelectionResponse:
+    """Tests for _parse_selection_response."""
+
+    def _candidates(self) -> list[SafewayProduct]:
+        """Create a list of test candidates.
+
+        Returns:
+            List of SafewayProduct instances.
+        """
+        return [
+            _make_product(product_id="A", name="Product A"),
+            _make_product(product_id="B", name="Product B"),
+        ]
+
+    def test_valid_selection(self) -> None:
+        """Test parsing a valid selection response."""
+        text = json.dumps({"selected_index": 0, "reasoning": "Best match"})
+        candidates = self._candidates()
+        result = _parse_selection_response(text, candidates)
+
+        assert result is not None
+        assert result[0] is not None
+        assert result[0].product_id == "A"
+        assert result[1] == "Best match"
+
+    def test_no_match_returns_none_product(self) -> None:
+        """Test selected_index -1 returns None product."""
+        text = json.dumps({"selected_index": -1, "reasoning": "Nothing fits"})
+        result = _parse_selection_response(text, self._candidates())
+
+        assert result is not None
+        assert result[0] is None
+        assert result[1] == "Nothing fits"
+
+    def test_invalid_json(self) -> None:
+        """Test invalid JSON returns None."""
+        assert _parse_selection_response("not json", self._candidates()) is None
+
+    def test_invalid_index_type(self) -> None:
+        """Test non-integer index returns None."""
+        text = json.dumps({"selected_index": "zero", "reasoning": "bad"})
+        assert _parse_selection_response(text, self._candidates()) is None
+
+    def test_out_of_range_index(self) -> None:
+        """Test out-of-range index returns None."""
+        text = json.dumps({"selected_index": 99, "reasoning": "bad"})
+        assert _parse_selection_response(text, self._candidates()) is None
+
+    def test_strips_markdown_fences(self) -> None:
+        """Test markdown fences are stripped."""
+        inner = json.dumps({"selected_index": 1, "reasoning": "Good"})
+        text = f"```json\n{inner}\n```"
+        result = _parse_selection_response(text, self._candidates())
+
+        assert result is not None
+        assert result[0] is not None
+        assert result[0].product_id == "B"
+
+
+# ------------------------------------------------------------------
+# Tests: _extract_json_text
+# ------------------------------------------------------------------
+
+
+class TestExtractJsonText:
+    """Tests for _extract_json_text."""
+
+    def test_plain_json(self) -> None:
+        """Test plain JSON passes through."""
+        assert _extract_json_text('{"a": 1}') == '{"a": 1}'
+
+    def test_strips_fences(self) -> None:
+        """Test markdown fences are removed."""
+        result = _extract_json_text('```json\n{"a": 1}\n```')
+        assert result == '{"a": 1}'
+
+    def test_strips_whitespace(self) -> None:
+        """Test leading/trailing whitespace is stripped."""
+        assert _extract_json_text("  {}\n  ") == "{}"
+
+
+# ------------------------------------------------------------------
+# Tests: ProductSelector.select_product
+# ------------------------------------------------------------------
+
+
+class TestSelectProduct:
+    """Tests for ProductSelector.select_product."""
+
+    def _make_selector(
+        self,
+        brand_prefs: list[BrandPreference] | None = None,
+        price_sensitivity: str | None = None,
+    ) -> ProductSelector:
+        """Create a ProductSelector with mocked dependencies.
+
+        Args:
+            brand_prefs: Brand preferences to return.
+            price_sensitivity: Price sensitivity preference value.
+
+        Returns:
+            ProductSelector with mock dependencies.
+        """
+        mock_client = MagicMock()
+        mock_store = MagicMock()
+        mock_store.get_brands_for_ingredient.return_value = brand_prefs or []
+        mock_store.get_preference.return_value = price_sensitivity
+        return ProductSelector(mock_client, mock_store)
+
+    def test_no_candidates_returns_none(self) -> None:
+        """Test empty candidates returns no product."""
+        selector = self._make_selector()
+        result = selector.select_product(_make_item(), [])
+
+        assert result.product is None
+        assert "No products available" in result.reasoning
+
+    def test_all_avoided_returns_none(self) -> None:
+        """Test all-avoided brands returns no product."""
+        selector = self._make_selector(
+            brand_prefs=[_make_pref("Organic", BrandPreferenceType.AVOID)]
+        )
+        candidates = [_make_product(name="Organic Milk")]
+        result = selector.select_product(_make_item(), candidates)
+
+        assert result.product is None
+        assert "avoided brands" in result.reasoning
+
+    @patch.object(ProductSelector, "_call_claude")
+    def test_claude_selection(self, mock_claude: MagicMock) -> None:
+        """Test Claude selects a product successfully."""
+        mock_claude.return_value = json.dumps(
+            {"selected_index": 0, "reasoning": "Best match for whole milk"}
+        )
+        selector = self._make_selector()
+        candidates = [_make_product(product_id="A")]
+
+        result = selector.select_product(_make_item(), candidates)
+
+        assert result.product is not None
+        assert result.product.product_id == "A"
+        assert "Best match" in result.reasoning
+
+    @patch.object(ProductSelector, "_call_claude")
+    def test_claude_returns_no_match(self, mock_claude: MagicMock) -> None:
+        """Test Claude returns no match (index -1)."""
+        mock_claude.return_value = json.dumps(
+            {"selected_index": -1, "reasoning": "Nothing suitable"}
+        )
+        selector = self._make_selector()
+        candidates = [_make_product()]
+
+        result = selector.select_product(_make_item(), candidates)
+
+        assert result.product is None
+        assert "Nothing suitable" in result.reasoning
+
+    @patch.object(ProductSelector, "_call_claude")
+    def test_fallback_on_claude_failure(self, mock_claude: MagicMock) -> None:
+        """Test fallback heuristic when Claude fails."""
+        mock_claude.return_value = None
+        selector = self._make_selector()
+        candidates = [
+            _make_product(product_id="1", price=5.99),
+            _make_product(product_id="2", price=3.49),
+        ]
+
+        result = selector.select_product(_make_item(), candidates)
+
+        assert result.product is not None
+        assert result.product.product_id == "2"
+        assert "fallback" in result.reasoning
+
+    @patch.object(ProductSelector, "_call_claude")
+    def test_fallback_on_bad_json(self, mock_claude: MagicMock) -> None:
+        """Test fallback when Claude returns unparseable response."""
+        mock_claude.return_value = "I think product A is best"
+        selector = self._make_selector()
+        candidates = [_make_product()]
+
+        result = selector.select_product(_make_item(), candidates)
+
+        assert result.product is not None
+        assert "fallback" in result.reasoning
+
+
+# ------------------------------------------------------------------
+# Tests: ProductSelector.select_products
+# ------------------------------------------------------------------
+
+
+class TestSelectProducts:
+    """Tests for ProductSelector.select_products."""
+
+    @patch.object(ProductSelector, "_call_claude")
+    def test_selects_multiple(self, mock_claude: MagicMock) -> None:
+        """Test batch selection for multiple items."""
+        mock_claude.return_value = json.dumps(
+            {"selected_index": 0, "reasoning": "Top choice"}
+        )
+        mock_client = MagicMock()
+        mock_store = MagicMock()
+        mock_store.get_brands_for_ingredient.return_value = []
+        mock_store.get_preference.return_value = None
+        selector = ProductSelector(mock_client, mock_store)
+
+        items_and_candidates = [
+            (_make_item(ingredient="milk"), [_make_product(product_id="M1")]),
+            (_make_item(ingredient="eggs"), [_make_product(product_id="E1")]),
+        ]
+        results = selector.select_products(items_and_candidates)
+
+        assert len(results) == 2
+        assert results[0].product is not None
+        assert results[1].product is not None
+
+
+# ------------------------------------------------------------------
+# Tests: ProductSelector._get_price_sensitivity
+# ------------------------------------------------------------------
+
+
+class TestGetPriceSensitivity:
+    """Tests for price sensitivity retrieval."""
+
+    def test_default_moderate(self) -> None:
+        """Test default price sensitivity is moderate."""
+        mock_client = MagicMock()
+        mock_store = MagicMock()
+        mock_store.get_preference.return_value = None
+        selector = ProductSelector(mock_client, mock_store)
+
+        assert selector._get_price_sensitivity() == "moderate"
+
+    def test_returns_stored_value(self) -> None:
+        """Test stored price sensitivity is returned."""
+        mock_client = MagicMock()
+        mock_store = MagicMock()
+        mock_store.get_preference.return_value = "budget"
+        selector = ProductSelector(mock_client, mock_store)
+
+        assert selector._get_price_sensitivity() == "budget"
+
+    def test_invalid_value_defaults_moderate(self) -> None:
+        """Test invalid stored value defaults to moderate."""
+        mock_client = MagicMock()
+        mock_store = MagicMock()
+        mock_store.get_preference.return_value = "invalid"
+        selector = ProductSelector(mock_client, mock_store)
+
+        assert selector._get_price_sensitivity() == "moderate"

--- a/tests/test_prompt_loader.py
+++ b/tests/test_prompt_loader.py
@@ -55,20 +55,37 @@ class TestLoadPrompt:
         assert "milk" in result
         assert "eggs" in result
 
-    def test_load_placeholder_product_selection(self) -> None:
-        """Test loading placeholder template without variables."""
-        result = load_prompt("product_selection")
-        assert "Phase 3" in result
+    def test_load_product_selection(self) -> None:
+        """Test loading product_selection template with variables."""
+        result = load_prompt(
+            "product_selection",
+            ingredient="whole milk",
+            quantity="1.0",
+            unit="gal",
+            search_term="whole milk gallon",
+            category="dairy",
+            products_json="[]",
+            brand_preferences="No preferences",
+            price_sensitivity="moderate",
+        )
+        assert "whole milk" in result
+        assert "moderate" in result
 
     def test_load_placeholder_substitution_ranking(self) -> None:
         """Test loading placeholder substitution_ranking template."""
         result = load_prompt("substitution_ranking")
         assert "Phase 3" in result
 
-    def test_load_placeholder_brand_selection(self) -> None:
-        """Test loading placeholder brand_selection template."""
-        result = load_prompt("brand_selection")
-        assert "Phase 3" in result
+    def test_load_brand_selection(self) -> None:
+        """Test loading brand_selection template with variables."""
+        result = load_prompt(
+            "brand_selection",
+            products_json="[]",
+            avoided_brands="Great Value",
+            preferred_brands="Organic Valley",
+        )
+        assert "Great Value" in result
+        assert "Organic Valley" in result
 
     def test_missing_variable_raises_key_error(self) -> None:
         """Test that missing template variable raises KeyError."""


### PR DESCRIPTION
## Summary
- Implement `ProductSelector` using Claude to choose the best Safeway product from search results
- Respects brand avoidance/preference rules (ingredient-level overrides category-level)
- Price sensitivity setting (budget/moderate/premium) affects selection
- Fallback heuristic selection when Claude is unavailable
- Prompt templates for `product_selection.txt` and `brand_selection.txt`

Closes #12

## Test plan
- [x] 34 new tests covering brand filtering, heuristic selection, Claude response parsing, prompt formatting
- [x] 734 tests passing, 96.52% coverage
- [x] All 7 quality checks green (`./scripts/check-all.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)