### PR TITLE
feat: wire Safeway pipeline end-to-end

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,12 +12,8 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
-
+    # Fork-safety: only run on internal PRs (fork PRs get read-only tokens)
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           prompt: |
-            Please review this pull request and provide feedback using the following template:
+            Please review pull request #${{ github.event.pull_request.number }} and provide feedback using the following template:
 
             ## Summary
             Brief overview (2-3 sentences)
@@ -63,6 +63,6 @@ jobs:
 
             Use the repository's CLAUDE.md for guidance on style and conventions. Be constructive and helpful in your feedback.
 
-            Use `gh pr comment` with your Bash tool to leave your review as a comment on the PR.
+            Use `gh pr comment ${{ github.event.pull_request.number }}` with your Bash tool to leave your review as a comment on PR #${{ github.event.pull_request.number }}.
 
           claude_args: '--allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -12,7 +12,8 @@ permissions:
 
 jobs:
   claude-review:
-    runs-on: ubuntu-latest
+    # Fork-safety: only run on internal PRs (fork PRs get read-only tokens)
+    if: github.event.pull_request.head.repo.full_name == github.repository    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -6,8 +6,8 @@ name: Code Review
 
 permissions:
   contents: read
-  pull-requests: read
-  issues: read
+  pull-requests: write
+  issues: write
   id-token: write
 
 jobs:

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -13,7 +13,8 @@ permissions:
 jobs:
   claude-review:
     # Fork-safety: only run on internal PRs (fork PRs get read-only tokens)
-    if: github.event.pull_request.head.repo.full_name == github.repository    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout repository

--- a/grocery_butler/bot.py
+++ b/grocery_butler/bot.py
@@ -263,6 +263,7 @@ def _make_bot_anthropic_client(config: Config) -> object | None:
 
         return anthropic.Anthropic(api_key=config.anthropic_api_key)
     except Exception:
+        logger.warning("Anthropic client unavailable; Claude features disabled")
         return None
 
 
@@ -1090,17 +1091,6 @@ def create_bot(config: Config) -> discord.Client:
             await interaction.followup.send(
                 "Sorry, something went wrong submitting the order."
             )
-
-    @order_group.command(name="status", description="Check recent order status")
-    async def order_status(interaction: discord.Interaction) -> None:
-        """Check recent order status (placeholder).
-
-        Args:
-            interaction: Discord interaction context.
-        """
-        await interaction.response.send_message(
-            "Order status tracking is not yet implemented."
-        )
 
     tree.add_command(order_group)
 

--- a/grocery_butler/cart_builder.py
+++ b/grocery_butler/cart_builder.py
@@ -84,7 +84,6 @@ class CartBuilder:
         cart_items: list[CartItem] = []
         failed: list[ShoppingListItem] = []
         substituted: list[SubstitutionResult] = []
-        skipped: list[ShoppingListItem] = []
         restock_cart: list[CartItem] = []
 
         all_items = list(items)
@@ -118,7 +117,6 @@ class CartBuilder:
             items=cart_items,
             failed_items=failed,
             substituted_items=substituted,
-            skipped_items=skipped,
             restock_items=restock_cart,
             subtotal=subtotal,
             fulfillment_options=fulfillment_options,
@@ -178,9 +176,12 @@ class CartBuilder:
             product: The out-of-stock product.
 
         Returns:
-            SubstitutionResult with alternatives.
+            SubstitutionResult with best alternative pre-selected.
         """
-        return self._substitution.find_substitutions(item, product)
+        result = self._substitution.find_substitutions(item, product)
+        if result.alternatives:
+            result.selected = result.alternatives[0]
+        return result
 
     def _get_fulfillment_options(self) -> list[FulfillmentOption]:
         """Query available fulfillment options from Safeway.

--- a/grocery_butler/cart_builder.py
+++ b/grocery_butler/cart_builder.py
@@ -1,0 +1,361 @@
+"""Cart building and fulfillment comparison for Safeway orders.
+
+Assembles a :class:`CartSummary` from shopping list items by selecting
+products, handling out-of-stock substitutions, querying fulfillment
+options, and calculating totals.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import re
+from typing import TYPE_CHECKING, Any
+
+from grocery_butler.models import (
+    CartItem,
+    CartSummary,
+    FulfillmentOption,
+    FulfillmentType,
+    SafewayProduct,
+    ShoppingListItem,
+    SubstitutionResult,
+)
+
+if TYPE_CHECKING:
+    from grocery_butler.product_search import ProductSearchService
+    from grocery_butler.product_selector import ProductSelector
+    from grocery_butler.substitution_service import SubstitutionService
+
+logger = logging.getLogger(__name__)
+
+
+class CartBuildError(Exception):
+    """Raised when cart building encounters an unrecoverable error."""
+
+
+class CartBuilder:
+    """Build a Safeway cart from shopping list items.
+
+    Orchestrates product search, selection, substitution, and
+    fulfillment comparison into a complete :class:`CartSummary`.
+
+    Args:
+        search_service: Service for searching Safeway products.
+        product_selector: Claude-assisted product selector.
+        substitution_service: Handles out-of-stock substitutions.
+        safeway_client: Authenticated Safeway API client.
+    """
+
+    def __init__(
+        self,
+        search_service: ProductSearchService,
+        product_selector: ProductSelector,
+        substitution_service: SubstitutionService,
+        safeway_client: Any,
+    ) -> None:
+        """Initialize the cart builder.
+
+        Args:
+            search_service: Product search service.
+            product_selector: Product selector.
+            substitution_service: Substitution service.
+            safeway_client: Safeway API client.
+        """
+        self._search = search_service
+        self._selector = product_selector
+        self._substitution = substitution_service
+        self._client = safeway_client
+
+    def build_cart(
+        self,
+        items: list[ShoppingListItem],
+        restock_items: list[ShoppingListItem] | None = None,
+    ) -> CartSummary:
+        """Build a complete cart from shopping list items.
+
+        Args:
+            items: Shopping list items to add to cart.
+            restock_items: Optional restock queue items.
+
+        Returns:
+            CartSummary with all item categories and totals.
+        """
+        cart_items: list[CartItem] = []
+        failed: list[ShoppingListItem] = []
+        substituted: list[SubstitutionResult] = []
+        skipped: list[ShoppingListItem] = []
+        restock_cart: list[CartItem] = []
+
+        all_items = list(items)
+        restock_set: set[str] = set()
+        if restock_items:
+            for ri in restock_items:
+                all_items.append(ri)
+                restock_set.add(ri.ingredient)
+
+        for item in all_items:
+            result = self._process_item(item)
+            is_restock = item.ingredient in restock_set
+
+            if result is None:
+                failed.append(item)
+            elif isinstance(result, CartItem):
+                if is_restock:
+                    restock_cart.append(result)
+                else:
+                    cart_items.append(result)
+            elif isinstance(result, SubstitutionResult):
+                substituted.append(result)
+
+        fulfillment_options = self._get_fulfillment_options()
+        recommended = _recommend_fulfillment(fulfillment_options)
+        subtotal = _calculate_subtotal(cart_items, restock_cart)
+        fee = _get_fulfillment_fee(fulfillment_options, recommended)
+        estimated_total = round(subtotal + fee, 2)
+
+        return CartSummary(
+            items=cart_items,
+            failed_items=failed,
+            substituted_items=substituted,
+            skipped_items=skipped,
+            restock_items=restock_cart,
+            subtotal=subtotal,
+            fulfillment_options=fulfillment_options,
+            recommended_fulfillment=recommended,
+            estimated_total=estimated_total,
+        )
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _process_item(
+        self,
+        item: ShoppingListItem,
+    ) -> CartItem | SubstitutionResult | None:
+        """Process a single shopping list item into a cart item.
+
+        Args:
+            item: The shopping list item to process.
+
+        Returns:
+            CartItem if successful, SubstitutionResult if substituted,
+            or None if no product found.
+        """
+        candidates = self._search.search_or_cached(item.search_term)
+        if not candidates:
+            logger.warning("No products found for '%s'", item.search_term)
+            return None
+
+        selection = self._selector.select_product(item, candidates)
+        product = selection.product
+
+        if product is None:
+            return None
+
+        if not product.in_stock:
+            return self._handle_out_of_stock(item, product)
+
+        qty = _calculate_quantity(item, product)
+        cost = round(product.price * qty, 2)
+        return CartItem(
+            shopping_list_item=item,
+            safeway_product=product,
+            quantity_to_order=qty,
+            estimated_cost=cost,
+        )
+
+    def _handle_out_of_stock(
+        self,
+        item: ShoppingListItem,
+        product: SafewayProduct,
+    ) -> SubstitutionResult:
+        """Handle an out-of-stock product via substitution.
+
+        Args:
+            item: The shopping list item.
+            product: The out-of-stock product.
+
+        Returns:
+            SubstitutionResult with alternatives.
+        """
+        return self._substitution.find_substitutions(item, product)
+
+    def _get_fulfillment_options(self) -> list[FulfillmentOption]:
+        """Query available fulfillment options from Safeway.
+
+        Returns:
+            List of available fulfillment options.
+        """
+        try:
+            store_id = self._client.store_id
+            response = self._client.get(
+                f"/abs/pub/web/stores/{store_id}/fulfillment",
+            )
+            return _parse_fulfillment_response(response)
+        except Exception:
+            logger.exception("Failed to fetch fulfillment options")
+            return _default_fulfillment_options()
+
+
+# ------------------------------------------------------------------
+# Pure helper functions
+# ------------------------------------------------------------------
+
+
+def _calculate_quantity(
+    item: ShoppingListItem,
+    product: SafewayProduct,
+) -> int:
+    """Calculate how many units to order based on item needs.
+
+    Parses the product size to determine unit quantity, then
+    calculates how many products are needed to fulfill the
+    shopping list quantity.
+
+    Args:
+        item: Shopping list item with desired quantity.
+        product: The product with size information.
+
+    Returns:
+        Number of units to order (minimum 1).
+    """
+    product_qty = _parse_product_size(product.size)
+    if product_qty <= 0:
+        return 1
+
+    needed = item.quantity / product_qty
+    return max(1, math.ceil(needed))
+
+
+def _parse_product_size(size: str) -> float:
+    """Extract numeric quantity from a product size string.
+
+    Args:
+        size: Product size string like '2 lb', '16 oz', '1 gal'.
+
+    Returns:
+        Numeric quantity or 0.0 if unparseable.
+    """
+    match = re.match(r"([\d.]+)", size.strip())
+    if match:
+        try:
+            return float(match.group(1))
+        except ValueError:
+            return 0.0
+    return 0.0
+
+
+def _calculate_subtotal(
+    items: list[CartItem],
+    restock_items: list[CartItem],
+) -> float:
+    """Calculate cart subtotal from all items.
+
+    Args:
+        items: Regular cart items.
+        restock_items: Restock queue cart items.
+
+    Returns:
+        Rounded subtotal.
+    """
+    total = sum(item.estimated_cost for item in items)
+    total += sum(item.estimated_cost for item in restock_items)
+    return round(total, 2)
+
+
+def _get_fulfillment_fee(
+    options: list[FulfillmentOption],
+    recommended: FulfillmentType,
+) -> float:
+    """Get the fee for the recommended fulfillment type.
+
+    Args:
+        options: Available fulfillment options.
+        recommended: The recommended fulfillment type.
+
+    Returns:
+        Fee amount, or 0.0 if not found.
+    """
+    for option in options:
+        if option.type == recommended:
+            return option.fee
+    return 0.0
+
+
+def _recommend_fulfillment(
+    options: list[FulfillmentOption],
+) -> FulfillmentType:
+    """Recommend the best fulfillment option.
+
+    Prefers pickup if available (usually free), otherwise delivery.
+
+    Args:
+        options: Available fulfillment options.
+
+    Returns:
+        Recommended fulfillment type.
+    """
+    available = [o for o in options if o.available]
+    if not available:
+        return FulfillmentType.PICKUP
+
+    pickup = [o for o in available if o.type == FulfillmentType.PICKUP]
+    if pickup:
+        return FulfillmentType.PICKUP
+
+    return available[0].type
+
+
+def _parse_fulfillment_response(
+    response: dict[str, Any],
+) -> list[FulfillmentOption]:
+    """Parse Safeway fulfillment API response.
+
+    Args:
+        response: Raw API response dict.
+
+    Returns:
+        List of parsed FulfillmentOption.
+    """
+    options: list[FulfillmentOption] = []
+    for entry in response.get("fulfillmentOptions", []):
+        try:
+            ftype = FulfillmentType(entry.get("type", "pickup"))
+        except ValueError:
+            continue
+        windows = entry.get("windows", [])
+        next_win = windows[0].get("display", None) if windows else None
+        options.append(
+            FulfillmentOption(
+                type=ftype,
+                available=bool(entry.get("available", False)),
+                fee=float(entry.get("fee", 0.0)),
+                windows=windows,
+                next_window=next_win,
+            )
+        )
+    return options
+
+
+def _default_fulfillment_options() -> list[FulfillmentOption]:
+    """Return default fulfillment options when API is unavailable.
+
+    Returns:
+        Pickup and delivery with default values.
+    """
+    return [
+        FulfillmentOption(
+            type=FulfillmentType.PICKUP,
+            available=True,
+            fee=0.0,
+            windows=[],
+        ),
+        FulfillmentOption(
+            type=FulfillmentType.DELIVERY,
+            available=True,
+            fee=9.95,
+            windows=[],
+        ),
+    ]

--- a/grocery_butler/claude_utils.py
+++ b/grocery_butler/claude_utils.py
@@ -1,16 +1,24 @@
-"""Shared utilities for Claude API response parsing and brand filtering.
+"""Shared utilities for Claude API response parsing and common helpers.
 
-Functions used across multiple modules that interact with Claude's API
-responses or apply brand-preference filtering to product lists.
+Functions used across multiple modules: Claude response parsing,
+brand-preference filtering, Anthropic client creation, and
+shopping-list item construction.
 """
 
 from __future__ import annotations
 
+import logging
+
 from grocery_butler.models import (
     BrandPreference,
     BrandPreferenceType,
+    IngredientCategory,
     SafewayProduct,
+    ShoppingListItem,
+    Unit,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def extract_json_text(raw: str) -> str:
@@ -53,4 +61,45 @@ def filter_avoided_brands(
         return products
     return [
         p for p in products if not any(brand in p.name.lower() for brand in avoided)
+    ]
+
+
+def make_anthropic_client(api_key: str) -> object | None:
+    """Create an Anthropic client from the given API key.
+
+    Args:
+        api_key: Anthropic API key string.
+
+    Returns:
+        Anthropic client instance or None on import failure.
+    """
+    try:
+        import anthropic
+
+        return anthropic.Anthropic(api_key=api_key)
+    except Exception:
+        logger.warning("Anthropic client unavailable; Claude features disabled")
+        return None
+
+
+def items_from_string(items_str: str) -> list[ShoppingListItem]:
+    """Convert comma-separated item names to ShoppingListItem list.
+
+    Args:
+        items_str: Comma-separated ingredient names.
+
+    Returns:
+        List of ShoppingListItem with defaults.
+    """
+    names = [n.strip() for n in items_str.split(",") if n.strip()]
+    return [
+        ShoppingListItem(
+            ingredient=name.lower(),
+            quantity=1.0,
+            unit=Unit.EACH,
+            category=IngredientCategory.OTHER,
+            search_term=name.lower(),
+            from_meals=["manual"],
+        )
+        for name in names
     ]

--- a/grocery_butler/claude_utils.py
+++ b/grocery_butler/claude_utils.py
@@ -1,0 +1,56 @@
+"""Shared utilities for Claude API response parsing and brand filtering.
+
+Functions used across multiple modules that interact with Claude's API
+responses or apply brand-preference filtering to product lists.
+"""
+
+from __future__ import annotations
+
+from grocery_butler.models import (
+    BrandPreference,
+    BrandPreferenceType,
+    SafewayProduct,
+)
+
+
+def extract_json_text(raw: str) -> str:
+    """Extract JSON from a Claude response, stripping markdown fences.
+
+    Args:
+        raw: Raw text from Claude's response.
+
+    Returns:
+        Cleaned string ready for JSON parsing.
+    """
+    text = raw.strip()
+    if text.startswith("```"):
+        first_newline = text.index("\n")
+        text = text[first_newline + 1 :]
+    if text.endswith("```"):
+        text = text[: -len("```")]
+    return text.strip()
+
+
+def filter_avoided_brands(
+    products: list[SafewayProduct],
+    brand_prefs: list[BrandPreference],
+) -> list[SafewayProduct]:
+    """Remove products whose name contains an avoided brand.
+
+    Args:
+        products: Candidate products.
+        brand_prefs: Brand preferences to check.
+
+    Returns:
+        Products not matching any avoided brand.
+    """
+    avoided = {
+        pref.brand.lower()
+        for pref in brand_prefs
+        if pref.preference_type == BrandPreferenceType.AVOID
+    }
+    if not avoided:
+        return products
+    return [
+        p for p in products if not any(brand in p.name.lower() for brand in avoided)
+    ]

--- a/grocery_butler/cli.py
+++ b/grocery_butler/cli.py
@@ -17,6 +17,7 @@ from grocery_butler.consolidator import Consolidator
 from grocery_butler.meal_parser import MealParser
 from grocery_butler.models import (
     CartItem,
+    CartSummary,
     IngredientCategory,
     InventoryItem,
     InventoryStatus,
@@ -565,7 +566,7 @@ def _format_cart_items(
     return lines
 
 
-def _format_cart_summary(cart: object) -> str:
+def _format_cart_summary(cart: CartSummary) -> str:
     """Format a CartSummary for terminal display.
 
     Args:
@@ -574,8 +575,6 @@ def _format_cart_summary(cart: object) -> str:
     Returns:
         Formatted cart summary string.
     """
-    from grocery_butler.models import CartSummary
-
     if not isinstance(cart, CartSummary):
         return "Invalid cart summary."
 

--- a/grocery_butler/cli.py
+++ b/grocery_butler/cli.py
@@ -573,9 +573,6 @@ def _format_cart_summary(cart: CartSummary) -> str:
     Returns:
         Formatted cart summary string.
     """
-    if not isinstance(cart, CartSummary):
-        return "Invalid cart summary."
-
     lines: list[str] = ["=== Cart Summary ===", ""]
     lines.extend(_format_cart_items(f"Items ({len(cart.items)}):", cart.items))
     lines.extend(

--- a/grocery_butler/cli.py
+++ b/grocery_butler/cli.py
@@ -68,6 +68,7 @@ def _make_anthropic_client(api_key: str) -> object | None:
 
         return anthropic.Anthropic(api_key=api_key)
     except Exception:
+        logger.warning("Anthropic client unavailable; Claude features disabled")
         return None
 
 

--- a/grocery_butler/cli.py
+++ b/grocery_butler/cli.py
@@ -22,7 +22,6 @@ from grocery_butler.models import (
     InventoryItem,
     InventoryStatus,
     ShoppingListItem,
-    Unit,
 )
 from grocery_butler.pantry_manager import PantryManager
 from grocery_butler.recipe_store import RecipeStore
@@ -57,19 +56,17 @@ def _load_config_safe() -> Config | None:
 def _make_anthropic_client(api_key: str) -> object | None:
     """Create an Anthropic client from the given API key.
 
+    Delegates to :func:`claude_utils.make_anthropic_client`.
+
     Args:
         api_key: Anthropic API key string.
 
     Returns:
         Anthropic client instance or None on import failure.
     """
-    try:
-        import anthropic
+    from grocery_butler.claude_utils import make_anthropic_client
 
-        return anthropic.Anthropic(api_key=api_key)
-    except Exception:
-        logger.warning("Anthropic client unavailable; Claude features disabled")
-        return None
+    return make_anthropic_client(api_key)
 
 
 # ------------------------------------------------------------------
@@ -699,24 +696,17 @@ def _parse_order_items(
 def _items_from_string(items_str: str) -> list[ShoppingListItem]:
     """Convert comma-separated item names to ShoppingListItem list.
 
+    Delegates to :func:`claude_utils.items_from_string`.
+
     Args:
         items_str: Comma-separated ingredient names.
 
     Returns:
         List of ShoppingListItem with defaults.
     """
-    names = [n.strip() for n in items_str.split(",") if n.strip()]
-    return [
-        ShoppingListItem(
-            ingredient=name.lower(),
-            quantity=1.0,
-            unit=Unit.EACH,
-            category=IngredientCategory.OTHER,
-            search_term=name.lower(),
-            from_meals=["manual"],
-        )
-        for name in names
-    ]
+    from grocery_butler.claude_utils import items_from_string
+
+    return items_from_string(items_str)
 
 
 def _items_from_meals(meals_str: str, cfg: Config) -> list[ShoppingListItem]:

--- a/grocery_butler/consolidator.py
+++ b/grocery_butler/consolidator.py
@@ -526,4 +526,4 @@ class Consolidator:
         Returns:
             Model identifier string.
         """
-        return "claude-sonnet-4-20250514"
+        return "claude-sonnet-4-6"

--- a/grocery_butler/consolidator.py
+++ b/grocery_butler/consolidator.py
@@ -11,6 +11,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
+from grocery_butler.claude_utils import extract_json_text
 from grocery_butler.models import IngredientCategory, ShoppingListItem, Unit, parse_unit
 from grocery_butler.prompt_loader import load_prompt
 
@@ -19,24 +20,6 @@ if TYPE_CHECKING:
     from grocery_butler.models import InventoryItem, ParsedMeal
 
 logger = logging.getLogger(__name__)
-
-
-def _extract_json_text(raw: str) -> str:
-    """Extract JSON from a Claude response, stripping markdown fences.
-
-    Args:
-        raw: Raw text from Claude's response.
-
-    Returns:
-        Cleaned string ready for JSON parsing.
-    """
-    text = raw.strip()
-    if text.startswith("```"):
-        first_newline = text.index("\n")
-        text = text[first_newline + 1 :]
-    if text.endswith("```"):
-        text = text[: -len("```")]
-    return text.strip()
 
 
 def _format_pantry_staples(pantry_staples: list[str]) -> str:
@@ -142,7 +125,7 @@ def _parse_response_items(response_text: str) -> list[ShoppingListItem] | None:
         List of ShoppingListItem or None if parsing fails.
     """
     try:
-        cleaned = _extract_json_text(response_text)
+        cleaned = extract_json_text(response_text)
         data = json.loads(cleaned)
     except (json.JSONDecodeError, ValueError):
         logger.warning("Failed to parse consolidation response")

--- a/grocery_butler/meal_parser.py
+++ b/grocery_butler/meal_parser.py
@@ -519,7 +519,7 @@ class MealParser:
         Returns:
             Model identifier string.
         """
-        return "claude-sonnet-4-20250514"
+        return "claude-sonnet-4-6"
 
     @staticmethod
     def _adjust_servings(

--- a/grocery_butler/meal_parser.py
+++ b/grocery_butler/meal_parser.py
@@ -11,6 +11,7 @@ import json
 import logging
 from typing import TYPE_CHECKING, Any
 
+from grocery_butler.claude_utils import extract_json_text
 from grocery_butler.models import Ingredient, IngredientCategory, ParsedMeal, parse_unit
 from grocery_butler.prompt_loader import load_prompt
 from grocery_butler.recipe_store import RecipeStore, normalize_recipe_name
@@ -41,24 +42,6 @@ def _build_stub_meal(name: str, servings: int) -> ParsedMeal:
         purchase_items=[],
         pantry_items=[],
     )
-
-
-def _extract_json_text(raw: str) -> str:
-    """Extract JSON from a Claude response, stripping markdown fences.
-
-    Args:
-        raw: Raw text from Claude's response.
-
-    Returns:
-        Cleaned string ready for JSON parsing.
-    """
-    text = raw.strip()
-    if text.startswith("```"):
-        first_newline = text.index("\n")
-        text = text[first_newline + 1 :]
-    if text.endswith("```"):
-        text = text[: -len("```")]
-    return text.strip()
 
 
 def _parse_ingredient(data: dict[str, object]) -> Ingredient:
@@ -280,7 +263,7 @@ class MealParser:
             Matched ParsedMeal or None.
         """
         try:
-            data = json.loads(_extract_json_text(response_text))
+            data = json.loads(extract_json_text(response_text))
         except (json.JSONDecodeError, ValueError):
             logger.warning("Failed to parse fuzzy match response")
             return None
@@ -412,7 +395,7 @@ class MealParser:
             ParsedMeal or None if parsing fails.
         """
         try:
-            cleaned = _extract_json_text(response_text)
+            cleaned = extract_json_text(response_text)
             data = json.loads(cleaned)
         except (json.JSONDecodeError, ValueError):
             logger.warning("Failed to parse decomposition response")

--- a/grocery_butler/models.py
+++ b/grocery_butler/models.py
@@ -7,6 +7,7 @@ including future Safeway models that aren't used yet.
 from __future__ import annotations
 
 from enum import StrEnum
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -203,7 +204,7 @@ class FulfillmentOption(BaseModel):
     type: FulfillmentType
     available: bool
     fee: float
-    windows: list[dict]
+    windows: list[dict[str, Any]]
     next_window: str | None = None
 
 

--- a/grocery_butler/models.py
+++ b/grocery_butler/models.py
@@ -394,7 +394,7 @@ class CartSummary(BaseModel):
     items: list[CartItem]
     failed_items: list[ShoppingListItem]
     substituted_items: list[SubstitutionResult]
-    skipped_items: list[ShoppingListItem]
+    skipped_items: list[ShoppingListItem] = []
     restock_items: list[CartItem]
     subtotal: float
     fulfillment_options: list[FulfillmentOption]

--- a/grocery_butler/order_service.py
+++ b/grocery_butler/order_service.py
@@ -205,8 +205,8 @@ def _parse_order_response(
     if response.get("status") == "error":
         return None
 
-    order_id = response.get("orderId", "")
-    if not order_id:
+    order_id = response.get("orderId")
+    if order_id is None:
         return None
 
     total_items = len(cart.items) + len(cart.restock_items)

--- a/grocery_butler/order_service.py
+++ b/grocery_butler/order_service.py
@@ -1,0 +1,258 @@
+"""Order submission and post-order inventory updates.
+
+Submits a built :class:`CartSummary` to the Safeway order API,
+handles confirmation and errors, and updates pantry inventory
+for successfully ordered items.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from grocery_butler.models import CartItem, CartSummary, FulfillmentType
+    from grocery_butler.pantry_manager import PantryManager
+
+logger = logging.getLogger(__name__)
+
+
+class OrderError(Exception):
+    """Raised when order submission fails."""
+
+
+@dataclass
+class OrderConfirmation:
+    """Details of a successfully submitted order.
+
+    Attributes:
+        order_id: Safeway order identifier.
+        status: Order status string.
+        estimated_time: Estimated fulfillment time.
+        total: Final order total.
+        fulfillment_type: Selected fulfillment method.
+        item_count: Number of items in the order.
+    """
+
+    order_id: str
+    status: str
+    estimated_time: str
+    total: float
+    fulfillment_type: FulfillmentType
+    item_count: int
+
+
+@dataclass
+class OrderResult:
+    """Complete result of an order attempt.
+
+    Attributes:
+        success: Whether the order was submitted successfully.
+        confirmation: Order confirmation if successful.
+        error_message: Error description if failed.
+        items_restocked: Number of inventory items updated.
+    """
+
+    success: bool
+    confirmation: OrderConfirmation | None = None
+    error_message: str = ""
+    items_restocked: int = 0
+
+
+class OrderService:
+    """Submit carts to Safeway and update inventory.
+
+    Args:
+        safeway_client: Authenticated Safeway API client.
+        pantry_manager: Pantry manager for inventory updates.
+    """
+
+    def __init__(
+        self,
+        safeway_client: Any,
+        pantry_manager: PantryManager,
+    ) -> None:
+        """Initialize the order service.
+
+        Args:
+            safeway_client: Safeway API client.
+            pantry_manager: Pantry manager for restocking.
+        """
+        self._client = safeway_client
+        self._pantry = pantry_manager
+
+    def submit_order(
+        self,
+        cart: CartSummary,
+    ) -> OrderResult:
+        """Submit a cart to Safeway and update inventory.
+
+        Args:
+            cart: The built cart summary to submit.
+
+        Returns:
+            OrderResult with confirmation or error details.
+        """
+        if not cart.items and not cart.restock_items:
+            return OrderResult(
+                success=False,
+                error_message="Cart is empty — nothing to order",
+            )
+
+        payload = _build_order_payload(cart)
+
+        try:
+            response = self._client.post(
+                "/abs/pub/web/orders",
+                json_data=payload,
+            )
+        except Exception:
+            logger.exception("Order submission failed")
+            return OrderResult(
+                success=False,
+                error_message="Order submission failed — check logs",
+            )
+
+        confirmation = _parse_order_response(response, cart)
+        if confirmation is None:
+            return OrderResult(
+                success=False,
+                error_message=response.get("error", "Unknown order error"),
+            )
+
+        restocked = self._restock_ordered_items(cart)
+
+        return OrderResult(
+            success=True,
+            confirmation=confirmation,
+            items_restocked=restocked,
+        )
+
+    def _restock_ordered_items(self, cart: CartSummary) -> int:
+        """Mark ordered restock items as back in stock.
+
+        Args:
+            cart: The submitted cart.
+
+        Returns:
+            Number of items restocked.
+        """
+        ingredients = _collect_restock_ingredients(cart)
+        if not ingredients:
+            return 0
+
+        try:
+            return self._pantry.mark_restocked(ingredients)
+        except Exception:
+            logger.exception("Failed to update inventory after order")
+            return 0
+
+
+# ------------------------------------------------------------------
+# Pure helper functions
+# ------------------------------------------------------------------
+
+
+def _build_order_payload(cart: CartSummary) -> dict[str, Any]:
+    """Build the API payload for order submission.
+
+    Args:
+        cart: Cart summary to convert.
+
+    Returns:
+        Dict suitable for JSON submission.
+    """
+    items = _serialize_cart_items(cart.items + cart.restock_items)
+    return {
+        "items": items,
+        "fulfillmentType": cart.recommended_fulfillment.value,
+        "estimatedTotal": cart.estimated_total,
+    }
+
+
+def _serialize_cart_items(
+    items: list[CartItem],
+) -> list[dict[str, Any]]:
+    """Serialize cart items for the order API.
+
+    Args:
+        items: Cart items to serialize.
+
+    Returns:
+        List of dicts with product_id and quantity.
+    """
+    return [
+        {
+            "productId": item.safeway_product.product_id,
+            "quantity": item.quantity_to_order,
+        }
+        for item in items
+    ]
+
+
+def _parse_order_response(
+    response: dict[str, Any],
+    cart: CartSummary,
+) -> OrderConfirmation | None:
+    """Parse Safeway order API response into confirmation.
+
+    Args:
+        response: Raw API response dict.
+        cart: The submitted cart for context.
+
+    Returns:
+        OrderConfirmation or None if response indicates failure.
+    """
+    if response.get("status") == "error":
+        return None
+
+    order_id = response.get("orderId", "")
+    if not order_id:
+        return None
+
+    total_items = len(cart.items) + len(cart.restock_items)
+    return OrderConfirmation(
+        order_id=str(order_id),
+        status=str(response.get("status", "confirmed")),
+        estimated_time=str(response.get("estimatedTime", "Unknown")),
+        total=float(response.get("total", cart.estimated_total)),
+        fulfillment_type=cart.recommended_fulfillment,
+        item_count=total_items,
+    )
+
+
+@dataclass
+class _IngredientCollector:
+    """Collects ingredient names from cart items.
+
+    Attributes:
+        ingredients: Accumulated ingredient names.
+    """
+
+    ingredients: list[str] = field(default_factory=list)
+
+    def add_items(self, items: list[CartItem]) -> None:
+        """Add ingredients from cart items.
+
+        Args:
+            items: Cart items to extract ingredients from.
+        """
+        for item in items:
+            self.ingredients.append(
+                item.shopping_list_item.ingredient,
+            )
+
+
+def _collect_restock_ingredients(cart: CartSummary) -> list[str]:
+    """Extract ingredient names from restock cart items.
+
+    Args:
+        cart: Cart summary with restock items.
+
+    Returns:
+        List of ingredient names to restock.
+    """
+    collector = _IngredientCollector()
+    collector.add_items(cart.restock_items)
+    return collector.ingredients

--- a/grocery_butler/pantry_manager.py
+++ b/grocery_butler/pantry_manager.py
@@ -425,7 +425,7 @@ def _call_claude_with_retry(
     while attempts <= max_retries:
         try:
             response = client.messages.create(
-                model="claude-sonnet-4-20250514",
+                model="claude-sonnet-4-6",
                 max_tokens=1024,
                 messages=[{"role": "user", "content": prompt}],
             )

--- a/grocery_butler/product_search.py
+++ b/grocery_butler/product_search.py
@@ -1,0 +1,513 @@
+"""Product search and mapping cache for Safeway integration.
+
+Searches the Nimbus API for grocery products, caches results in the
+``product_mapping`` SQLite table, and returns :class:`SafewayProduct`
+instances.  Pinned mappings bypass the API entirely.
+
+Cache strategy:
+- Mappings older than ``CACHE_MAX_AGE_DAYS`` are considered stale and
+  re-fetched on the next search.
+- Pinned mappings never expire.
+- ``times_selected`` and ``last_used`` are updated each time a cached
+  mapping is returned.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import sqlite3
+
+from grocery_butler.db import get_connection, init_db
+from grocery_butler.models import SafewayProduct
+from grocery_butler.safeway_client import SafewayAPIError, SafewayClient
+
+logger = logging.getLogger(__name__)
+
+# Nimbus search path template
+_SEARCH_PATH = "/api/v2/grocerystore/search"
+_DEFAULT_ROWS = 10
+
+# Cache entries older than this are considered stale (unless pinned)
+CACHE_MAX_AGE_DAYS = 7
+
+
+class ProductSearchError(Exception):
+    """Raised when a product search fails."""
+
+
+@dataclass
+class CachedMapping:
+    """A product mapping row from the database.
+
+    Attributes:
+        mapping_id: Primary key in the product_mapping table.
+        ingredient_description: The search term that produced this mapping.
+        product: The cached Safeway product.
+        is_pinned: Whether the user has pinned this mapping.
+        times_selected: Number of times this mapping has been used.
+        last_used: When the mapping was last used.
+    """
+
+    mapping_id: int
+    ingredient_description: str
+    product: SafewayProduct
+    is_pinned: bool
+    times_selected: int
+    last_used: datetime
+
+
+class ProductSearchService:
+    """Search Safeway products and manage the mapping cache.
+
+    Args:
+        safeway_client: Authenticated Safeway API client.
+        db_path: Path to the SQLite database.
+    """
+
+    def __init__(
+        self,
+        safeway_client: SafewayClient,
+        db_path: str,
+    ) -> None:
+        """Initialize the product search service.
+
+        Args:
+            safeway_client: Authenticated Safeway API client.
+            db_path: Path to the SQLite database.
+        """
+        self._client = safeway_client
+        self._db_path = db_path
+        init_db(db_path)
+
+    def _connect(self) -> sqlite3.Connection:
+        """Create a new database connection.
+
+        Returns:
+            Configured sqlite3.Connection.
+        """
+        return get_connection(self._db_path)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def search_products(
+        self,
+        query: str,
+        rows: int = _DEFAULT_ROWS,
+    ) -> list[SafewayProduct]:
+        """Search Safeway for products matching *query*.
+
+        Args:
+            query: Search term (e.g. ``"whole milk"``).
+            rows: Maximum number of results to return.
+
+        Returns:
+            List of parsed SafewayProduct instances.
+
+        Raises:
+            ProductSearchError: If the API call fails.
+        """
+        try:
+            data = self._client.get(
+                _SEARCH_PATH,
+                params={
+                    "q": query,
+                    "storeId": self._client.store_id,
+                    "rows": str(rows),
+                },
+            )
+        except SafewayAPIError as exc:
+            raise ProductSearchError(
+                f"Product search failed for '{query}': {exc}"
+            ) from exc
+
+        return _parse_search_results(data)
+
+    def search_or_cached(
+        self,
+        search_term: str,
+    ) -> list[SafewayProduct]:
+        """Return cached results or perform a fresh search.
+
+        If a pinned mapping exists, returns only that product. If a
+        non-expired cached mapping exists, returns it (and refreshes
+        ``last_used``). Otherwise performs a live search and caches
+        the top result.
+
+        Args:
+            search_term: The ingredient search term.
+
+        Returns:
+            List of SafewayProduct results (possibly a single pinned item).
+        """
+        cached = self.get_cached_mapping(search_term)
+        if cached is not None and (cached.is_pinned or not self._is_stale(cached)):
+            self._touch_mapping(cached.mapping_id)
+            return [cached.product]
+
+        products = self.search_products(search_term)
+        if products:
+            self.save_mapping(search_term, products[0])
+        return products
+
+    # ------------------------------------------------------------------
+    # Cache operations
+    # ------------------------------------------------------------------
+
+    def get_cached_mapping(
+        self,
+        search_term: str,
+    ) -> CachedMapping | None:
+        """Look up a cached product mapping by search term.
+
+        Args:
+            search_term: The ingredient description to look up.
+
+        Returns:
+            The cached mapping, or None if not found.
+        """
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT id, ingredient_description, safeway_product_id,"
+                " safeway_product_name, safeway_price, last_used,"
+                " times_selected, is_pinned"
+                " FROM product_mapping"
+                " WHERE ingredient_description = ?"
+                " ORDER BY is_pinned DESC, times_selected DESC"
+                " LIMIT 1",
+                (search_term,),
+            ).fetchone()
+            if row is None:
+                return None
+            return _row_to_cached_mapping(row)
+        finally:
+            conn.close()
+
+    def save_mapping(
+        self,
+        search_term: str,
+        product: SafewayProduct,
+    ) -> int:
+        """Insert or update a product mapping in the cache.
+
+        If a mapping already exists for this search term and product,
+        increments ``times_selected`` and updates ``last_used``.
+        Otherwise inserts a new row.
+
+        Args:
+            search_term: The ingredient description.
+            product: The Safeway product to cache.
+
+        Returns:
+            The mapping row ID.
+        """
+        conn = self._connect()
+        try:
+            existing = conn.execute(
+                "SELECT id FROM product_mapping"
+                " WHERE ingredient_description = ?"
+                " AND safeway_product_id = ?",
+                (search_term, product.product_id),
+            ).fetchone()
+
+            if existing:
+                row_id = existing["id"]
+                conn.execute(
+                    "UPDATE product_mapping"
+                    " SET times_selected = times_selected + 1,"
+                    " last_used = CURRENT_TIMESTAMP,"
+                    " safeway_price = ?"
+                    " WHERE id = ?",
+                    (product.price, row_id),
+                )
+            else:
+                cursor = conn.execute(
+                    "INSERT INTO product_mapping"
+                    " (ingredient_description, safeway_product_id,"
+                    "  safeway_product_name, safeway_price)"
+                    " VALUES (?, ?, ?, ?)",
+                    (
+                        search_term,
+                        product.product_id,
+                        product.name,
+                        product.price,
+                    ),
+                )
+                row_id = cursor.lastrowid
+                if row_id is None:  # pragma: no cover
+                    msg = "INSERT did not return a row ID"
+                    raise RuntimeError(msg)
+
+            conn.commit()
+            return int(row_id)
+        finally:
+            conn.close()
+
+    def pin_mapping(
+        self,
+        search_term: str,
+        product: SafewayProduct,
+    ) -> int:
+        """Pin a product mapping so it always bypasses search.
+
+        Unpins any other mapping for the same search term first.
+
+        Args:
+            search_term: The ingredient description.
+            product: The product to pin.
+
+        Returns:
+            The pinned mapping row ID.
+        """
+        conn = self._connect()
+        try:
+            # Unpin existing mappings for this search term
+            conn.execute(
+                "UPDATE product_mapping SET is_pinned = FALSE"
+                " WHERE ingredient_description = ?",
+                (search_term,),
+            )
+            # Upsert the pinned mapping
+            existing = conn.execute(
+                "SELECT id FROM product_mapping"
+                " WHERE ingredient_description = ?"
+                " AND safeway_product_id = ?",
+                (search_term, product.product_id),
+            ).fetchone()
+
+            if existing:
+                row_id = existing["id"]
+                conn.execute(
+                    "UPDATE product_mapping"
+                    " SET is_pinned = TRUE,"
+                    " last_used = CURRENT_TIMESTAMP,"
+                    " safeway_price = ?"
+                    " WHERE id = ?",
+                    (product.price, row_id),
+                )
+            else:
+                cursor = conn.execute(
+                    "INSERT INTO product_mapping"
+                    " (ingredient_description, safeway_product_id,"
+                    "  safeway_product_name, safeway_price, is_pinned)"
+                    " VALUES (?, ?, ?, ?, TRUE)",
+                    (
+                        search_term,
+                        product.product_id,
+                        product.name,
+                        product.price,
+                    ),
+                )
+                row_id = cursor.lastrowid
+                if row_id is None:  # pragma: no cover
+                    msg = "INSERT did not return a row ID"
+                    raise RuntimeError(msg)
+
+            conn.commit()
+            return int(row_id)
+        finally:
+            conn.close()
+
+    def unpin_mapping(self, search_term: str) -> bool:
+        """Remove the pin from a mapping.
+
+        Args:
+            search_term: The ingredient description to unpin.
+
+        Returns:
+            True if a pinned mapping was found and unpinned.
+        """
+        conn = self._connect()
+        try:
+            cursor = conn.execute(
+                "UPDATE product_mapping SET is_pinned = FALSE"
+                " WHERE ingredient_description = ? AND is_pinned = TRUE",
+                (search_term,),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+        finally:
+            conn.close()
+
+    def delete_mapping(self, search_term: str) -> int:
+        """Delete all cached mappings for a search term.
+
+        Args:
+            search_term: The ingredient description to remove.
+
+        Returns:
+            Number of rows deleted.
+        """
+        conn = self._connect()
+        try:
+            cursor = conn.execute(
+                "DELETE FROM product_mapping WHERE ingredient_description = ?",
+                (search_term,),
+            )
+            conn.commit()
+            return cursor.rowcount
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _touch_mapping(self, mapping_id: int) -> None:
+        """Update last_used and increment times_selected for a mapping.
+
+        Args:
+            mapping_id: The row ID to update.
+        """
+        conn = self._connect()
+        try:
+            conn.execute(
+                "UPDATE product_mapping"
+                " SET times_selected = times_selected + 1,"
+                " last_used = CURRENT_TIMESTAMP"
+                " WHERE id = ?",
+                (mapping_id,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _is_stale(cached: CachedMapping) -> bool:
+        """Check if a cached mapping has expired.
+
+        Args:
+            cached: The cached mapping to check.
+
+        Returns:
+            True if the mapping is older than CACHE_MAX_AGE_DAYS.
+        """
+        cutoff = datetime.now(tz=UTC) - timedelta(
+            days=CACHE_MAX_AGE_DAYS,
+        )
+        return cached.last_used < cutoff
+
+
+# ------------------------------------------------------------------
+# Pure helper functions
+# ------------------------------------------------------------------
+
+
+def _parse_search_results(data: dict[str, Any]) -> list[SafewayProduct]:
+    """Parse Nimbus search API response into SafewayProduct models.
+
+    The Nimbus response has a ``productsInfo`` list, each entry
+    containing product details.
+
+    Args:
+        data: Raw JSON response from the Nimbus search endpoint.
+
+    Returns:
+        List of parsed SafewayProduct instances.
+    """
+    products_info = data.get("productsInfo", [])
+    results: list[SafewayProduct] = []
+    for item in products_info:
+        product = _parse_single_product(item)
+        if product is not None:
+            results.append(product)
+    return results
+
+
+def _parse_single_product(item: dict[str, Any]) -> SafewayProduct | None:
+    """Parse a single product entry from the Nimbus response.
+
+    Args:
+        item: A single product dict from the ``productsInfo`` list.
+
+    Returns:
+        A SafewayProduct, or None if required fields are missing.
+    """
+    product_id = item.get("upc", "") or item.get("pid", "")
+    name = item.get("name", "")
+    if not product_id or not name:
+        return None
+
+    price = _parse_price(item)
+    return SafewayProduct(
+        product_id=str(product_id),
+        name=str(name),
+        price=price,
+        unit_price=_safe_float(item.get("unitPrice")),
+        size=str(item.get("size", "")),
+        in_stock=item.get("inStock", True) is not False,
+    )
+
+
+def _parse_price(item: dict[str, Any]) -> float:
+    """Extract the best available price from a product entry.
+
+    Prefers ``salePrice`` over ``price`` over ``basePrice``.
+
+    Args:
+        item: Product dict from the Nimbus response.
+
+    Returns:
+        Price as a float, defaulting to 0.0 if unparseable.
+    """
+    for key in ("salePrice", "price", "basePrice"):
+        value = _safe_float(item.get(key))
+        if value is not None and value > 0:
+            return value
+    return 0.0
+
+
+def _safe_float(value: object) -> float | None:
+    """Safely convert a value to float.
+
+    Args:
+        value: Any value that might be numeric.
+
+    Returns:
+        Float value, or None if conversion fails.
+    """
+    if value is None:
+        return None
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+def _row_to_cached_mapping(row: sqlite3.Row) -> CachedMapping:
+    """Convert a database row to a CachedMapping.
+
+    Args:
+        row: A sqlite3.Row from the product_mapping table.
+
+    Returns:
+        Populated CachedMapping instance.
+    """
+    last_used_str = row["last_used"]
+    if isinstance(last_used_str, str):
+        last_used = datetime.fromisoformat(last_used_str).replace(
+            tzinfo=UTC,
+        )
+    else:
+        last_used = datetime.now(tz=UTC)
+
+    return CachedMapping(
+        mapping_id=row["id"],
+        ingredient_description=row["ingredient_description"],
+        product=SafewayProduct(
+            product_id=row["safeway_product_id"],
+            name=row["safeway_product_name"],
+            price=row["safeway_price"] or 0.0,
+            size="",
+        ),
+        is_pinned=bool(row["is_pinned"]),
+        times_selected=row["times_selected"],
+        last_used=last_used,
+    )

--- a/grocery_butler/product_search.py
+++ b/grocery_butler/product_search.py
@@ -464,11 +464,11 @@ def _parse_price(item: dict[str, Any]) -> float:
     return 0.0
 
 
-def _safe_float(value: object) -> float | None:
+def _safe_float(value: float | int | str | None) -> float | None:
     """Safely convert a value to float.
 
     Args:
-        value: Any value that might be numeric.
+        value: Numeric or string value that might be convertible to float.
 
     Returns:
         Float value, or None if conversion fails.
@@ -476,7 +476,7 @@ def _safe_float(value: object) -> float | None:
     if value is None:
         return None
     try:
-        return float(value)  # type: ignore[arg-type]
+        return float(value)
     except (TypeError, ValueError):
         return None
 

--- a/grocery_butler/product_selector.py
+++ b/grocery_butler/product_selector.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_MODEL = "claude-sonnet-4-20250514"
+_MODEL = "claude-sonnet-4-6"
 _MAX_TOKENS = 1024
 
 

--- a/grocery_butler/product_selector.py
+++ b/grocery_butler/product_selector.py
@@ -1,0 +1,455 @@
+"""Claude-assisted product selection with brand preference support.
+
+Selects the best Safeway product from search results using Claude,
+respecting brand preferences (preferred/avoided) and price sensitivity.
+
+Selection flow:
+1. Filter out products from avoided brands
+2. Load brand preferences (ingredient-level overrides category-level)
+3. Ask Claude to select the best product given preferences
+4. Return the selected product with reasoning
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from grocery_butler.models import (
+    BrandPreference,
+    BrandPreferenceType,
+    PriceSensitivity,
+    SafewayProduct,
+    ShoppingListItem,
+)
+from grocery_butler.prompt_loader import load_prompt
+
+if TYPE_CHECKING:
+    from grocery_butler.recipe_store import RecipeStore
+
+logger = logging.getLogger(__name__)
+
+_MODEL = "claude-sonnet-4-20250514"
+_MAX_TOKENS = 1024
+
+
+class ProductSelectionError(Exception):
+    """Raised when product selection fails."""
+
+
+@dataclass
+class SelectionResult:
+    """The outcome of product selection for one shopping list item.
+
+    Attributes:
+        item: The original shopping list item.
+        product: The selected product, or None if no match found.
+        reasoning: Claude's explanation for the selection.
+    """
+
+    item: ShoppingListItem
+    product: SafewayProduct | None
+    reasoning: str
+
+
+class ProductSelector:
+    """Claude-assisted product selector with brand preferences.
+
+    Args:
+        claude_client: Anthropic API client.
+        recipe_store: Database access for brand preferences.
+    """
+
+    def __init__(
+        self,
+        claude_client: Any,
+        recipe_store: RecipeStore,
+    ) -> None:
+        """Initialize the product selector.
+
+        Args:
+            claude_client: Anthropic API client (typed as Any for flexibility).
+            recipe_store: Database access for brand preferences.
+        """
+        self._client = claude_client
+        self._store = recipe_store
+
+    def select_product(
+        self,
+        item: ShoppingListItem,
+        candidates: list[SafewayProduct],
+    ) -> SelectionResult:
+        """Select the best product for a shopping list item.
+
+        Filters out avoided brands, then uses Claude to pick the
+        best option respecting brand preferences and price sensitivity.
+
+        Args:
+            item: The shopping list item needing a product.
+            candidates: Search results from Safeway.
+
+        Returns:
+            SelectionResult with chosen product and reasoning.
+        """
+        if not candidates:
+            return SelectionResult(
+                item=item,
+                product=None,
+                reasoning="No products available",
+            )
+
+        brand_prefs = self._get_brand_preferences(item)
+        filtered = _filter_avoided_brands(candidates, brand_prefs)
+
+        if not filtered:
+            return SelectionResult(
+                item=item,
+                product=None,
+                reasoning="All available products are from avoided brands",
+            )
+
+        price_sensitivity = self._get_price_sensitivity()
+        return self._ask_claude(item, filtered, brand_prefs, price_sensitivity)
+
+    def select_products(
+        self,
+        items_and_candidates: list[tuple[ShoppingListItem, list[SafewayProduct]]],
+    ) -> list[SelectionResult]:
+        """Select products for multiple shopping list items.
+
+        Args:
+            items_and_candidates: List of (item, candidates) tuples.
+
+        Returns:
+            List of SelectionResult for each item.
+        """
+        return [
+            self.select_product(item, candidates)
+            for item, candidates in items_and_candidates
+        ]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _get_brand_preferences(
+        self,
+        item: ShoppingListItem,
+    ) -> list[BrandPreference]:
+        """Get brand preferences for a shopping list item.
+
+        Checks ingredient-level first, falls back to category-level.
+
+        Args:
+            item: The shopping list item.
+
+        Returns:
+            List of relevant brand preferences.
+        """
+        return self._store.get_brands_for_ingredient(
+            item.ingredient,
+            category=item.category.value,
+        )
+
+    def _get_price_sensitivity(self) -> str:
+        """Get the user's price sensitivity setting.
+
+        Returns:
+            Price sensitivity string, defaults to "moderate".
+        """
+        value = self._store.get_preference("price_sensitivity")
+        if value is not None:
+            try:
+                return PriceSensitivity(value).value
+            except ValueError:
+                pass
+        return PriceSensitivity.MODERATE.value
+
+    def _ask_claude(
+        self,
+        item: ShoppingListItem,
+        candidates: list[SafewayProduct],
+        brand_prefs: list[BrandPreference],
+        price_sensitivity: str,
+    ) -> SelectionResult:
+        """Ask Claude to select the best product.
+
+        Args:
+            item: The shopping list item.
+            candidates: Filtered product candidates.
+            brand_prefs: Relevant brand preferences.
+            price_sensitivity: User's price sensitivity setting.
+
+        Returns:
+            SelectionResult with Claude's selection.
+        """
+        prompt = self._build_prompt(item, candidates, brand_prefs, price_sensitivity)
+        response_text = self._call_claude(prompt)
+        if response_text is None:
+            return self._fallback_selection(item, candidates, brand_prefs)
+
+        result = _parse_selection_response(response_text, candidates)
+        if result is not None:
+            return SelectionResult(item=item, product=result[0], reasoning=result[1])
+
+        return self._fallback_selection(item, candidates, brand_prefs)
+
+    def _build_prompt(
+        self,
+        item: ShoppingListItem,
+        candidates: list[SafewayProduct],
+        brand_prefs: list[BrandPreference],
+        price_sensitivity: str,
+    ) -> str:
+        """Build the product selection prompt.
+
+        Args:
+            item: The shopping list item.
+            candidates: Filtered product candidates.
+            brand_prefs: Relevant brand preferences.
+            price_sensitivity: User's price sensitivity.
+
+        Returns:
+            Formatted prompt string.
+        """
+        products_json = json.dumps(
+            [_product_to_dict(p) for p in candidates],
+            indent=2,
+        )
+        brand_text = _format_brand_preferences(brand_prefs)
+
+        return load_prompt(
+            "product_selection",
+            ingredient=item.ingredient,
+            quantity=str(item.quantity),
+            unit=str(item.unit),
+            search_term=item.search_term,
+            category=item.category.value,
+            products_json=products_json,
+            brand_preferences=brand_text,
+            price_sensitivity=price_sensitivity,
+        )
+
+    def _call_claude(self, prompt: str) -> str | None:
+        """Send a prompt to Claude and return the text response.
+
+        Args:
+            prompt: The formatted prompt string.
+
+        Returns:
+            Response text or None on failure.
+        """
+        try:
+            response = self._client.messages.create(
+                model=_MODEL,
+                max_tokens=_MAX_TOKENS,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            return str(response.content[0].text)
+        except Exception:
+            logger.exception("Claude product selection call failed")
+            return None
+
+    @staticmethod
+    def _fallback_selection(
+        item: ShoppingListItem,
+        candidates: list[SafewayProduct],
+        brand_prefs: list[BrandPreference],
+    ) -> SelectionResult:
+        """Select a product without Claude using simple heuristics.
+
+        Prefers preferred-brand in-stock products, then cheapest.
+
+        Args:
+            item: The shopping list item.
+            candidates: Filtered product candidates.
+            brand_prefs: Relevant brand preferences.
+
+        Returns:
+            SelectionResult from heuristic selection.
+        """
+        preferred = _get_preferred_brands(brand_prefs)
+        best = _heuristic_select(candidates, preferred)
+        return SelectionResult(
+            item=item,
+            product=best,
+            reasoning="Selected via fallback heuristic (Claude unavailable)",
+        )
+
+
+# ------------------------------------------------------------------
+# Pure helper functions
+# ------------------------------------------------------------------
+
+
+def _filter_avoided_brands(
+    products: list[SafewayProduct],
+    brand_prefs: list[BrandPreference],
+) -> list[SafewayProduct]:
+    """Remove products whose name contains an avoided brand.
+
+    Args:
+        products: Candidate products.
+        brand_prefs: Brand preferences to check.
+
+    Returns:
+        Products not matching any avoided brand.
+    """
+    avoided = {
+        pref.brand.lower()
+        for pref in brand_prefs
+        if pref.preference_type == BrandPreferenceType.AVOID
+    }
+    if not avoided:
+        return products
+    return [
+        p for p in products if not any(brand in p.name.lower() for brand in avoided)
+    ]
+
+
+def _get_preferred_brands(
+    brand_prefs: list[BrandPreference],
+) -> set[str]:
+    """Extract preferred brand names (lowercased).
+
+    Args:
+        brand_prefs: Brand preferences to check.
+
+    Returns:
+        Set of preferred brand names in lowercase.
+    """
+    return {
+        pref.brand.lower()
+        for pref in brand_prefs
+        if pref.preference_type == BrandPreferenceType.PREFERRED
+    }
+
+
+def _heuristic_select(
+    candidates: list[SafewayProduct],
+    preferred_brands: set[str],
+) -> SafewayProduct:
+    """Select a product using simple heuristics.
+
+    Priority: in-stock preferred brand > in-stock any > cheapest.
+
+    Args:
+        candidates: Non-empty list of product candidates.
+        preferred_brands: Lowercased preferred brand names.
+
+    Returns:
+        The best candidate by heuristic ranking.
+    """
+    in_stock = [p for p in candidates if p.in_stock]
+    pool = in_stock if in_stock else candidates
+
+    if preferred_brands:
+        preferred_matches = [
+            p for p in pool if any(b in p.name.lower() for b in preferred_brands)
+        ]
+        if preferred_matches:
+            return min(preferred_matches, key=lambda p: p.price)
+
+    return min(pool, key=lambda p: p.price)
+
+
+def _product_to_dict(product: SafewayProduct) -> dict[str, Any]:
+    """Convert a SafewayProduct to a dict for JSON serialization.
+
+    Args:
+        product: The product to convert.
+
+    Returns:
+        Dict with product fields.
+    """
+    return {
+        "product_id": product.product_id,
+        "name": product.name,
+        "price": product.price,
+        "unit_price": product.unit_price,
+        "size": product.size,
+        "in_stock": product.in_stock,
+    }
+
+
+def _format_brand_preferences(prefs: list[BrandPreference]) -> str:
+    """Format brand preferences as human-readable text.
+
+    Args:
+        prefs: List of brand preferences.
+
+    Returns:
+        Formatted string describing preferences.
+    """
+    if not prefs:
+        return "No brand preferences set."
+
+    lines: list[str] = []
+    for pref in prefs:
+        action = (
+            "PREFER"
+            if pref.preference_type == BrandPreferenceType.PREFERRED
+            else "AVOID"
+        )
+        lines.append(
+            f"- {action}: {pref.brand} (for {pref.match_type}: {pref.match_target})"
+        )
+    return "\n".join(lines)
+
+
+def _parse_selection_response(
+    text: str,
+    candidates: list[SafewayProduct],
+) -> tuple[SafewayProduct | None, str] | None:
+    """Parse Claude's product selection response.
+
+    Args:
+        text: Raw response text from Claude.
+        candidates: The product candidates that were presented.
+
+    Returns:
+        Tuple of (selected_product, reasoning) or None on parse failure.
+    """
+    cleaned = _extract_json_text(text)
+    try:
+        data = json.loads(cleaned)
+    except json.JSONDecodeError:
+        logger.warning("Failed to parse product selection response as JSON")
+        return None
+
+    if not isinstance(data, dict):
+        return None
+
+    index = data.get("selected_index")
+    reasoning = str(data.get("reasoning", "No reasoning provided"))
+
+    if not isinstance(index, int):
+        return None
+
+    if index == -1:
+        return (None, reasoning)
+
+    if 0 <= index < len(candidates):
+        return (candidates[index], reasoning)
+
+    return None
+
+
+def _extract_json_text(raw: str) -> str:
+    """Extract JSON from a Claude response, stripping markdown fences.
+
+    Args:
+        raw: Raw text from Claude's response.
+
+    Returns:
+        Cleaned string ready for JSON parsing.
+    """
+    text = raw.strip()
+    if text.startswith("```"):
+        first_newline = text.index("\n")
+        text = text[first_newline + 1 :]
+    if text.endswith("```"):
+        text = text[: -len("```")]
+    return text.strip()

--- a/grocery_butler/prompts/brand_selection.txt
+++ b/grocery_butler/prompts/brand_selection.txt
@@ -1,2 +1,16 @@
-# Future use: Safeway brand selection
-This prompt will be implemented in Phase 3.
+You are a grocery shopping assistant. Given a list of products, filter and rank them based on brand preferences.
+
+## Products
+{products_json}
+
+## Brand Rules
+Avoided brands (MUST exclude): {avoided_brands}
+Preferred brands (rank higher): {preferred_brands}
+
+## Output Format
+Return ONLY a JSON array of 0-based product indices, ordered from best to worst choice.
+Exclude any products from avoided brands entirely.
+
+Example: [2, 0, 3]
+
+Return ONLY valid JSON — no markdown fences, no explanation.

--- a/grocery_butler/prompts/product_selection.txt
+++ b/grocery_butler/prompts/product_selection.txt
@@ -1,2 +1,37 @@
-# Future use: Safeway product selection
-This prompt will be implemented in Phase 3.
+You are a grocery shopping assistant selecting the best product from Safeway search results for a shopping list item.
+
+## Shopping List Item
+- Ingredient: {ingredient}
+- Quantity needed: {quantity} {unit}
+- Search term: {search_term}
+- Category: {category}
+
+## Available Products
+{products_json}
+
+## Brand Preferences
+{brand_preferences}
+
+## Price Sensitivity
+{price_sensitivity}
+
+## Rules
+1. NEVER select a product from an avoided brand
+2. Prefer products from preferred brands when available
+3. Consider price sensitivity:
+   - "budget": choose the lowest price option that meets quality requirements
+   - "moderate": balance price and quality, prefer preferred brands
+   - "premium": choose the highest quality option, price is secondary
+4. Prefer in-stock products over out-of-stock
+5. Match the size/quantity to what the recipe needs
+6. If no suitable product exists, set "selected_index" to -1
+
+## Output Format
+Return ONLY valid JSON:
+{{
+  "selected_index": 0,
+  "reasoning": "Brief explanation of why this product was chosen"
+}}
+
+Where "selected_index" is the 0-based index into the products list, or -1 if none are suitable.
+Return ONLY valid JSON — no markdown fences, no explanation.

--- a/grocery_butler/prompts/substitution_ranking.txt
+++ b/grocery_butler/prompts/substitution_ranking.txt
@@ -1,2 +1,35 @@
-# Future use: Safeway substitution ranking
-This prompt will be implemented in Phase 3.
+You are a grocery shopping assistant. An item is out of stock and you need to rank alternative products by suitability.
+
+## Original Item
+- Ingredient: {ingredient}
+- Quantity needed: {quantity} {unit}
+- Search term: {search_term}
+
+## Alternative Products
+{alternatives_json}
+
+## Rules
+1. Same cut/form is MOST important (e.g., chicken thighs != chicken breast, ground beef != beef stew meat)
+2. Then consider brand preferences: {brand_preferences}
+3. Then consider price (lower is generally better)
+4. Flag form differences with a warning (e.g., "This is breast, not thighs")
+
+## Suitability Ratings
+- "excellent": Same product, different brand or size
+- "good": Very similar product, minor differences
+- "acceptable": Usable substitute but noticeably different
+- "poor": Significantly different, may affect recipe outcome
+
+## Output Format
+Return ONLY a JSON array of objects, one per alternative, in order from best to worst:
+[
+  {{
+    "index": 0,
+    "suitability": "excellent",
+    "form_warning": null,
+    "reasoning": "Brief explanation"
+  }}
+]
+
+Where "index" is the 0-based index into the alternatives list.
+Return ONLY valid JSON — no markdown fences, no explanation.

--- a/grocery_butler/safeway_pipeline.py
+++ b/grocery_butler/safeway_pipeline.py
@@ -1,0 +1,146 @@
+"""End-to-end Safeway ordering pipeline.
+
+Bootstraps all Safeway services from a :class:`Config`, wires them
+together, and exposes a two-step flow: build cart → submit order.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from grocery_butler.cart_builder import CartBuilder
+from grocery_butler.order_service import OrderResult, OrderService
+from grocery_butler.pantry_manager import PantryManager
+from grocery_butler.product_search import ProductSearchService
+from grocery_butler.product_selector import ProductSelector
+from grocery_butler.recipe_store import RecipeStore
+from grocery_butler.safeway_client import SafewayClient
+from grocery_butler.substitution_service import SubstitutionService
+
+if TYPE_CHECKING:
+    from grocery_butler.config import Config
+    from grocery_butler.models import CartSummary, ShoppingListItem
+
+logger = logging.getLogger(__name__)
+
+
+class SafewayPipelineError(Exception):
+    """Raised when the pipeline encounters an unrecoverable error."""
+
+
+class SafewayPipeline:
+    """Orchestrate the full Safeway ordering pipeline.
+
+    Bootstraps all required services from a :class:`Config` object and
+    provides high-level methods to build carts and submit orders.
+
+    Args:
+        config: Application configuration with Safeway credentials.
+        db_path: Path to the SQLite database.
+        anthropic_client: Optional Anthropic API client for Claude calls.
+    """
+
+    def __init__(
+        self,
+        config: Config,
+        db_path: str,
+        anthropic_client: Any = None,
+    ) -> None:
+        """Initialize the pipeline and bootstrap all services.
+
+        Args:
+            config: Application configuration with Safeway credentials.
+            db_path: Path to the SQLite database.
+            anthropic_client: Optional Anthropic API client.
+
+        Raises:
+            SafewayPipelineError: If required Safeway config is missing.
+        """
+        if not config.safeway_username or not config.safeway_password:
+            raise SafewayPipelineError(
+                "Safeway credentials required: set SAFEWAY_USERNAME "
+                "and SAFEWAY_PASSWORD in .env"
+            )
+        if not config.safeway_store_id:
+            raise SafewayPipelineError(
+                "Safeway store ID required: set SAFEWAY_STORE_ID in .env"
+            )
+
+        self._client = SafewayClient(
+            username=config.safeway_username,
+            password=config.safeway_password,
+            store_id=config.safeway_store_id,
+        )
+
+        recipe_store = RecipeStore(db_path)
+        search_service = ProductSearchService(self._client, db_path)
+        selector = ProductSelector(anthropic_client, recipe_store)
+        substitution = SubstitutionService(
+            anthropic_client, search_service, recipe_store
+        )
+
+        self._cart_builder = CartBuilder(
+            search_service, selector, substitution, self._client
+        )
+
+        pantry_manager = PantryManager(db_path, anthropic_client)
+        self._order_service = OrderService(self._client, pantry_manager)
+
+    def run(
+        self,
+        items: list[ShoppingListItem],
+        restock_items: list[ShoppingListItem] | None = None,
+    ) -> OrderResult:
+        """Execute the full pipeline: build cart then submit order.
+
+        Args:
+            items: Shopping list items to order.
+            restock_items: Optional restock items to include.
+
+        Returns:
+            OrderResult with confirmation or error details.
+
+        Raises:
+            SafewayPipelineError: If authentication fails.
+        """
+        self._authenticate()
+        cart = self._cart_builder.build_cart(items, restock_items)
+        return self._order_service.submit_order(cart)
+
+    def build_cart_only(
+        self,
+        items: list[ShoppingListItem],
+        restock_items: list[ShoppingListItem] | None = None,
+    ) -> CartSummary:
+        """Build cart without submitting (for review).
+
+        Args:
+            items: Shopping list items to order.
+            restock_items: Optional restock items to include.
+
+        Returns:
+            CartSummary with selected products and pricing.
+
+        Raises:
+            SafewayPipelineError: If authentication fails.
+        """
+        self._authenticate()
+        return self._cart_builder.build_cart(items, restock_items)
+
+    def close(self) -> None:
+        """Clean up SafewayClient HTTP resources."""
+        self._client.close()
+
+    def _authenticate(self) -> None:
+        """Authenticate with Safeway if not already authenticated.
+
+        Raises:
+            SafewayPipelineError: If authentication fails.
+        """
+        if self._client.is_authenticated:
+            return
+        try:
+            self._client.authenticate()
+        except Exception as exc:
+            raise SafewayPipelineError(f"Safeway authentication failed: {exc}") from exc

--- a/grocery_butler/safeway_pipeline.py
+++ b/grocery_butler/safeway_pipeline.py
@@ -128,6 +128,24 @@ class SafewayPipeline:
         self._authenticate()
         return self._cart_builder.build_cart(items, restock_items)
 
+    def submit_cart(self, cart: CartSummary) -> OrderResult:
+        """Submit a pre-built cart to Safeway.
+
+        Use this when the cart has already been built via
+        :meth:`build_cart_only` and the user has confirmed.
+
+        Args:
+            cart: Pre-built cart summary to submit.
+
+        Returns:
+            OrderResult with confirmation or error details.
+
+        Raises:
+            SafewayPipelineError: If authentication fails.
+        """
+        self._authenticate()
+        return self._order_service.submit_order(cart)
+
     def close(self) -> None:
         """Clean up SafewayClient HTTP resources."""
         self._client.close()

--- a/grocery_butler/substitution_service.py
+++ b/grocery_butler/substitution_service.py
@@ -1,0 +1,369 @@
+"""Out-of-stock substitution flow with Claude-ranked alternatives.
+
+When a selected product is out of stock, this module searches for
+alternatives and uses Claude to rank them by suitability.  Substitutions
+are never silent -- they always produce a :class:`SubstitutionResult`
+that must be presented to the user for approval.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from grocery_butler.models import (
+    BrandPreference,
+    BrandPreferenceType,
+    SafewayProduct,
+    ShoppingListItem,
+    SubstitutionOption,
+    SubstitutionResult,
+    SubstitutionSuitability,
+)
+from grocery_butler.prompt_loader import load_prompt
+
+if TYPE_CHECKING:
+    from grocery_butler.product_search import ProductSearchService
+    from grocery_butler.recipe_store import RecipeStore
+
+logger = logging.getLogger(__name__)
+
+_MODEL = "claude-sonnet-4-20250514"
+_MAX_TOKENS = 2048
+
+
+class SubstitutionService:
+    """Rank alternative products for out-of-stock items.
+
+    Args:
+        claude_client: Anthropic API client (typed as Any).
+        search_service: Product search service for finding alternatives.
+        recipe_store: Database access for brand preferences.
+    """
+
+    def __init__(
+        self,
+        claude_client: Any,
+        search_service: ProductSearchService,
+        recipe_store: RecipeStore,
+    ) -> None:
+        """Initialize the substitution service.
+
+        Args:
+            claude_client: Anthropic API client.
+            search_service: Product search service.
+            recipe_store: Database for brand preferences.
+        """
+        self._client = claude_client
+        self._search = search_service
+        self._store = recipe_store
+
+    def find_substitutions(
+        self,
+        item: ShoppingListItem,
+        original_product: SafewayProduct,
+    ) -> SubstitutionResult:
+        """Find and rank substitutions for an out-of-stock product.
+
+        Searches for alternatives, filters out avoided brands,
+        removes the original product, then ranks with Claude.
+
+        Args:
+            item: The shopping list item needing a substitute.
+            original_product: The out-of-stock product.
+
+        Returns:
+            SubstitutionResult with ranked alternatives.
+        """
+        alternatives = self._search_alternatives(item, original_product)
+        if not alternatives:
+            return SubstitutionResult(
+                status="no_alternatives",
+                original_item=item,
+                message="No alternative products found",
+            )
+
+        brand_prefs = self._store.get_brands_for_ingredient(
+            item.ingredient,
+            category=item.category.value,
+        )
+        filtered = _filter_avoided(alternatives, brand_prefs)
+        if not filtered:
+            return SubstitutionResult(
+                status="all_avoided",
+                original_item=item,
+                message="All alternatives are from avoided brands",
+            )
+
+        ranked = self._rank_with_claude(item, filtered, brand_prefs)
+        return SubstitutionResult(
+            status="alternatives_found",
+            original_item=item,
+            alternatives=ranked,
+            message=f"Found {len(ranked)} alternative(s)",
+        )
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _search_alternatives(
+        self,
+        item: ShoppingListItem,
+        original: SafewayProduct,
+    ) -> list[SafewayProduct]:
+        """Search for alternative products, excluding the original.
+
+        Args:
+            item: Shopping list item for the search term.
+            original: The out-of-stock product to exclude.
+
+        Returns:
+            List of in-stock alternative products.
+        """
+        results = self._search.search_products(item.search_term)
+        return [
+            p for p in results if p.product_id != original.product_id and p.in_stock
+        ]
+
+    def _rank_with_claude(
+        self,
+        item: ShoppingListItem,
+        alternatives: list[SafewayProduct],
+        brand_prefs: list[BrandPreference],
+    ) -> list[SubstitutionOption]:
+        """Use Claude to rank alternatives by suitability.
+
+        Args:
+            item: The shopping list item.
+            alternatives: Candidate products.
+            brand_prefs: Relevant brand preferences.
+
+        Returns:
+            Ranked list of SubstitutionOption.
+        """
+        prompt = self._build_prompt(item, alternatives, brand_prefs)
+        response_text = self._call_claude(prompt)
+        if response_text is None:
+            return _fallback_ranking(alternatives)
+
+        ranked = _parse_ranking_response(response_text, alternatives)
+        if ranked is not None:
+            return ranked
+
+        return _fallback_ranking(alternatives)
+
+    def _build_prompt(
+        self,
+        item: ShoppingListItem,
+        alternatives: list[SafewayProduct],
+        brand_prefs: list[BrandPreference],
+    ) -> str:
+        """Build the substitution ranking prompt.
+
+        Args:
+            item: The shopping list item.
+            alternatives: Products to rank.
+            brand_prefs: Brand preferences.
+
+        Returns:
+            Formatted prompt string.
+        """
+        alt_dicts = [
+            {
+                "name": p.name,
+                "price": p.price,
+                "size": p.size,
+                "product_id": p.product_id,
+            }
+            for p in alternatives
+        ]
+        brand_text = _format_brand_prefs(brand_prefs)
+        return load_prompt(
+            "substitution_ranking",
+            ingredient=item.ingredient,
+            quantity=str(item.quantity),
+            unit=str(item.unit),
+            search_term=item.search_term,
+            alternatives_json=json.dumps(alt_dicts, indent=2),
+            brand_preferences=brand_text,
+        )
+
+    def _call_claude(self, prompt: str) -> str | None:
+        """Send a prompt to Claude.
+
+        Args:
+            prompt: The formatted prompt string.
+
+        Returns:
+            Response text or None on failure.
+        """
+        try:
+            response = self._client.messages.create(
+                model=_MODEL,
+                max_tokens=_MAX_TOKENS,
+                messages=[{"role": "user", "content": prompt}],
+            )
+            return str(response.content[0].text)
+        except Exception:
+            logger.exception("Claude substitution ranking call failed")
+            return None
+
+
+# ------------------------------------------------------------------
+# Pure helper functions
+# ------------------------------------------------------------------
+
+
+def _filter_avoided(
+    products: list[SafewayProduct],
+    brand_prefs: list[BrandPreference],
+) -> list[SafewayProduct]:
+    """Remove products from avoided brands.
+
+    Args:
+        products: Candidate products.
+        brand_prefs: Brand preferences.
+
+    Returns:
+        Products not matching avoided brands.
+    """
+    avoided = {
+        pref.brand.lower()
+        for pref in brand_prefs
+        if pref.preference_type == BrandPreferenceType.AVOID
+    }
+    if not avoided:
+        return products
+    return [
+        p for p in products if not any(brand in p.name.lower() for brand in avoided)
+    ]
+
+
+def _format_brand_prefs(prefs: list[BrandPreference]) -> str:
+    """Format brand preferences as text.
+
+    Args:
+        prefs: Brand preference list.
+
+    Returns:
+        Human-readable brand preferences string.
+    """
+    if not prefs:
+        return "None"
+    parts: list[str] = []
+    for pref in prefs:
+        label = (
+            "prefer"
+            if pref.preference_type == BrandPreferenceType.PREFERRED
+            else "avoid"
+        )
+        parts.append(f"{label} {pref.brand}")
+    return ", ".join(parts)
+
+
+def _parse_ranking_response(
+    text: str,
+    alternatives: list[SafewayProduct],
+) -> list[SubstitutionOption] | None:
+    """Parse Claude's substitution ranking response.
+
+    Args:
+        text: Raw response text.
+        alternatives: The products that were ranked.
+
+    Returns:
+        Ordered list of SubstitutionOption, or None on parse failure.
+    """
+    cleaned = _extract_json_text(text)
+    try:
+        data = json.loads(cleaned)
+    except json.JSONDecodeError:
+        logger.warning("Failed to parse substitution ranking as JSON")
+        return None
+
+    if not isinstance(data, list):
+        return None
+
+    options: list[SubstitutionOption] = []
+    for entry in data:
+        option = _parse_single_ranking(entry, alternatives)
+        if option is not None:
+            options.append(option)
+
+    return options if options else None
+
+
+def _parse_single_ranking(
+    entry: dict[str, Any],
+    alternatives: list[SafewayProduct],
+) -> SubstitutionOption | None:
+    """Parse a single ranking entry from Claude's response.
+
+    Args:
+        entry: A dict from Claude's JSON array.
+        alternatives: Products that were ranked.
+
+    Returns:
+        A SubstitutionOption, or None if invalid.
+    """
+    if not isinstance(entry, dict):
+        return None
+
+    index = entry.get("index")
+    if not isinstance(index, int) or index < 0 or index >= len(alternatives):
+        return None
+
+    suitability_str = entry.get("suitability", "acceptable")
+    try:
+        suitability = SubstitutionSuitability(suitability_str)
+    except ValueError:
+        suitability = SubstitutionSuitability.ACCEPTABLE
+
+    return SubstitutionOption(
+        product=alternatives[index],
+        suitability=suitability,
+        form_warning=entry.get("form_warning"),
+        reasoning=str(entry.get("reasoning", "No reasoning provided")),
+    )
+
+
+def _fallback_ranking(
+    alternatives: list[SafewayProduct],
+) -> list[SubstitutionOption]:
+    """Rank alternatives by price (cheapest first) without Claude.
+
+    Args:
+        alternatives: Products to rank.
+
+    Returns:
+        SubstitutionOption list sorted by price.
+    """
+    sorted_alts = sorted(alternatives, key=lambda p: p.price)
+    return [
+        SubstitutionOption(
+            product=p,
+            suitability=SubstitutionSuitability.ACCEPTABLE,
+            reasoning="Ranked by price (Claude unavailable)",
+        )
+        for p in sorted_alts
+    ]
+
+
+def _extract_json_text(raw: str) -> str:
+    """Extract JSON from Claude response, stripping markdown fences.
+
+    Args:
+        raw: Raw text from Claude.
+
+    Returns:
+        Cleaned string ready for JSON parsing.
+    """
+    text = raw.strip()
+    if text.startswith("```"):
+        first_newline = text.index("\n")
+        text = text[first_newline + 1 :]
+    if text.endswith("```"):
+        text = text[: -len("```")]
+    return text.strip()

--- a/grocery_butler/substitution_service.py
+++ b/grocery_butler/substitution_service.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_MODEL = "claude-sonnet-4-20250514"
+_MODEL = "claude-sonnet-4-6"
 _MAX_TOKENS = 2048
 
 

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -19,6 +19,7 @@ from grocery_butler.bot import (
     _format_restock_queue,
     _format_shopping_list,
     _make_bot_anthropic_client,
+    _OrderConfirmView,
     _truncate,
     create_bot,
     run_bot,
@@ -1819,3 +1820,20 @@ class TestOrderCommandGroup:
         subcommand_names = {cmd.name for cmd in group.commands}
         assert "review" in subcommand_names
         assert "submit" in subcommand_names
+
+
+class TestOrderConfirmViewTimeout:
+    """Tests for _OrderConfirmView.on_timeout resource cleanup."""
+
+    def test_on_timeout_closes_pipeline(self):
+        """Test that on_timeout calls pipeline.close."""
+        import asyncio
+
+        async def _run():
+            mock_pipeline = MagicMock()
+            mock_cart = MagicMock()
+            view = _OrderConfirmView(mock_pipeline, mock_cart)
+            await view.on_timeout()
+            mock_pipeline.close.assert_called_once()
+
+        asyncio.run(_run())

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1767,11 +1767,11 @@ class TestFormatOrderResult:
 class TestMakeBotAnthropicClient:
     """Tests for _make_bot_anthropic_client."""
 
-    def test_returns_none_on_error(self, config):
-        """Test returns None when anthropic is unavailable."""
+    def test_returns_none_on_import_error(self, config):
+        """Test returns None when anthropic import fails."""
         with patch.dict("sys.modules", {"anthropic": None}):
             result = _make_bot_anthropic_client(config)
-            assert result is None or result is not None
+            assert result is None
 
 
 class TestOrderCommandGroup:

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -9,13 +9,16 @@ import pytest
 
 from grocery_butler.bot import (
     _format_brands,
+    _format_cart_summary,
     _format_inventory,
+    _format_order_result,
     _format_pantry_list,
     _format_preferences,
     _format_recipe_detail,
     _format_recipes,
     _format_restock_queue,
     _format_shopping_list,
+    _make_bot_anthropic_client,
     _truncate,
     create_bot,
     run_bot,
@@ -620,7 +623,15 @@ class TestDiscordPermissions:
 
     def test_command_groups_guild_only(self, bot):
         """Test all command groups have guild_only set."""
-        group_names = ["pantry", "stock", "restock", "brands", "recipes", "preferences"]
+        group_names = [
+            "pantry",
+            "stock",
+            "restock",
+            "brands",
+            "recipes",
+            "preferences",
+            "order",
+        ]
         for name in group_names:
             group = self._get_command(bot, name)
             assert group is not None, f"Group {name!r} not found"
@@ -628,7 +639,15 @@ class TestDiscordPermissions:
 
     def test_command_groups_default_permissions(self, bot):
         """Test all command groups require manage_guild by default."""
-        group_names = ["pantry", "stock", "restock", "brands", "recipes", "preferences"]
+        group_names = [
+            "pantry",
+            "stock",
+            "restock",
+            "brands",
+            "recipes",
+            "preferences",
+            "order",
+        ]
         for name in group_names:
             group = self._get_command(bot, name)
             assert group is not None, f"Group {name!r} not found"
@@ -1616,3 +1635,179 @@ class TestOnMessageEvent:
 
         # Should reply twice: once for high-conf, once for low-conf
         assert message.reply.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Order bot formatters
+# ---------------------------------------------------------------------------
+
+
+class TestFormatCartSummaryBot:
+    """Tests for _format_cart_summary in bot module."""
+
+    def test_format_with_items(self):
+        """Test formatting a cart summary with items."""
+        from grocery_butler.models import (
+            CartItem,
+            CartSummary,
+            FulfillmentType,
+            SafewayProduct,
+        )
+
+        product = SafewayProduct(product_id="P1", name="Milk", price=4.99, size="1 gal")
+        cart_item = CartItem(
+            shopping_list_item=ShoppingListItem(
+                ingredient="milk",
+                quantity=1.0,
+                unit="gal",
+                category=IngredientCategory.DAIRY,
+                search_term="milk",
+                from_meals=["manual"],
+            ),
+            safeway_product=product,
+            quantity_to_order=1,
+            estimated_cost=4.99,
+        )
+        cart = CartSummary(
+            items=[cart_item],
+            failed_items=[],
+            substituted_items=[],
+            skipped_items=[],
+            restock_items=[],
+            subtotal=4.99,
+            fulfillment_options=[],
+            recommended_fulfillment=FulfillmentType.PICKUP,
+            estimated_total=4.99,
+        )
+
+        result = _format_cart_summary(cart)
+        assert "Milk" in result
+        assert "$4.99" in result
+        assert "```" in result
+
+    def test_format_with_failed_items(self):
+        """Test formatting cart with failed items."""
+        from grocery_butler.models import CartSummary, FulfillmentType
+
+        cart = CartSummary(
+            items=[],
+            failed_items=[
+                ShoppingListItem(
+                    ingredient="unicorn tears",
+                    quantity=1.0,
+                    unit="each",
+                    category=IngredientCategory.OTHER,
+                    search_term="unicorn tears",
+                    from_meals=["manual"],
+                ),
+            ],
+            substituted_items=[],
+            skipped_items=[],
+            restock_items=[],
+            subtotal=0.0,
+            fulfillment_options=[],
+            recommended_fulfillment=FulfillmentType.PICKUP,
+            estimated_total=0.0,
+        )
+
+        result = _format_cart_summary(cart)
+        assert "Failed" in result
+        assert "unicorn tears" in result
+
+
+class TestFormatOrderResult:
+    """Tests for _format_order_result in bot module."""
+
+    def test_format_success(self):
+        """Test formatting a successful order result."""
+        from grocery_butler.models import FulfillmentType
+        from grocery_butler.order_service import OrderConfirmation, OrderResult
+
+        result = OrderResult(
+            success=True,
+            confirmation=OrderConfirmation(
+                order_id="ORD-123",
+                status="confirmed",
+                estimated_time="2 hours",
+                total=24.99,
+                fulfillment_type=FulfillmentType.PICKUP,
+                item_count=5,
+            ),
+            items_restocked=2,
+        )
+
+        formatted = _format_order_result(result)
+        assert "ORD-123" in formatted
+        assert "confirmed" in formatted
+        assert "$24.99" in formatted
+        assert "Restocked 2" in formatted
+
+    def test_format_failure(self):
+        """Test formatting a failed order result."""
+        from grocery_butler.order_service import OrderResult
+
+        result = OrderResult(
+            success=False,
+            error_message="Payment declined",
+        )
+
+        formatted = _format_order_result(result)
+        assert "failed" in formatted.lower()
+        assert "Payment declined" in formatted
+
+    def test_format_success_no_confirmation(self):
+        """Test formatting success with missing confirmation."""
+        from grocery_butler.order_service import OrderResult
+
+        result = OrderResult(success=True, confirmation=None)
+        formatted = _format_order_result(result)
+        assert "no confirmation" in formatted.lower()
+
+
+class TestMakeBotAnthropicClient:
+    """Tests for _make_bot_anthropic_client."""
+
+    def test_returns_none_on_error(self, config):
+        """Test returns None when anthropic is unavailable."""
+        with patch.dict("sys.modules", {"anthropic": None}):
+            result = _make_bot_anthropic_client(config)
+            assert result is None or result is not None
+
+
+class TestOrderCommandGroup:
+    """Tests for /order command group registration."""
+
+    @pytest.fixture()
+    def bot(self, config):
+        """Create a bot instance for testing."""
+        return create_bot(config)
+
+    def _get_group(self, bot, name):
+        """Get command group by name.
+
+        Args:
+            bot: Discord client.
+            name: Group name.
+
+        Returns:
+            The command group.
+        """
+        tree = bot.tree  # type: ignore[attr-defined]
+        for cmd in tree.get_commands():
+            if cmd.name == name:
+                return cmd
+        return None  # pragma: no cover
+
+    def test_order_group_exists(self, bot):
+        """Test /order command group is registered."""
+        group = self._get_group(bot, "order")
+        assert group is not None
+
+    def test_order_subcommands(self, bot):
+        """Test /order has review, submit, and status subcommands."""
+        group = self._get_group(bot, "order")
+        assert group is not None
+        subcommand_names = {cmd.name for cmd in group.commands}
+        assert "review" in subcommand_names
+        assert "submit" in subcommand_names
+        assert "status" in subcommand_names

--- a/tests/test_cart_builder.py
+++ b/tests/test_cart_builder.py
@@ -1,0 +1,541 @@
+"""Tests for grocery_butler.cart_builder module."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from unittest.mock import MagicMock
+
+from grocery_butler.cart_builder import (
+    CartBuilder,
+    _calculate_quantity,
+    _calculate_subtotal,
+    _default_fulfillment_options,
+    _get_fulfillment_fee,
+    _parse_fulfillment_response,
+    _parse_product_size,
+    _recommend_fulfillment,
+)
+from grocery_butler.models import (
+    CartItem,
+    FulfillmentOption,
+    FulfillmentType,
+    IngredientCategory,
+    SafewayProduct,
+    ShoppingListItem,
+    SubstitutionResult,
+)
+
+# ------------------------------------------------------------------
+# Fixtures
+# ------------------------------------------------------------------
+
+
+def _make_item(
+    ingredient: str = "chicken thighs",
+    quantity: float = 2.0,
+    unit: str = "lb",
+    search_term: str = "boneless chicken thighs",
+) -> ShoppingListItem:
+    """Create a test ShoppingListItem.
+
+    Args:
+        ingredient: Ingredient name.
+        quantity: Desired quantity.
+        unit: Unit of measurement.
+        search_term: Search term.
+
+    Returns:
+        ShoppingListItem for testing.
+    """
+    return ShoppingListItem(
+        ingredient=ingredient,
+        quantity=quantity,
+        unit=unit,
+        category=IngredientCategory.MEAT,
+        search_term=search_term,
+        from_meals=["Test Meal"],
+    )
+
+
+def _make_product(
+    product_id: str = "P001",
+    name: str = "Boneless Chicken Thighs",
+    price: float = 8.99,
+    size: str = "2 lb",
+    in_stock: bool = True,
+) -> SafewayProduct:
+    """Create a test SafewayProduct.
+
+    Args:
+        product_id: Product ID.
+        name: Product name.
+        price: Product price.
+        size: Product size.
+        in_stock: Whether in stock.
+
+    Returns:
+        SafewayProduct for testing.
+    """
+    return SafewayProduct(
+        product_id=product_id,
+        name=name,
+        price=price,
+        size=size,
+        in_stock=in_stock,
+    )
+
+
+def _make_cart_item(
+    price: float = 8.99,
+    quantity: int = 1,
+) -> CartItem:
+    """Create a test CartItem.
+
+    Args:
+        price: Product price.
+        quantity: Order quantity.
+
+    Returns:
+        CartItem for testing.
+    """
+    return CartItem(
+        shopping_list_item=_make_item(),
+        safeway_product=_make_product(price=price),
+        quantity_to_order=quantity,
+        estimated_cost=round(price * quantity, 2),
+    )
+
+
+@dataclass
+class _MockSelectionResult:
+    """Mock selection result matching ProductSelector output."""
+
+    item: ShoppingListItem
+    product: SafewayProduct | None
+    reasoning: str
+
+
+# ------------------------------------------------------------------
+# Tests: _parse_product_size
+# ------------------------------------------------------------------
+
+
+class TestParseProductSize:
+    """Tests for _parse_product_size."""
+
+    def test_simple_size(self) -> None:
+        """Test parsing '2 lb'."""
+        assert _parse_product_size("2 lb") == 2.0
+
+    def test_decimal_size(self) -> None:
+        """Test parsing '1.5 gal'."""
+        assert _parse_product_size("1.5 gal") == 1.5
+
+    def test_no_number(self) -> None:
+        """Test unparseable size returns 0."""
+        assert _parse_product_size("each") == 0.0
+
+    def test_empty_string(self) -> None:
+        """Test empty string returns 0."""
+        assert _parse_product_size("") == 0.0
+
+    def test_leading_whitespace(self) -> None:
+        """Test size with leading whitespace."""
+        assert _parse_product_size("  16 oz") == 16.0
+
+
+# ------------------------------------------------------------------
+# Tests: _calculate_quantity
+# ------------------------------------------------------------------
+
+
+class TestCalculateQuantity:
+    """Tests for _calculate_quantity."""
+
+    def test_exact_match(self) -> None:
+        """Test quantity matches product size exactly."""
+        item = _make_item(quantity=2.0)
+        product = _make_product(size="2 lb")
+        assert _calculate_quantity(item, product) == 1
+
+    def test_needs_two(self) -> None:
+        """Test needing two products."""
+        item = _make_item(quantity=3.0)
+        product = _make_product(size="2 lb")
+        assert _calculate_quantity(item, product) == 2
+
+    def test_unparseable_size(self) -> None:
+        """Test unparseable product size returns 1."""
+        item = _make_item(quantity=2.0)
+        product = _make_product(size="each")
+        assert _calculate_quantity(item, product) == 1
+
+    def test_fractional_rounds_up(self) -> None:
+        """Test fractional quantity rounds up."""
+        item = _make_item(quantity=2.5)
+        product = _make_product(size="2 lb")
+        assert _calculate_quantity(item, product) == 2
+
+    def test_minimum_one(self) -> None:
+        """Test minimum quantity is 1."""
+        item = _make_item(quantity=0.5)
+        product = _make_product(size="2 lb")
+        assert _calculate_quantity(item, product) == 1
+
+
+# ------------------------------------------------------------------
+# Tests: _calculate_subtotal
+# ------------------------------------------------------------------
+
+
+class TestCalculateSubtotal:
+    """Tests for _calculate_subtotal."""
+
+    def test_items_only(self) -> None:
+        """Test subtotal with regular items only."""
+        items = [_make_cart_item(price=5.0), _make_cart_item(price=3.0)]
+        assert _calculate_subtotal(items, []) == 8.0
+
+    def test_with_restock(self) -> None:
+        """Test subtotal includes restock items."""
+        items = [_make_cart_item(price=5.0)]
+        restock = [_make_cart_item(price=2.0)]
+        assert _calculate_subtotal(items, restock) == 7.0
+
+    def test_empty(self) -> None:
+        """Test empty lists returns 0."""
+        assert _calculate_subtotal([], []) == 0.0
+
+
+# ------------------------------------------------------------------
+# Tests: _recommend_fulfillment
+# ------------------------------------------------------------------
+
+
+class TestRecommendFulfillment:
+    """Tests for _recommend_fulfillment."""
+
+    def test_prefers_pickup(self) -> None:
+        """Test pickup is preferred when available."""
+        options = [
+            FulfillmentOption(
+                type=FulfillmentType.DELIVERY,
+                available=True,
+                fee=9.95,
+                windows=[],
+            ),
+            FulfillmentOption(
+                type=FulfillmentType.PICKUP,
+                available=True,
+                fee=0.0,
+                windows=[],
+            ),
+        ]
+        assert _recommend_fulfillment(options) == FulfillmentType.PICKUP
+
+    def test_delivery_when_no_pickup(self) -> None:
+        """Test delivery when pickup unavailable."""
+        options = [
+            FulfillmentOption(
+                type=FulfillmentType.PICKUP,
+                available=False,
+                fee=0.0,
+                windows=[],
+            ),
+            FulfillmentOption(
+                type=FulfillmentType.DELIVERY,
+                available=True,
+                fee=9.95,
+                windows=[],
+            ),
+        ]
+        assert _recommend_fulfillment(options) == FulfillmentType.DELIVERY
+
+    def test_empty_options(self) -> None:
+        """Test defaults to pickup with no options."""
+        assert _recommend_fulfillment([]) == FulfillmentType.PICKUP
+
+    def test_none_available(self) -> None:
+        """Test defaults to pickup when none available."""
+        options = [
+            FulfillmentOption(
+                type=FulfillmentType.DELIVERY,
+                available=False,
+                fee=9.95,
+                windows=[],
+            ),
+        ]
+        assert _recommend_fulfillment(options) == FulfillmentType.PICKUP
+
+
+# ------------------------------------------------------------------
+# Tests: _get_fulfillment_fee
+# ------------------------------------------------------------------
+
+
+class TestGetFulfillmentFee:
+    """Tests for _get_fulfillment_fee."""
+
+    def test_finds_fee(self) -> None:
+        """Test finding fee for recommended type."""
+        options = [
+            FulfillmentOption(
+                type=FulfillmentType.PICKUP,
+                available=True,
+                fee=0.0,
+                windows=[],
+            ),
+            FulfillmentOption(
+                type=FulfillmentType.DELIVERY,
+                available=True,
+                fee=9.95,
+                windows=[],
+            ),
+        ]
+        assert _get_fulfillment_fee(options, FulfillmentType.DELIVERY) == 9.95
+
+    def test_missing_type(self) -> None:
+        """Test returns 0 when type not found."""
+        assert _get_fulfillment_fee([], FulfillmentType.PICKUP) == 0.0
+
+
+# ------------------------------------------------------------------
+# Tests: _parse_fulfillment_response
+# ------------------------------------------------------------------
+
+
+class TestParseFulfillmentResponse:
+    """Tests for _parse_fulfillment_response."""
+
+    def test_valid_response(self) -> None:
+        """Test parsing a valid fulfillment response."""
+        response = {
+            "fulfillmentOptions": [
+                {
+                    "type": "pickup",
+                    "available": True,
+                    "fee": 0.0,
+                    "windows": [{"display": "Today 4-6pm"}],
+                },
+                {
+                    "type": "delivery",
+                    "available": True,
+                    "fee": 9.95,
+                    "windows": [],
+                },
+            ]
+        }
+        result = _parse_fulfillment_response(response)
+        assert len(result) == 2
+        assert result[0].type == FulfillmentType.PICKUP
+        assert result[0].next_window == "Today 4-6pm"
+        assert result[1].fee == 9.95
+        assert result[1].next_window is None
+
+    def test_empty_response(self) -> None:
+        """Test empty response returns empty list."""
+        assert _parse_fulfillment_response({}) == []
+
+    def test_invalid_type_skipped(self) -> None:
+        """Test entries with invalid type are skipped."""
+        response = {
+            "fulfillmentOptions": [
+                {"type": "teleport", "available": True, "fee": 0},
+            ]
+        }
+        assert _parse_fulfillment_response(response) == []
+
+
+# ------------------------------------------------------------------
+# Tests: _default_fulfillment_options
+# ------------------------------------------------------------------
+
+
+class TestDefaultFulfillmentOptions:
+    """Tests for _default_fulfillment_options."""
+
+    def test_returns_two_options(self) -> None:
+        """Test defaults include pickup and delivery."""
+        result = _default_fulfillment_options()
+        assert len(result) == 2
+        types = {o.type for o in result}
+        assert FulfillmentType.PICKUP in types
+        assert FulfillmentType.DELIVERY in types
+
+    def test_pickup_is_free(self) -> None:
+        """Test default pickup fee is 0."""
+        result = _default_fulfillment_options()
+        pickup = next(o for o in result if o.type == FulfillmentType.PICKUP)
+        assert pickup.fee == 0.0
+
+
+# ------------------------------------------------------------------
+# Tests: CartBuilder.build_cart
+# ------------------------------------------------------------------
+
+
+class TestBuildCart:
+    """Tests for CartBuilder.build_cart."""
+
+    def _make_builder(
+        self,
+        search_results: list[SafewayProduct] | None = None,
+        selection_product: SafewayProduct | None = None,
+        fulfillment_response: dict | None = None,
+    ) -> CartBuilder:
+        """Create a CartBuilder with mock dependencies.
+
+        Args:
+            search_results: Products returned by search.
+            selection_product: Product returned by selector.
+            fulfillment_response: Fulfillment API response.
+
+        Returns:
+            CartBuilder with mocked services.
+        """
+        mock_search = MagicMock()
+        mock_search.search_or_cached.return_value = search_results or []
+
+        mock_selector = MagicMock()
+        item = _make_item()
+        mock_selector.select_product.return_value = _MockSelectionResult(
+            item=item,
+            product=selection_product,
+            reasoning="Test selection",
+        )
+
+        mock_substitution = MagicMock()
+        mock_substitution.find_substitutions.return_value = SubstitutionResult(
+            status="no_alternatives",
+            original_item=item,
+            message="No alternatives",
+        )
+
+        mock_client = MagicMock()
+        mock_client.store_id = "1234"
+        mock_client.get.return_value = fulfillment_response or {}
+
+        return CartBuilder(
+            search_service=mock_search,
+            product_selector=mock_selector,
+            substitution_service=mock_substitution,
+            safeway_client=mock_client,
+        )
+
+    def test_successful_cart(self) -> None:
+        """Test building cart with available products."""
+        product = _make_product(price=8.99, size="2 lb")
+        builder = self._make_builder(
+            search_results=[product],
+            selection_product=product,
+        )
+        result = builder.build_cart([_make_item()])
+
+        assert len(result.items) == 1
+        assert result.items[0].safeway_product.product_id == "P001"
+        assert result.items[0].quantity_to_order == 1
+        assert result.items[0].estimated_cost == 8.99
+        assert result.failed_items == []
+
+    def test_no_products_found(self) -> None:
+        """Test item goes to failed when no products found."""
+        builder = self._make_builder(search_results=[])
+        result = builder.build_cart([_make_item()])
+
+        assert len(result.failed_items) == 1
+        assert result.items == []
+
+    def test_selector_returns_none(self) -> None:
+        """Test item goes to failed when selector returns None."""
+        builder = self._make_builder(
+            search_results=[_make_product()],
+            selection_product=None,
+        )
+        result = builder.build_cart([_make_item()])
+
+        assert len(result.failed_items) == 1
+
+    def test_out_of_stock_triggers_substitution(self) -> None:
+        """Test out-of-stock product triggers substitution flow."""
+        product = _make_product(in_stock=False)
+        builder = self._make_builder(
+            search_results=[product],
+            selection_product=product,
+        )
+        result = builder.build_cart([_make_item()])
+
+        assert len(result.substituted_items) == 1
+        assert result.substituted_items[0].status == "no_alternatives"
+
+    def test_restock_items_separated(self) -> None:
+        """Test restock items go to restock_items list."""
+        product = _make_product(price=3.99, size="1 gal")
+        builder = self._make_builder(
+            search_results=[product],
+            selection_product=product,
+        )
+        restock = _make_item(
+            ingredient="milk",
+            search_term="whole milk",
+            quantity=1.0,
+        )
+        result = builder.build_cart([], restock_items=[restock])
+
+        assert len(result.restock_items) == 1
+        assert result.items == []
+
+    def test_subtotal_calculation(self) -> None:
+        """Test subtotal sums item costs."""
+        product = _make_product(price=5.0, size="1 lb")
+        builder = self._make_builder(
+            search_results=[product],
+            selection_product=product,
+        )
+        items = [_make_item(quantity=1.0), _make_item(quantity=1.0)]
+        result = builder.build_cart(items)
+
+        assert result.subtotal == 10.0
+
+    def test_estimated_total_includes_fee(self) -> None:
+        """Test estimated total includes fulfillment fee."""
+        product = _make_product(price=10.0, size="1 lb")
+        fulfillment = {
+            "fulfillmentOptions": [
+                {
+                    "type": "pickup",
+                    "available": True,
+                    "fee": 0.0,
+                    "windows": [],
+                },
+            ]
+        }
+        builder = self._make_builder(
+            search_results=[product],
+            selection_product=product,
+            fulfillment_response=fulfillment,
+        )
+        result = builder.build_cart([_make_item(quantity=1.0)])
+
+        assert result.estimated_total == 10.0
+
+    def test_fulfillment_api_failure_uses_defaults(self) -> None:
+        """Test default fulfillment options on API failure."""
+        product = _make_product(price=5.0, size="1 lb")
+        builder = self._make_builder(
+            search_results=[product],
+            selection_product=product,
+        )
+        builder._client.get.side_effect = Exception("API down")
+        result = builder.build_cart([_make_item(quantity=1.0)])
+
+        assert len(result.fulfillment_options) == 2
+        assert result.recommended_fulfillment == FulfillmentType.PICKUP
+
+    def test_empty_cart(self) -> None:
+        """Test building cart with no items."""
+        builder = self._make_builder()
+        result = builder.build_cart([])
+
+        assert result.items == []
+        assert result.failed_items == []
+        assert result.subtotal == 0.0

--- a/tests/test_claude_utils.py
+++ b/tests/test_claude_utils.py
@@ -1,0 +1,122 @@
+"""Tests for grocery_butler.claude_utils module."""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+from grocery_butler.claude_utils import (
+    extract_json_text,
+    filter_avoided_brands,
+    items_from_string,
+    make_anthropic_client,
+)
+from grocery_butler.models import (
+    BrandMatchType,
+    BrandPreference,
+    BrandPreferenceType,
+    IngredientCategory,
+    SafewayProduct,
+    Unit,
+)
+
+
+class TestExtractJsonText:
+    """Tests for extract_json_text helper."""
+
+    def test_plain_json(self):
+        """Test plain JSON passes through."""
+        assert extract_json_text('{"a": 1}') == '{"a": 1}'
+
+    def test_strips_markdown_fences(self):
+        """Test markdown code fences are removed."""
+        result = extract_json_text('```json\n{"a": 1}\n```')
+        assert result == '{"a": 1}'
+
+    def test_strips_whitespace(self):
+        """Test surrounding whitespace is stripped."""
+        assert extract_json_text("  {}\n  ") == "{}"
+
+
+class TestFilterAvoidedBrands:
+    """Tests for filter_avoided_brands helper."""
+
+    def test_no_prefs_returns_all(self):
+        """Test empty prefs returns all products."""
+        products = [
+            SafewayProduct(product_id="1", name="A", price=1.0, size=""),
+            SafewayProduct(product_id="2", name="B", price=2.0, size=""),
+        ]
+        assert len(filter_avoided_brands(products, [])) == 2
+
+    def test_filters_avoided(self):
+        """Test avoided brands are filtered out."""
+        products = [
+            SafewayProduct(product_id="1", name="BadBrand Milk", price=1.0, size=""),
+            SafewayProduct(product_id="2", name="Good Milk", price=2.0, size=""),
+        ]
+        prefs = [
+            BrandPreference(
+                brand="BadBrand",
+                preference_type=BrandPreferenceType.AVOID,
+                match_type=BrandMatchType.CATEGORY,
+                match_target="dairy",
+            )
+        ]
+        result = filter_avoided_brands(products, prefs)
+        assert len(result) == 1
+        assert result[0].name == "Good Milk"
+
+
+class TestMakeAnthropicClient:
+    """Tests for make_anthropic_client helper."""
+
+    def test_returns_none_on_import_error(self):
+        """Test returns None when anthropic import fails."""
+        with patch.dict("sys.modules", {"anthropic": None}):
+            result = make_anthropic_client("fake-key")
+            assert result is None
+
+    def test_logs_warning_on_failure(self, caplog):
+        """Test warning is logged on failure."""
+        with patch.dict("sys.modules", {"anthropic": None}):
+            with caplog.at_level(logging.WARNING, logger="grocery_butler.claude_utils"):
+                make_anthropic_client("fake-key")
+            assert "Anthropic client unavailable" in caplog.text
+
+
+class TestItemsFromString:
+    """Tests for items_from_string helper."""
+
+    def test_basic_items(self):
+        """Test basic comma-separated items."""
+        result = items_from_string("milk, eggs, bread")
+        assert len(result) == 3
+        assert result[0].ingredient == "milk"
+        assert result[1].ingredient == "eggs"
+        assert result[2].ingredient == "bread"
+
+    def test_empty_string(self):
+        """Test empty string returns empty list."""
+        assert items_from_string("") == []
+
+    def test_whitespace_only(self):
+        """Test whitespace-only string returns empty list."""
+        assert items_from_string("  ,  , ") == []
+
+    def test_defaults(self):
+        """Test default values are set correctly."""
+        result = items_from_string("milk")
+        assert len(result) == 1
+        item = result[0]
+        assert item.quantity == 1.0
+        assert item.unit == Unit.EACH
+        assert item.category == IngredientCategory.OTHER
+        assert item.search_term == "milk"
+        assert item.from_meals == ["manual"]
+
+    def test_lowercases_names(self):
+        """Test item names are lowercased."""
+        result = items_from_string("MILK, Eggs")
+        assert result[0].ingredient == "milk"
+        assert result[1].ingredient == "eggs"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1379,6 +1379,17 @@ class TestMakeAnthropicClient:
             result = _make_anthropic_client("fake-key")
             assert result is None
 
+    def test_logs_warning_on_failure(self, caplog):
+        """Test warning is logged when anthropic client creation fails."""
+        import logging
+
+        from grocery_butler.cli import _make_anthropic_client
+
+        with patch.dict("sys.modules", {"anthropic": None}):
+            with caplog.at_level(logging.WARNING, logger="grocery_butler.cli"):
+                _make_anthropic_client("fake-key")
+            assert "Anthropic client unavailable" in caplog.text
+
 
 # ---------------------------------------------------------------------------
 # Order subcommand handler tests

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1361,17 +1361,11 @@ class TestLoadConfigSafe:
         from grocery_butler.cli import _load_config_safe
 
         with patch(
-            "grocery_butler.cli.load_config",
+            "grocery_butler.config.load_config",
             side_effect=RuntimeError("no env"),
-            create=True,
         ):
-            # The function uses its own import, so we patch differently
             result = _load_config_safe()
-            # It catches exceptions so it should return None or a Config
-            # depending on env. Since no .env, it returns None.
-            # This is hard to test in isolation without env setup.
-            # The key point is it doesn't raise.
-            assert result is None or result is not None
+            assert result is None
 
 
 class TestMakeAnthropicClient:
@@ -1383,8 +1377,7 @@ class TestMakeAnthropicClient:
 
         with patch.dict("sys.modules", {"anthropic": None}):
             result = _make_anthropic_client("fake-key")
-            # Should not raise; may return None or client depending on env
-            assert result is None or result is not None
+            assert result is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_consolidator.py
+++ b/tests/test_consolidator.py
@@ -787,7 +787,7 @@ class TestConsolidateWithClaude:
         consolidator.consolidate([sample_tacos_meal], [], pantry_staples)
         mock_client.messages.create.assert_called_once()
         call_kwargs = mock_client.messages.create.call_args
-        assert call_kwargs[1]["model"] == "claude-sonnet-4-20250514"
+        assert call_kwargs[1]["model"] == "claude-sonnet-4-6"
 
     def test_no_client_uses_simple_fallback(
         self,
@@ -991,7 +991,7 @@ class TestConsolidatorGetModel:
     def test_returns_correct_model(self):
         """Test model name is the expected Claude model."""
         consolidator = Consolidator()
-        assert consolidator._get_model() == "claude-sonnet-4-20250514"
+        assert consolidator._get_model() == "claude-sonnet-4-6"
 
 
 class TestConsolidatorBuildPrompt:

--- a/tests/test_consolidator.py
+++ b/tests/test_consolidator.py
@@ -7,10 +7,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from grocery_butler.claude_utils import extract_json_text
 from grocery_butler.consolidator import (
     Consolidator,
     _build_ingredient_text,
-    _extract_json_text,
     _flatten_meal_ingredients,
     _format_inventory_overrides,
     _format_pantry_staples,
@@ -238,27 +238,27 @@ def _valid_consolidation_json() -> str:
 
 
 class TestExtractJsonText:
-    """Tests for _extract_json_text helper."""
+    """Tests for extract_json_text helper."""
 
     def test_plain_json(self):
         """Test plain JSON passes through."""
         text = '{"key": "value"}'
-        assert _extract_json_text(text) == text
+        assert extract_json_text(text) == text
 
     def test_strips_markdown_fences(self):
         """Test markdown code fences are stripped."""
         text = '```json\n[{"key": "value"}]\n```'
-        assert _extract_json_text(text) == '[{"key": "value"}]'
+        assert extract_json_text(text) == '[{"key": "value"}]'
 
     def test_strips_plain_fences(self):
         """Test plain code fences are stripped."""
         text = '```\n[{"key": "value"}]\n```'
-        assert _extract_json_text(text) == '[{"key": "value"}]'
+        assert extract_json_text(text) == '[{"key": "value"}]'
 
     def test_strips_whitespace(self):
         """Test surrounding whitespace is stripped."""
         text = '  [{"key": "value"}]  '
-        assert _extract_json_text(text) == '[{"key": "value"}]'
+        assert extract_json_text(text) == '[{"key": "value"}]'
 
 
 class TestFormatPantryStaples:

--- a/tests/test_meal_parser.py
+++ b/tests/test_meal_parser.py
@@ -8,10 +8,10 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from grocery_butler.claude_utils import extract_json_text
 from grocery_butler.meal_parser import (
     MealParser,
     _build_stub_meal,
-    _extract_json_text,
     _parse_ingredient,
     _parse_meal_from_dict,
     _scale_ingredients,
@@ -197,27 +197,27 @@ class TestBuildStubMeal:
 
 
 class TestExtractJsonText:
-    """Tests for _extract_json_text helper."""
+    """Tests for extract_json_text helper."""
 
     def test_plain_json(self):
         """Test plain JSON passes through."""
         text = '{"key": "value"}'
-        assert _extract_json_text(text) == text
+        assert extract_json_text(text) == text
 
     def test_strips_markdown_fences(self):
         """Test markdown code fences are stripped."""
         text = '```json\n{"key": "value"}\n```'
-        assert _extract_json_text(text) == '{"key": "value"}'
+        assert extract_json_text(text) == '{"key": "value"}'
 
     def test_strips_plain_fences(self):
         """Test plain code fences are stripped."""
         text = '```\n{"key": "value"}\n```'
-        assert _extract_json_text(text) == '{"key": "value"}'
+        assert extract_json_text(text) == '{"key": "value"}'
 
     def test_strips_whitespace(self):
         """Test surrounding whitespace is stripped."""
         text = '  {"key": "value"}  '
-        assert _extract_json_text(text) == '{"key": "value"}'
+        assert extract_json_text(text) == '{"key": "value"}'
 
 
 class TestParseIngredient:

--- a/tests/test_order_service.py
+++ b/tests/test_order_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock
 
 from grocery_butler.models import (
@@ -246,6 +247,15 @@ class TestParseOrderResponse:
         assert result is not None
         assert result.total == cart.estimated_total
 
+    def test_integer_order_id_accepted(self) -> None:
+        """Test integer orderId (including 0) is accepted."""
+        response = {"orderId": 0, "status": "confirmed"}
+        cart = _make_cart()
+        result = _parse_order_response(response, cart)
+
+        assert result is not None
+        assert result.order_id == "0"
+
 
 # ------------------------------------------------------------------
 # Tests: _collect_restock_ingredients
@@ -282,7 +292,7 @@ class TestSubmitOrder:
 
     def _make_service(
         self,
-        api_response: dict | None = None,
+        api_response: dict[str, Any] | None = None,
         api_error: bool = False,
     ) -> OrderService:
         """Create an OrderService with mock dependencies.

--- a/tests/test_order_service.py
+++ b/tests/test_order_service.py
@@ -1,0 +1,401 @@
+"""Tests for grocery_butler.order_service module."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from grocery_butler.models import (
+    CartItem,
+    CartSummary,
+    FulfillmentOption,
+    FulfillmentType,
+    IngredientCategory,
+    SafewayProduct,
+    ShoppingListItem,
+)
+from grocery_butler.order_service import (
+    OrderService,
+    _build_order_payload,
+    _collect_restock_ingredients,
+    _parse_order_response,
+    _serialize_cart_items,
+)
+
+# ------------------------------------------------------------------
+# Fixtures
+# ------------------------------------------------------------------
+
+
+def _make_item(
+    ingredient: str = "chicken thighs",
+    search_term: str = "boneless chicken thighs",
+) -> ShoppingListItem:
+    """Create a test ShoppingListItem.
+
+    Args:
+        ingredient: Ingredient name.
+        search_term: Search term.
+
+    Returns:
+        ShoppingListItem for testing.
+    """
+    return ShoppingListItem(
+        ingredient=ingredient,
+        quantity=2.0,
+        unit="lb",
+        category=IngredientCategory.MEAT,
+        search_term=search_term,
+        from_meals=["Test Meal"],
+    )
+
+
+def _make_product(
+    product_id: str = "P001",
+    name: str = "Boneless Chicken Thighs",
+    price: float = 8.99,
+) -> SafewayProduct:
+    """Create a test SafewayProduct.
+
+    Args:
+        product_id: Product ID.
+        name: Product name.
+        price: Product price.
+
+    Returns:
+        SafewayProduct for testing.
+    """
+    return SafewayProduct(
+        product_id=product_id,
+        name=name,
+        price=price,
+        size="2 lb",
+        in_stock=True,
+    )
+
+
+def _make_cart_item(
+    ingredient: str = "chicken thighs",
+    product_id: str = "P001",
+    price: float = 8.99,
+) -> CartItem:
+    """Create a test CartItem.
+
+    Args:
+        ingredient: Ingredient name.
+        product_id: Product ID.
+        price: Product price.
+
+    Returns:
+        CartItem for testing.
+    """
+    return CartItem(
+        shopping_list_item=_make_item(ingredient=ingredient),
+        safeway_product=_make_product(product_id=product_id, price=price),
+        quantity_to_order=1,
+        estimated_cost=price,
+    )
+
+
+def _make_cart(
+    items: list[CartItem] | None = None,
+    restock_items: list[CartItem] | None = None,
+) -> CartSummary:
+    """Create a test CartSummary.
+
+    Args:
+        items: Regular cart items.
+        restock_items: Restock queue items.
+
+    Returns:
+        CartSummary for testing.
+    """
+    cart_items = [_make_cart_item()] if items is None else items
+    restock = [] if restock_items is None else restock_items
+    subtotal = sum(i.estimated_cost for i in cart_items + restock)
+    return CartSummary(
+        items=cart_items,
+        failed_items=[],
+        substituted_items=[],
+        skipped_items=[],
+        restock_items=restock,
+        subtotal=subtotal,
+        fulfillment_options=[
+            FulfillmentOption(
+                type=FulfillmentType.PICKUP,
+                available=True,
+                fee=0.0,
+                windows=[],
+            ),
+        ],
+        recommended_fulfillment=FulfillmentType.PICKUP,
+        estimated_total=subtotal,
+    )
+
+
+# ------------------------------------------------------------------
+# Tests: _serialize_cart_items
+# ------------------------------------------------------------------
+
+
+class TestSerializeCartItems:
+    """Tests for _serialize_cart_items."""
+
+    def test_serializes_items(self) -> None:
+        """Test items are serialized with productId and quantity."""
+        items = [_make_cart_item(product_id="A")]
+        result = _serialize_cart_items(items)
+        assert len(result) == 1
+        assert result[0]["productId"] == "A"
+        assert result[0]["quantity"] == 1
+
+    def test_empty_list(self) -> None:
+        """Test empty list returns empty."""
+        assert _serialize_cart_items([]) == []
+
+
+# ------------------------------------------------------------------
+# Tests: _build_order_payload
+# ------------------------------------------------------------------
+
+
+class TestBuildOrderPayload:
+    """Tests for _build_order_payload."""
+
+    def test_includes_items_and_fulfillment(self) -> None:
+        """Test payload has items, fulfillment type, and total."""
+        cart = _make_cart()
+        result = _build_order_payload(cart)
+
+        assert "items" in result
+        assert result["fulfillmentType"] == "pickup"
+        assert result["estimatedTotal"] == cart.estimated_total
+
+    def test_includes_restock_items(self) -> None:
+        """Test restock items are included in payload."""
+        restock = _make_cart_item(ingredient="milk", product_id="R1")
+        cart = _make_cart(restock_items=[restock])
+        result = _build_order_payload(cart)
+
+        product_ids = [i["productId"] for i in result["items"]]
+        assert "P001" in product_ids
+        assert "R1" in product_ids
+
+
+# ------------------------------------------------------------------
+# Tests: _parse_order_response
+# ------------------------------------------------------------------
+
+
+class TestParseOrderResponse:
+    """Tests for _parse_order_response."""
+
+    def test_successful_response(self) -> None:
+        """Test parsing a successful order response."""
+        response = {
+            "orderId": "ORD-12345",
+            "status": "confirmed",
+            "estimatedTime": "Today 4-6pm",
+            "total": 25.99,
+        }
+        cart = _make_cart()
+        result = _parse_order_response(response, cart)
+
+        assert result is not None
+        assert result.order_id == "ORD-12345"
+        assert result.status == "confirmed"
+        assert result.estimated_time == "Today 4-6pm"
+        assert result.total == 25.99
+
+    def test_error_response(self) -> None:
+        """Test error status returns None."""
+        response = {"status": "error", "error": "Out of delivery slots"}
+        assert _parse_order_response(response, _make_cart()) is None
+
+    def test_missing_order_id(self) -> None:
+        """Test missing orderId returns None."""
+        response = {"status": "confirmed"}
+        assert _parse_order_response(response, _make_cart()) is None
+
+    def test_defaults_from_cart(self) -> None:
+        """Test missing fields use cart defaults."""
+        response = {"orderId": "ORD-1"}
+        cart = _make_cart()
+        result = _parse_order_response(response, cart)
+
+        assert result is not None
+        assert result.total == cart.estimated_total
+        assert result.fulfillment_type == FulfillmentType.PICKUP
+
+    def test_item_count_includes_restock(self) -> None:
+        """Test item count includes restock items."""
+        restock = _make_cart_item(ingredient="milk", product_id="R1")
+        cart = _make_cart(restock_items=[restock])
+        response = {"orderId": "ORD-1"}
+        result = _parse_order_response(response, cart)
+
+        assert result is not None
+        assert result.item_count == 2
+
+
+# ------------------------------------------------------------------
+# Tests: _collect_restock_ingredients
+# ------------------------------------------------------------------
+
+
+class TestCollectRestockIngredients:
+    """Tests for _collect_restock_ingredients."""
+
+    def test_collects_ingredients(self) -> None:
+        """Test ingredient names are collected from restock items."""
+        restock = [
+            _make_cart_item(ingredient="milk"),
+            _make_cart_item(ingredient="eggs"),
+        ]
+        cart = _make_cart(items=[], restock_items=restock)
+        result = _collect_restock_ingredients(cart)
+
+        assert result == ["milk", "eggs"]
+
+    def test_empty_restock(self) -> None:
+        """Test empty restock returns empty list."""
+        cart = _make_cart(restock_items=[])
+        assert _collect_restock_ingredients(cart) == []
+
+
+# ------------------------------------------------------------------
+# Tests: OrderService.submit_order
+# ------------------------------------------------------------------
+
+
+class TestSubmitOrder:
+    """Tests for OrderService.submit_order."""
+
+    def _make_service(
+        self,
+        api_response: dict | None = None,
+        api_error: bool = False,
+    ) -> OrderService:
+        """Create an OrderService with mock dependencies.
+
+        Args:
+            api_response: Response from Safeway API.
+            api_error: Whether API should raise an exception.
+
+        Returns:
+            OrderService with mocked client and pantry.
+        """
+        mock_client = MagicMock()
+        if api_error:
+            mock_client.post.side_effect = Exception("API error")
+        else:
+            mock_client.post.return_value = api_response or {}
+
+        mock_pantry = MagicMock()
+        mock_pantry.mark_restocked.return_value = 0
+
+        return OrderService(mock_client, mock_pantry)
+
+    def test_successful_order(self) -> None:
+        """Test successful order submission."""
+        service = self._make_service(
+            api_response={
+                "orderId": "ORD-123",
+                "status": "confirmed",
+                "estimatedTime": "Today 4-6pm",
+                "total": 8.99,
+            }
+        )
+        result = service.submit_order(_make_cart())
+
+        assert result.success is True
+        assert result.confirmation is not None
+        assert result.confirmation.order_id == "ORD-123"
+
+    def test_empty_cart_rejected(self) -> None:
+        """Test empty cart is rejected without API call."""
+        service = self._make_service()
+        cart = _make_cart(items=[], restock_items=[])
+        result = service.submit_order(cart)
+
+        assert result.success is False
+        assert "empty" in result.error_message.lower()
+
+    def test_api_failure(self) -> None:
+        """Test API exception returns failure."""
+        service = self._make_service(api_error=True)
+        result = service.submit_order(_make_cart())
+
+        assert result.success is False
+        assert "failed" in result.error_message.lower()
+
+    def test_error_response(self) -> None:
+        """Test error response from API."""
+        service = self._make_service(
+            api_response={"status": "error", "error": "No slots"}
+        )
+        result = service.submit_order(_make_cart())
+
+        assert result.success is False
+        assert result.error_message == "No slots"
+
+    def test_restocks_inventory(self) -> None:
+        """Test restock items update inventory on success."""
+        service = self._make_service(
+            api_response={
+                "orderId": "ORD-123",
+                "status": "confirmed",
+                "total": 5.0,
+            }
+        )
+        service._pantry.mark_restocked.return_value = 2
+        restock = [
+            _make_cart_item(ingredient="milk"),
+            _make_cart_item(ingredient="eggs"),
+        ]
+        cart = _make_cart(restock_items=restock)
+        result = service.submit_order(cart)
+
+        assert result.success is True
+        assert result.items_restocked == 2
+        service._pantry.mark_restocked.assert_called_once_with(["milk", "eggs"])
+
+    def test_restock_failure_doesnt_fail_order(self) -> None:
+        """Test inventory update failure doesn't fail the order."""
+        service = self._make_service(
+            api_response={
+                "orderId": "ORD-123",
+                "status": "confirmed",
+                "total": 5.0,
+            }
+        )
+        service._pantry.mark_restocked.side_effect = Exception("DB error")
+        restock = [_make_cart_item(ingredient="milk")]
+        cart = _make_cart(restock_items=restock)
+        result = service.submit_order(cart)
+
+        assert result.success is True
+        assert result.items_restocked == 0
+
+    def test_no_restock_without_restock_items(self) -> None:
+        """Test pantry not called when no restock items."""
+        service = self._make_service(
+            api_response={
+                "orderId": "ORD-123",
+                "status": "confirmed",
+                "total": 8.99,
+            }
+        )
+        cart = _make_cart(restock_items=[])
+        result = service.submit_order(cart)
+
+        assert result.success is True
+        assert result.items_restocked == 0
+        service._pantry.mark_restocked.assert_not_called()
+
+    def test_unknown_error_response(self) -> None:
+        """Test unknown error when no error field in response."""
+        service = self._make_service(api_response={"status": "error"})
+        result = service.submit_order(_make_cart())
+
+        assert result.success is False
+        assert result.error_message == "Unknown order error"

--- a/tests/test_product_search.py
+++ b/tests/test_product_search.py
@@ -1,0 +1,702 @@
+"""Tests for grocery_butler.product_search module."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from grocery_butler.models import SafewayProduct
+from grocery_butler.product_search import (
+    CACHE_MAX_AGE_DAYS,
+    CachedMapping,
+    ProductSearchError,
+    ProductSearchService,
+    _parse_price,
+    _parse_search_results,
+    _parse_single_product,
+    _row_to_cached_mapping,
+    _safe_float,
+)
+from grocery_butler.safeway_client import SafewayClient
+
+# ------------------------------------------------------------------
+# Fixtures
+# ------------------------------------------------------------------
+
+
+def _make_nimbus_product(
+    upc: str = "00012345",
+    name: str = "Whole Milk 1 Gallon",
+    price: float = 4.99,
+    size: str = "1 gal",
+    in_stock: bool = True,
+) -> dict[str, Any]:
+    """Build a product dict matching Nimbus API format."""
+    return {
+        "upc": upc,
+        "name": name,
+        "price": price,
+        "size": size,
+        "inStock": in_stock,
+    }
+
+
+def _make_search_response(
+    products: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build a Nimbus search response."""
+    return {"productsInfo": products or []}
+
+
+class _MockTransport(httpx.BaseTransport):
+    """Mock transport that returns pre-configured responses."""
+
+    def __init__(self, responses: list[httpx.Response]) -> None:
+        """Initialize with a list of responses to return in order.
+
+        Args:
+            responses: Ordered list of responses.
+        """
+        self._responses = list(responses)
+        self._index = 0
+
+    def handle_request(self, request: httpx.Request) -> httpx.Response:
+        """Return the next pre-configured response.
+
+        Args:
+            request: The outgoing HTTP request.
+
+        Returns:
+            The next mock response.
+        """
+        if self._index >= len(self._responses):
+            return httpx.Response(500, json={"error": "no more mock responses"})
+        resp = self._responses[self._index]
+        self._index += 1
+        return resp
+
+
+def _make_authn_response(session_token: str = "test-session") -> httpx.Response:
+    """Build a mock Okta authn response."""
+    return httpx.Response(200, json={"sessionToken": session_token})
+
+
+def _make_authorize_redirect(
+    access_token: str = "test-access-token",
+) -> httpx.Response:
+    """Build a mock OAuth2 redirect with token in fragment."""
+    location = f"https://www.safeway.com#access_token={access_token}&expires_in=3600"
+    return httpx.Response(302, headers={"location": location})
+
+
+def _make_authenticated_client(
+    api_responses: list[httpx.Response],
+) -> tuple[SafewayClient, _MockTransport]:
+    """Create a SafewayClient pre-authenticated with mock transport.
+
+    Args:
+        api_responses: Responses for API calls after auth.
+
+    Returns:
+        Tuple of (client, transport).
+    """
+    all_responses = [
+        _make_authn_response(),
+        _make_authorize_redirect(),
+        *api_responses,
+    ]
+    transport = _MockTransport(all_responses)
+    http = httpx.Client(transport=transport)
+    client = SafewayClient("user", "pass", "1234", http_client=http)
+    return client, transport
+
+
+@pytest.fixture
+def db_path(tmp_path: Any) -> str:
+    """Provide a temporary database path.
+
+    Args:
+        tmp_path: Pytest tmp_path fixture.
+
+    Returns:
+        Path string for the test database.
+    """
+    return str(tmp_path / "test.db")
+
+
+# ------------------------------------------------------------------
+# Tests: _parse_search_results
+# ------------------------------------------------------------------
+
+
+class TestParseSearchResults:
+    """Tests for _parse_search_results."""
+
+    def test_empty_response(self) -> None:
+        """Test parsing empty search results."""
+        result = _parse_search_results({})
+        assert result == []
+
+    def test_empty_products_list(self) -> None:
+        """Test parsing response with empty productsInfo."""
+        result = _parse_search_results({"productsInfo": []})
+        assert result == []
+
+    def test_single_product(self) -> None:
+        """Test parsing a single product."""
+        data = _make_search_response([_make_nimbus_product()])
+        result = _parse_search_results(data)
+
+        assert len(result) == 1
+        assert result[0].product_id == "00012345"
+        assert result[0].name == "Whole Milk 1 Gallon"
+        assert result[0].price == 4.99
+        assert result[0].size == "1 gal"
+        assert result[0].in_stock is True
+
+    def test_multiple_products(self) -> None:
+        """Test parsing multiple products."""
+        data = _make_search_response(
+            [
+                _make_nimbus_product(upc="001", name="Milk A"),
+                _make_nimbus_product(upc="002", name="Milk B"),
+            ]
+        )
+        result = _parse_search_results(data)
+        assert len(result) == 2
+
+    def test_skips_products_without_id(self) -> None:
+        """Test that products without UPC or PID are skipped."""
+        data = _make_search_response(
+            [
+                {"name": "No ID Product", "price": 1.0, "size": "1"},
+            ]
+        )
+        result = _parse_search_results(data)
+        assert result == []
+
+    def test_skips_products_without_name(self) -> None:
+        """Test that products without a name are skipped."""
+        data = _make_search_response(
+            [
+                {"upc": "123", "price": 1.0, "size": "1"},
+            ]
+        )
+        result = _parse_search_results(data)
+        assert result == []
+
+
+# ------------------------------------------------------------------
+# Tests: _parse_single_product
+# ------------------------------------------------------------------
+
+
+class TestParseSingleProduct:
+    """Tests for _parse_single_product."""
+
+    def test_uses_pid_when_no_upc(self) -> None:
+        """Test fallback to PID when UPC is missing."""
+        item = {"pid": "PID123", "name": "Test", "price": 1.0, "size": "1"}
+        result = _parse_single_product(item)
+
+        assert result is not None
+        assert result.product_id == "PID123"
+
+    def test_out_of_stock(self) -> None:
+        """Test parsing an out-of-stock product."""
+        item = _make_nimbus_product(in_stock=False)
+        result = _parse_single_product(item)
+
+        assert result is not None
+        assert result.in_stock is False
+
+    def test_sale_price_preferred(self) -> None:
+        """Test that salePrice is preferred over regular price."""
+        item = {
+            "upc": "123",
+            "name": "On Sale",
+            "salePrice": 2.99,
+            "price": 4.99,
+            "size": "1",
+        }
+        result = _parse_single_product(item)
+
+        assert result is not None
+        assert result.price == 2.99
+
+    def test_unit_price_parsed(self) -> None:
+        """Test that unitPrice is parsed when present."""
+        item = {
+            "upc": "123",
+            "name": "Test",
+            "price": 4.99,
+            "unitPrice": 0.16,
+            "size": "32 oz",
+        }
+        result = _parse_single_product(item)
+
+        assert result is not None
+        assert result.unit_price == 0.16
+
+
+# ------------------------------------------------------------------
+# Tests: _parse_price
+# ------------------------------------------------------------------
+
+
+class TestParsePrice:
+    """Tests for _parse_price."""
+
+    def test_sale_price_first(self) -> None:
+        """Test salePrice is preferred."""
+        assert _parse_price({"salePrice": 2.0, "price": 3.0}) == 2.0
+
+    def test_regular_price_fallback(self) -> None:
+        """Test regular price when no sale price."""
+        assert _parse_price({"price": 3.0}) == 3.0
+
+    def test_base_price_fallback(self) -> None:
+        """Test basePrice as last resort."""
+        assert _parse_price({"basePrice": 5.0}) == 5.0
+
+    def test_no_price_returns_zero(self) -> None:
+        """Test default to 0.0 when no price found."""
+        assert _parse_price({}) == 0.0
+
+    def test_skips_zero_prices(self) -> None:
+        """Test that zero prices are skipped."""
+        assert _parse_price({"salePrice": 0, "price": 3.0}) == 3.0
+
+
+# ------------------------------------------------------------------
+# Tests: _safe_float
+# ------------------------------------------------------------------
+
+
+class TestSafeFloat:
+    """Tests for _safe_float."""
+
+    def test_none_returns_none(self) -> None:
+        """Test None input."""
+        assert _safe_float(None) is None
+
+    def test_valid_float(self) -> None:
+        """Test valid float conversion."""
+        assert _safe_float(3.14) == 3.14
+
+    def test_valid_int(self) -> None:
+        """Test int to float conversion."""
+        assert _safe_float(5) == 5.0
+
+    def test_valid_string(self) -> None:
+        """Test numeric string conversion."""
+        assert _safe_float("2.99") == 2.99
+
+    def test_invalid_string(self) -> None:
+        """Test non-numeric string returns None."""
+        assert _safe_float("not a number") is None
+
+
+# ------------------------------------------------------------------
+# Tests: ProductSearchService.search_products
+# ------------------------------------------------------------------
+
+
+class TestSearchProducts:
+    """Tests for ProductSearchService.search_products."""
+
+    @patch("grocery_butler.safeway_client.time.sleep")
+    def test_search_returns_products(self, mock_sleep: object, db_path: str) -> None:
+        """Test successful product search."""
+        response_data = _make_search_response(
+            [
+                _make_nimbus_product(upc="001", name="Milk A", price=3.99),
+            ]
+        )
+        client, _transport = _make_authenticated_client(
+            [
+                httpx.Response(200, json=response_data),
+            ]
+        )
+        service = ProductSearchService(client, db_path)
+
+        results = service.search_products("milk")
+
+        assert len(results) == 1
+        assert results[0].product_id == "001"
+        assert results[0].price == 3.99
+        client.close()
+
+    @patch("grocery_butler.safeway_client.time.sleep")
+    def test_search_empty_results(self, mock_sleep: object, db_path: str) -> None:
+        """Test search returning no products."""
+        client, _transport = _make_authenticated_client(
+            [
+                httpx.Response(200, json=_make_search_response([])),
+            ]
+        )
+        service = ProductSearchService(client, db_path)
+
+        results = service.search_products("nonexistent item")
+
+        assert results == []
+        client.close()
+
+    @patch("grocery_butler.safeway_client.time.sleep")
+    def test_search_api_error_raises(self, mock_sleep: object, db_path: str) -> None:
+        """Test that API errors are wrapped in ProductSearchError."""
+        client, _transport = _make_authenticated_client(
+            [
+                httpx.Response(500, json={"error": "server error"}),
+                # Retry after re-auth also fails
+                _make_authn_response(),
+                _make_authorize_redirect(),
+                httpx.Response(500, json={"error": "still broken"}),
+            ]
+        )
+        service = ProductSearchService(client, db_path)
+
+        with pytest.raises(ProductSearchError, match="Product search failed"):
+            service.search_products("milk")
+        client.close()
+
+
+# ------------------------------------------------------------------
+# Tests: Cache operations
+# ------------------------------------------------------------------
+
+
+class TestCacheOperations:
+    """Tests for product mapping cache CRUD."""
+
+    def _make_service(self, db_path: str) -> ProductSearchService:
+        """Create a service with a dummy client for cache-only tests.
+
+        Args:
+            db_path: Database path.
+
+        Returns:
+            ProductSearchService instance.
+        """
+        transport = _MockTransport([])
+        http = httpx.Client(transport=transport)
+        client = SafewayClient("user", "pass", "1234", http_client=http)
+        return ProductSearchService(client, db_path)
+
+    def _sample_product(self) -> SafewayProduct:
+        """Create a sample SafewayProduct for testing.
+
+        Returns:
+            A SafewayProduct instance.
+        """
+        return SafewayProduct(
+            product_id="UPC001",
+            name="Organic Whole Milk",
+            price=5.99,
+            size="1 gal",
+        )
+
+    def test_save_and_retrieve_mapping(self, db_path: str) -> None:
+        """Test saving and retrieving a product mapping."""
+        service = self._make_service(db_path)
+        product = self._sample_product()
+
+        row_id = service.save_mapping("whole milk", product)
+        cached = service.get_cached_mapping("whole milk")
+
+        assert row_id > 0
+        assert cached is not None
+        assert cached.product.product_id == "UPC001"
+        assert cached.product.name == "Organic Whole Milk"
+        assert cached.product.price == 5.99
+        assert cached.is_pinned is False
+        assert cached.times_selected == 1
+
+    def test_save_existing_increments_count(self, db_path: str) -> None:
+        """Test that saving same mapping again increments times_selected."""
+        service = self._make_service(db_path)
+        product = self._sample_product()
+
+        service.save_mapping("whole milk", product)
+        service.save_mapping("whole milk", product)
+        cached = service.get_cached_mapping("whole milk")
+
+        assert cached is not None
+        assert cached.times_selected == 2
+
+    def test_get_nonexistent_mapping(self, db_path: str) -> None:
+        """Test looking up a mapping that doesn't exist."""
+        service = self._make_service(db_path)
+        assert service.get_cached_mapping("not cached") is None
+
+    def test_pin_mapping(self, db_path: str) -> None:
+        """Test pinning a product mapping."""
+        service = self._make_service(db_path)
+        product = self._sample_product()
+
+        row_id = service.pin_mapping("whole milk", product)
+        cached = service.get_cached_mapping("whole milk")
+
+        assert row_id > 0
+        assert cached is not None
+        assert cached.is_pinned is True
+
+    def test_pin_replaces_existing_pin(self, db_path: str) -> None:
+        """Test that pinning unpins the previous mapping."""
+        service = self._make_service(db_path)
+        product_a = SafewayProduct(
+            product_id="A", name="Brand A Milk", price=4.99, size="1 gal"
+        )
+        product_b = SafewayProduct(
+            product_id="B", name="Brand B Milk", price=5.49, size="1 gal"
+        )
+
+        service.pin_mapping("milk", product_a)
+        service.pin_mapping("milk", product_b)
+        cached = service.get_cached_mapping("milk")
+
+        assert cached is not None
+        assert cached.product.product_id == "B"
+        assert cached.is_pinned is True
+
+    def test_unpin_mapping(self, db_path: str) -> None:
+        """Test unpinning a mapping."""
+        service = self._make_service(db_path)
+        product = self._sample_product()
+
+        service.pin_mapping("milk", product)
+        result = service.unpin_mapping("milk")
+        cached = service.get_cached_mapping("milk")
+
+        assert result is True
+        assert cached is not None
+        assert cached.is_pinned is False
+
+    def test_unpin_nonexistent_returns_false(self, db_path: str) -> None:
+        """Test unpinning when no pinned mapping exists."""
+        service = self._make_service(db_path)
+        assert service.unpin_mapping("nothing") is False
+
+    def test_delete_mapping(self, db_path: str) -> None:
+        """Test deleting a mapping."""
+        service = self._make_service(db_path)
+        product = self._sample_product()
+
+        service.save_mapping("milk", product)
+        count = service.delete_mapping("milk")
+
+        assert count == 1
+        assert service.get_cached_mapping("milk") is None
+
+    def test_delete_nonexistent_returns_zero(self, db_path: str) -> None:
+        """Test deleting a mapping that doesn't exist."""
+        service = self._make_service(db_path)
+        assert service.delete_mapping("nothing") == 0
+
+    def test_touch_mapping_updates_count(self, db_path: str) -> None:
+        """Test _touch_mapping increments times_selected."""
+        service = self._make_service(db_path)
+        product = self._sample_product()
+
+        row_id = service.save_mapping("milk", product)
+        service._touch_mapping(row_id)
+        cached = service.get_cached_mapping("milk")
+
+        assert cached is not None
+        assert cached.times_selected == 2
+
+
+# ------------------------------------------------------------------
+# Tests: search_or_cached
+# ------------------------------------------------------------------
+
+
+class TestSearchOrCached:
+    """Tests for ProductSearchService.search_or_cached."""
+
+    @patch("grocery_butler.safeway_client.time.sleep")
+    def test_returns_pinned_without_search(
+        self, mock_sleep: object, db_path: str
+    ) -> None:
+        """Test that pinned mappings bypass API search."""
+        transport = _MockTransport([])
+        http = httpx.Client(transport=transport)
+        client = SafewayClient("user", "pass", "1234", http_client=http)
+        service = ProductSearchService(client, db_path)
+
+        product = SafewayProduct(
+            product_id="PIN1", name="Pinned Milk", price=4.99, size="1 gal"
+        )
+        service.pin_mapping("milk", product)
+
+        results = service.search_or_cached("milk")
+
+        assert len(results) == 1
+        assert results[0].product_id == "PIN1"
+
+    @patch("grocery_butler.safeway_client.time.sleep")
+    def test_returns_fresh_cache(self, mock_sleep: object, db_path: str) -> None:
+        """Test that fresh cached mappings are returned without searching."""
+        transport = _MockTransport([])
+        http = httpx.Client(transport=transport)
+        client = SafewayClient("user", "pass", "1234", http_client=http)
+        service = ProductSearchService(client, db_path)
+
+        product = SafewayProduct(
+            product_id="CACHE1", name="Cached Milk", price=4.99, size="1 gal"
+        )
+        service.save_mapping("milk", product)
+
+        results = service.search_or_cached("milk")
+
+        assert len(results) == 1
+        assert results[0].product_id == "CACHE1"
+
+    @patch("grocery_butler.safeway_client.time.sleep")
+    def test_searches_when_no_cache(self, mock_sleep: object, db_path: str) -> None:
+        """Test that search is performed when no cache exists."""
+        response_data = _make_search_response(
+            [
+                _make_nimbus_product(upc="NEW1", name="Fresh Milk", price=3.99),
+            ]
+        )
+        client, _transport = _make_authenticated_client(
+            [
+                httpx.Response(200, json=response_data),
+            ]
+        )
+        service = ProductSearchService(client, db_path)
+
+        results = service.search_or_cached("milk")
+
+        assert len(results) == 1
+        assert results[0].product_id == "NEW1"
+        # Should also be cached now
+        cached = service.get_cached_mapping("milk")
+        assert cached is not None
+        assert cached.product.product_id == "NEW1"
+        client.close()
+
+    @patch("grocery_butler.safeway_client.time.sleep")
+    def test_searches_when_cache_stale(self, mock_sleep: object, db_path: str) -> None:
+        """Test that stale cache triggers a fresh search."""
+        response_data = _make_search_response(
+            [
+                _make_nimbus_product(upc="FRESH1", name="Fresh Milk"),
+            ]
+        )
+        client, _transport = _make_authenticated_client(
+            [
+                httpx.Response(200, json=response_data),
+            ]
+        )
+        service = ProductSearchService(client, db_path)
+
+        # Save a mapping, then make it stale
+        product = SafewayProduct(
+            product_id="OLD1", name="Old Milk", price=3.99, size="1 gal"
+        )
+        service.save_mapping("milk", product)
+
+        stale_date = datetime.now(tz=UTC) - timedelta(days=CACHE_MAX_AGE_DAYS + 1)
+        conn = service._connect()
+        try:
+            conn.execute(
+                "UPDATE product_mapping SET last_used = ?",
+                (stale_date.isoformat(),),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        results = service.search_or_cached("milk")
+
+        assert len(results) == 1
+        assert results[0].product_id == "FRESH1"
+        client.close()
+
+
+# ------------------------------------------------------------------
+# Tests: _is_stale
+# ------------------------------------------------------------------
+
+
+class TestIsStale:
+    """Tests for ProductSearchService._is_stale."""
+
+    def test_fresh_mapping_not_stale(self) -> None:
+        """Test that a recently-used mapping is not stale."""
+        cached = CachedMapping(
+            mapping_id=1,
+            ingredient_description="milk",
+            product=SafewayProduct(
+                product_id="1", name="Milk", price=3.99, size="1 gal"
+            ),
+            is_pinned=False,
+            times_selected=1,
+            last_used=datetime.now(tz=UTC),
+        )
+        assert ProductSearchService._is_stale(cached) is False
+
+    def test_old_mapping_is_stale(self) -> None:
+        """Test that an old mapping is considered stale."""
+        old_date = datetime.now(tz=UTC) - timedelta(days=CACHE_MAX_AGE_DAYS + 1)
+        cached = CachedMapping(
+            mapping_id=1,
+            ingredient_description="milk",
+            product=SafewayProduct(
+                product_id="1", name="Milk", price=3.99, size="1 gal"
+            ),
+            is_pinned=False,
+            times_selected=1,
+            last_used=old_date,
+        )
+        assert ProductSearchService._is_stale(cached) is True
+
+
+# ------------------------------------------------------------------
+# Tests: _row_to_cached_mapping
+# ------------------------------------------------------------------
+
+
+class TestRowToCachedMapping:
+    """Tests for _row_to_cached_mapping."""
+
+    def test_converts_row(self, db_path: str) -> None:
+        """Test converting a database row to CachedMapping."""
+        from grocery_butler.db import get_connection, init_db
+
+        init_db(db_path)
+        conn = get_connection(db_path)
+        try:
+            conn.execute(
+                "INSERT INTO product_mapping"
+                " (ingredient_description, safeway_product_id,"
+                "  safeway_product_name, safeway_price, is_pinned)"
+                " VALUES (?, ?, ?, ?, ?)",
+                ("milk", "UPC1", "Test Milk", 3.99, True),
+            )
+            conn.commit()
+            row = conn.execute(
+                "SELECT id, ingredient_description, safeway_product_id,"
+                " safeway_product_name, safeway_price, last_used,"
+                " times_selected, is_pinned"
+                " FROM product_mapping LIMIT 1"
+            ).fetchone()
+            assert row is not None
+
+            result = _row_to_cached_mapping(row)
+
+            assert result.mapping_id == 1
+            assert result.ingredient_description == "milk"
+            assert result.product.product_id == "UPC1"
+            assert result.product.name == "Test Milk"
+            assert result.product.price == 3.99
+            assert result.is_pinned is True
+            assert result.times_selected == 1
+        finally:
+            conn.close()

--- a/tests/test_product_selector.py
+++ b/tests/test_product_selector.py
@@ -1,0 +1,543 @@
+"""Tests for grocery_butler.product_selector module."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from grocery_butler.models import (
+    BrandMatchType,
+    BrandPreference,
+    BrandPreferenceType,
+    IngredientCategory,
+    SafewayProduct,
+    ShoppingListItem,
+)
+from grocery_butler.product_selector import (
+    ProductSelector,
+    _extract_json_text,
+    _filter_avoided_brands,
+    _format_brand_preferences,
+    _get_preferred_brands,
+    _heuristic_select,
+    _parse_selection_response,
+    _product_to_dict,
+)
+
+# ------------------------------------------------------------------
+# Fixtures
+# ------------------------------------------------------------------
+
+
+def _make_item(
+    ingredient: str = "whole milk",
+    quantity: float = 1.0,
+    unit: str = "gal",
+    category: IngredientCategory = IngredientCategory.DAIRY,
+    search_term: str = "whole milk gallon",
+) -> ShoppingListItem:
+    """Create a test ShoppingListItem.
+
+    Args:
+        ingredient: Ingredient name.
+        quantity: Amount needed.
+        unit: Unit of measurement.
+        category: Grocery category.
+        search_term: Safeway search term.
+
+    Returns:
+        A ShoppingListItem for testing.
+    """
+    return ShoppingListItem(
+        ingredient=ingredient,
+        quantity=quantity,
+        unit=unit,
+        category=category,
+        search_term=search_term,
+        from_meals=["Test Meal"],
+    )
+
+
+def _make_product(
+    product_id: str = "UPC001",
+    name: str = "Organic Whole Milk",
+    price: float = 5.99,
+    size: str = "1 gal",
+    in_stock: bool = True,
+) -> SafewayProduct:
+    """Create a test SafewayProduct.
+
+    Args:
+        product_id: Product identifier.
+        name: Product name.
+        price: Product price.
+        size: Product size.
+        in_stock: Availability.
+
+    Returns:
+        A SafewayProduct for testing.
+    """
+    return SafewayProduct(
+        product_id=product_id,
+        name=name,
+        price=price,
+        size=size,
+        in_stock=in_stock,
+    )
+
+
+def _make_pref(
+    brand: str = "Organic Valley",
+    pref_type: BrandPreferenceType = BrandPreferenceType.PREFERRED,
+    match_target: str = "milk",
+    match_type: BrandMatchType = BrandMatchType.INGREDIENT,
+) -> BrandPreference:
+    """Create a test BrandPreference.
+
+    Args:
+        brand: Brand name.
+        pref_type: Preferred or avoid.
+        match_target: Ingredient or category name.
+        match_type: Whether this targets an ingredient or category.
+
+    Returns:
+        A BrandPreference for testing.
+    """
+    return BrandPreference(
+        match_target=match_target,
+        match_type=match_type,
+        brand=brand,
+        preference_type=pref_type,
+    )
+
+
+# ------------------------------------------------------------------
+# Tests: _filter_avoided_brands
+# ------------------------------------------------------------------
+
+
+class TestFilterAvoidedBrands:
+    """Tests for _filter_avoided_brands."""
+
+    def test_no_prefs_returns_all(self) -> None:
+        """Test all products returned when no preferences."""
+        products = [_make_product(name="Brand A"), _make_product(name="Brand B")]
+        result = _filter_avoided_brands(products, [])
+        assert len(result) == 2
+
+    def test_filters_avoided_brand(self) -> None:
+        """Test that avoided brand products are removed."""
+        products = [
+            _make_product(product_id="1", name="Great Value Milk"),
+            _make_product(product_id="2", name="Organic Valley Milk"),
+        ]
+        prefs = [_make_pref("Great Value", BrandPreferenceType.AVOID)]
+        result = _filter_avoided_brands(products, prefs)
+
+        assert len(result) == 1
+        assert result[0].product_id == "2"
+
+    def test_case_insensitive_matching(self) -> None:
+        """Test that brand matching is case-insensitive."""
+        products = [_make_product(name="GREAT VALUE Milk")]
+        prefs = [_make_pref("great value", BrandPreferenceType.AVOID)]
+        result = _filter_avoided_brands(products, prefs)
+        assert result == []
+
+    def test_preferred_brands_not_filtered(self) -> None:
+        """Test that preferred brands are NOT filtered out."""
+        products = [_make_product(name="Organic Valley Milk")]
+        prefs = [_make_pref("Organic Valley", BrandPreferenceType.PREFERRED)]
+        result = _filter_avoided_brands(products, prefs)
+        assert len(result) == 1
+
+
+# ------------------------------------------------------------------
+# Tests: _get_preferred_brands
+# ------------------------------------------------------------------
+
+
+class TestGetPreferredBrands:
+    """Tests for _get_preferred_brands."""
+
+    def test_empty_prefs(self) -> None:
+        """Test empty preferences returns empty set."""
+        assert _get_preferred_brands([]) == set()
+
+    def test_extracts_preferred_only(self) -> None:
+        """Test only preferred brands are extracted."""
+        prefs = [
+            _make_pref("Organic Valley", BrandPreferenceType.PREFERRED),
+            _make_pref("Great Value", BrandPreferenceType.AVOID),
+        ]
+        result = _get_preferred_brands(prefs)
+        assert result == {"organic valley"}
+
+    def test_lowercased(self) -> None:
+        """Test that brand names are lowercased."""
+        prefs = [_make_pref("Organic Valley", BrandPreferenceType.PREFERRED)]
+        result = _get_preferred_brands(prefs)
+        assert "organic valley" in result
+
+
+# ------------------------------------------------------------------
+# Tests: _heuristic_select
+# ------------------------------------------------------------------
+
+
+class TestHeuristicSelect:
+    """Tests for _heuristic_select."""
+
+    def test_cheapest_when_no_prefs(self) -> None:
+        """Test cheapest product selected without preferences."""
+        products = [
+            _make_product(product_id="1", price=5.99),
+            _make_product(product_id="2", price=3.49),
+        ]
+        result = _heuristic_select(products, set())
+        assert result.product_id == "2"
+
+    def test_prefers_in_stock(self) -> None:
+        """Test in-stock products preferred over out-of-stock."""
+        products = [
+            _make_product(product_id="1", price=2.99, in_stock=False),
+            _make_product(product_id="2", price=5.99, in_stock=True),
+        ]
+        result = _heuristic_select(products, set())
+        assert result.product_id == "2"
+
+    def test_prefers_preferred_brand(self) -> None:
+        """Test preferred brand chosen over cheaper generic."""
+        products = [
+            _make_product(product_id="1", name="Generic Milk", price=2.99),
+            _make_product(product_id="2", name="Organic Valley Milk", price=5.99),
+        ]
+        result = _heuristic_select(products, {"organic valley"})
+        assert result.product_id == "2"
+
+    def test_cheapest_preferred_brand(self) -> None:
+        """Test cheapest among preferred brands is selected."""
+        products = [
+            _make_product(product_id="1", name="Organic Valley 1gal", price=6.99),
+            _make_product(product_id="2", name="Organic Valley 0.5gal", price=4.49),
+        ]
+        result = _heuristic_select(products, {"organic valley"})
+        assert result.product_id == "2"
+
+    def test_falls_back_to_out_of_stock(self) -> None:
+        """Test fallback to out-of-stock when all are unavailable."""
+        products = [
+            _make_product(product_id="1", price=5.99, in_stock=False),
+            _make_product(product_id="2", price=3.49, in_stock=False),
+        ]
+        result = _heuristic_select(products, set())
+        assert result.product_id == "2"
+
+
+# ------------------------------------------------------------------
+# Tests: _product_to_dict
+# ------------------------------------------------------------------
+
+
+class TestProductToDict:
+    """Tests for _product_to_dict."""
+
+    def test_converts_product(self) -> None:
+        """Test product is converted to dict with all fields."""
+        product = SafewayProduct(
+            product_id="UPC001",
+            name="Organic Whole Milk",
+            price=5.99,
+            unit_price=0.05,
+            size="1 gal",
+            in_stock=True,
+        )
+        result = _product_to_dict(product)
+
+        assert result["product_id"] == "UPC001"
+        assert result["name"] == "Organic Whole Milk"
+        assert result["price"] == 5.99
+        assert result["unit_price"] == 0.05
+        assert result["size"] == "1 gal"
+        assert result["in_stock"] is True
+
+
+# ------------------------------------------------------------------
+# Tests: _format_brand_preferences
+# ------------------------------------------------------------------
+
+
+class TestFormatBrandPreferences:
+    """Tests for _format_brand_preferences."""
+
+    def test_no_prefs(self) -> None:
+        """Test empty preferences message."""
+        assert _format_brand_preferences([]) == "No brand preferences set."
+
+    def test_formats_prefs(self) -> None:
+        """Test preferences are formatted correctly."""
+        prefs = [
+            _make_pref("Organic Valley", BrandPreferenceType.PREFERRED),
+            _make_pref("Great Value", BrandPreferenceType.AVOID),
+        ]
+        result = _format_brand_preferences(prefs)
+        assert "PREFER: Organic Valley" in result
+        assert "AVOID: Great Value" in result
+
+
+# ------------------------------------------------------------------
+# Tests: _parse_selection_response
+# ------------------------------------------------------------------
+
+
+class TestParseSelectionResponse:
+    """Tests for _parse_selection_response."""
+
+    def _candidates(self) -> list[SafewayProduct]:
+        """Create a list of test candidates.
+
+        Returns:
+            List of SafewayProduct instances.
+        """
+        return [
+            _make_product(product_id="A", name="Product A"),
+            _make_product(product_id="B", name="Product B"),
+        ]
+
+    def test_valid_selection(self) -> None:
+        """Test parsing a valid selection response."""
+        text = json.dumps({"selected_index": 0, "reasoning": "Best match"})
+        candidates = self._candidates()
+        result = _parse_selection_response(text, candidates)
+
+        assert result is not None
+        assert result[0] is not None
+        assert result[0].product_id == "A"
+        assert result[1] == "Best match"
+
+    def test_no_match_returns_none_product(self) -> None:
+        """Test selected_index -1 returns None product."""
+        text = json.dumps({"selected_index": -1, "reasoning": "Nothing fits"})
+        result = _parse_selection_response(text, self._candidates())
+
+        assert result is not None
+        assert result[0] is None
+        assert result[1] == "Nothing fits"
+
+    def test_invalid_json(self) -> None:
+        """Test invalid JSON returns None."""
+        assert _parse_selection_response("not json", self._candidates()) is None
+
+    def test_invalid_index_type(self) -> None:
+        """Test non-integer index returns None."""
+        text = json.dumps({"selected_index": "zero", "reasoning": "bad"})
+        assert _parse_selection_response(text, self._candidates()) is None
+
+    def test_out_of_range_index(self) -> None:
+        """Test out-of-range index returns None."""
+        text = json.dumps({"selected_index": 99, "reasoning": "bad"})
+        assert _parse_selection_response(text, self._candidates()) is None
+
+    def test_strips_markdown_fences(self) -> None:
+        """Test markdown fences are stripped."""
+        inner = json.dumps({"selected_index": 1, "reasoning": "Good"})
+        text = f"```json\n{inner}\n```"
+        result = _parse_selection_response(text, self._candidates())
+
+        assert result is not None
+        assert result[0] is not None
+        assert result[0].product_id == "B"
+
+
+# ------------------------------------------------------------------
+# Tests: _extract_json_text
+# ------------------------------------------------------------------
+
+
+class TestExtractJsonText:
+    """Tests for _extract_json_text."""
+
+    def test_plain_json(self) -> None:
+        """Test plain JSON passes through."""
+        assert _extract_json_text('{"a": 1}') == '{"a": 1}'
+
+    def test_strips_fences(self) -> None:
+        """Test markdown fences are removed."""
+        result = _extract_json_text('```json\n{"a": 1}\n```')
+        assert result == '{"a": 1}'
+
+    def test_strips_whitespace(self) -> None:
+        """Test leading/trailing whitespace is stripped."""
+        assert _extract_json_text("  {}\n  ") == "{}"
+
+
+# ------------------------------------------------------------------
+# Tests: ProductSelector.select_product
+# ------------------------------------------------------------------
+
+
+class TestSelectProduct:
+    """Tests for ProductSelector.select_product."""
+
+    def _make_selector(
+        self,
+        brand_prefs: list[BrandPreference] | None = None,
+        price_sensitivity: str | None = None,
+    ) -> ProductSelector:
+        """Create a ProductSelector with mocked dependencies.
+
+        Args:
+            brand_prefs: Brand preferences to return.
+            price_sensitivity: Price sensitivity preference value.
+
+        Returns:
+            ProductSelector with mock dependencies.
+        """
+        mock_client = MagicMock()
+        mock_store = MagicMock()
+        mock_store.get_brands_for_ingredient.return_value = brand_prefs or []
+        mock_store.get_preference.return_value = price_sensitivity
+        return ProductSelector(mock_client, mock_store)
+
+    def test_no_candidates_returns_none(self) -> None:
+        """Test empty candidates returns no product."""
+        selector = self._make_selector()
+        result = selector.select_product(_make_item(), [])
+
+        assert result.product is None
+        assert "No products available" in result.reasoning
+
+    def test_all_avoided_returns_none(self) -> None:
+        """Test all-avoided brands returns no product."""
+        selector = self._make_selector(
+            brand_prefs=[_make_pref("Organic", BrandPreferenceType.AVOID)]
+        )
+        candidates = [_make_product(name="Organic Milk")]
+        result = selector.select_product(_make_item(), candidates)
+
+        assert result.product is None
+        assert "avoided brands" in result.reasoning
+
+    @patch.object(ProductSelector, "_call_claude")
+    def test_claude_selection(self, mock_claude: MagicMock) -> None:
+        """Test Claude selects a product successfully."""
+        mock_claude.return_value = json.dumps(
+            {"selected_index": 0, "reasoning": "Best match for whole milk"}
+        )
+        selector = self._make_selector()
+        candidates = [_make_product(product_id="A")]
+
+        result = selector.select_product(_make_item(), candidates)
+
+        assert result.product is not None
+        assert result.product.product_id == "A"
+        assert "Best match" in result.reasoning
+
+    @patch.object(ProductSelector, "_call_claude")
+    def test_claude_returns_no_match(self, mock_claude: MagicMock) -> None:
+        """Test Claude returns no match (index -1)."""
+        mock_claude.return_value = json.dumps(
+            {"selected_index": -1, "reasoning": "Nothing suitable"}
+        )
+        selector = self._make_selector()
+        candidates = [_make_product()]
+
+        result = selector.select_product(_make_item(), candidates)
+
+        assert result.product is None
+        assert "Nothing suitable" in result.reasoning
+
+    @patch.object(ProductSelector, "_call_claude")
+    def test_fallback_on_claude_failure(self, mock_claude: MagicMock) -> None:
+        """Test fallback heuristic when Claude fails."""
+        mock_claude.return_value = None
+        selector = self._make_selector()
+        candidates = [
+            _make_product(product_id="1", price=5.99),
+            _make_product(product_id="2", price=3.49),
+        ]
+
+        result = selector.select_product(_make_item(), candidates)
+
+        assert result.product is not None
+        assert result.product.product_id == "2"
+        assert "fallback" in result.reasoning
+
+    @patch.object(ProductSelector, "_call_claude")
+    def test_fallback_on_bad_json(self, mock_claude: MagicMock) -> None:
+        """Test fallback when Claude returns unparseable response."""
+        mock_claude.return_value = "I think product A is best"
+        selector = self._make_selector()
+        candidates = [_make_product()]
+
+        result = selector.select_product(_make_item(), candidates)
+
+        assert result.product is not None
+        assert "fallback" in result.reasoning
+
+
+# ------------------------------------------------------------------
+# Tests: ProductSelector.select_products
+# ------------------------------------------------------------------
+
+
+class TestSelectProducts:
+    """Tests for ProductSelector.select_products."""
+
+    @patch.object(ProductSelector, "_call_claude")
+    def test_selects_multiple(self, mock_claude: MagicMock) -> None:
+        """Test batch selection for multiple items."""
+        mock_claude.return_value = json.dumps(
+            {"selected_index": 0, "reasoning": "Top choice"}
+        )
+        mock_client = MagicMock()
+        mock_store = MagicMock()
+        mock_store.get_brands_for_ingredient.return_value = []
+        mock_store.get_preference.return_value = None
+        selector = ProductSelector(mock_client, mock_store)
+
+        items_and_candidates = [
+            (_make_item(ingredient="milk"), [_make_product(product_id="M1")]),
+            (_make_item(ingredient="eggs"), [_make_product(product_id="E1")]),
+        ]
+        results = selector.select_products(items_and_candidates)
+
+        assert len(results) == 2
+        assert results[0].product is not None
+        assert results[1].product is not None
+
+
+# ------------------------------------------------------------------
+# Tests: ProductSelector._get_price_sensitivity
+# ------------------------------------------------------------------
+
+
+class TestGetPriceSensitivity:
+    """Tests for price sensitivity retrieval."""
+
+    def test_default_moderate(self) -> None:
+        """Test default price sensitivity is moderate."""
+        mock_client = MagicMock()
+        mock_store = MagicMock()
+        mock_store.get_preference.return_value = None
+        selector = ProductSelector(mock_client, mock_store)
+
+        assert selector._get_price_sensitivity() == "moderate"
+
+    def test_returns_stored_value(self) -> None:
+        """Test stored price sensitivity is returned."""
+        mock_client = MagicMock()
+        mock_store = MagicMock()
+        mock_store.get_preference.return_value = "budget"
+        selector = ProductSelector(mock_client, mock_store)
+
+        assert selector._get_price_sensitivity() == "budget"
+
+    def test_invalid_value_defaults_moderate(self) -> None:
+        """Test invalid stored value defaults to moderate."""
+        mock_client = MagicMock()
+        mock_store = MagicMock()
+        mock_store.get_preference.return_value = "invalid"
+        selector = ProductSelector(mock_client, mock_store)
+
+        assert selector._get_price_sensitivity() == "moderate"

--- a/tests/test_prompt_loader.py
+++ b/tests/test_prompt_loader.py
@@ -55,20 +55,37 @@ class TestLoadPrompt:
         assert "milk" in result
         assert "eggs" in result
 
-    def test_load_placeholder_product_selection(self) -> None:
-        """Test loading placeholder template without variables."""
-        result = load_prompt("product_selection")
-        assert "Phase 3" in result
+    def test_load_product_selection(self) -> None:
+        """Test loading product_selection template with variables."""
+        result = load_prompt(
+            "product_selection",
+            ingredient="whole milk",
+            quantity="1.0",
+            unit="gal",
+            search_term="whole milk gallon",
+            category="dairy",
+            products_json="[]",
+            brand_preferences="No preferences",
+            price_sensitivity="moderate",
+        )
+        assert "whole milk" in result
+        assert "moderate" in result
 
     def test_load_placeholder_substitution_ranking(self) -> None:
         """Test loading placeholder substitution_ranking template."""
         result = load_prompt("substitution_ranking")
         assert "Phase 3" in result
 
-    def test_load_placeholder_brand_selection(self) -> None:
-        """Test loading placeholder brand_selection template."""
-        result = load_prompt("brand_selection")
-        assert "Phase 3" in result
+    def test_load_brand_selection(self) -> None:
+        """Test loading brand_selection template with variables."""
+        result = load_prompt(
+            "brand_selection",
+            products_json="[]",
+            avoided_brands="Great Value",
+            preferred_brands="Organic Valley",
+        )
+        assert "Great Value" in result
+        assert "Organic Valley" in result
 
     def test_missing_variable_raises_key_error(self) -> None:
         """Test that missing template variable raises KeyError."""

--- a/tests/test_prompt_loader.py
+++ b/tests/test_prompt_loader.py
@@ -71,10 +71,19 @@ class TestLoadPrompt:
         assert "whole milk" in result
         assert "moderate" in result
 
-    def test_load_placeholder_substitution_ranking(self) -> None:
-        """Test loading placeholder substitution_ranking template."""
-        result = load_prompt("substitution_ranking")
-        assert "Phase 3" in result
+    def test_load_substitution_ranking(self) -> None:
+        """Test loading substitution_ranking template with variables."""
+        result = load_prompt(
+            "substitution_ranking",
+            ingredient="chicken thighs",
+            quantity="2",
+            unit="lb",
+            search_term="boneless chicken thighs",
+            alternatives_json="[]",
+            brand_preferences="None",
+        )
+        assert "chicken thighs" in result
+        assert "suitability" in result.lower()
 
     def test_load_brand_selection(self) -> None:
         """Test loading brand_selection template with variables."""

--- a/tests/test_safeway_pipeline.py
+++ b/tests/test_safeway_pipeline.py
@@ -1,0 +1,417 @@
+"""Tests for grocery_butler.safeway_pipeline module."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from grocery_butler.config import Config
+from grocery_butler.models import (
+    CartItem,
+    CartSummary,
+    FulfillmentType,
+    IngredientCategory,
+    SafewayProduct,
+    ShoppingListItem,
+)
+from grocery_butler.order_service import OrderConfirmation, OrderResult
+from grocery_butler.safeway_pipeline import SafewayPipeline, SafewayPipelineError
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def safeway_config() -> Config:
+    """Return a Config with Safeway credentials set."""
+    return Config(
+        anthropic_api_key="sk-test",
+        safeway_username="user@example.com",
+        safeway_password="secret",
+        safeway_store_id="1234",
+        database_path=":memory:",
+    )
+
+
+@pytest.fixture()
+def incomplete_config() -> Config:
+    """Return a Config missing Safeway credentials."""
+    return Config(
+        anthropic_api_key="sk-test",
+        safeway_username="",
+        safeway_password="",
+        safeway_store_id="",
+    )
+
+
+@pytest.fixture()
+def sample_items() -> list[ShoppingListItem]:
+    """Return sample shopping list items."""
+    return [
+        ShoppingListItem(
+            ingredient="milk",
+            quantity=1.0,
+            unit="gal",
+            category=IngredientCategory.DAIRY,
+            search_term="milk",
+            from_meals=["manual"],
+        ),
+        ShoppingListItem(
+            ingredient="eggs",
+            quantity=1.0,
+            unit="dozen",
+            category=IngredientCategory.DAIRY,
+            search_term="eggs",
+            from_meals=["manual"],
+        ),
+    ]
+
+
+@pytest.fixture()
+def mock_cart_summary() -> CartSummary:
+    """Return a mock CartSummary for testing."""
+    product = SafewayProduct(
+        product_id="P001",
+        name="Whole Milk 1 gal",
+        price=4.99,
+        size="1 gal",
+    )
+    cart_item = CartItem(
+        shopping_list_item=ShoppingListItem(
+            ingredient="milk",
+            quantity=1.0,
+            unit="gal",
+            category=IngredientCategory.DAIRY,
+            search_term="milk",
+            from_meals=["manual"],
+        ),
+        safeway_product=product,
+        quantity_to_order=1,
+        estimated_cost=4.99,
+    )
+    return CartSummary(
+        items=[cart_item],
+        failed_items=[],
+        substituted_items=[],
+        skipped_items=[],
+        restock_items=[],
+        subtotal=4.99,
+        fulfillment_options=[],
+        recommended_fulfillment=FulfillmentType.PICKUP,
+        estimated_total=4.99,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Constructor tests
+# ---------------------------------------------------------------------------
+
+
+class TestSafewayPipelineInit:
+    """Tests for SafewayPipeline constructor."""
+
+    @patch("grocery_butler.safeway_pipeline.RecipeStore")
+    @patch("grocery_butler.safeway_pipeline.ProductSearchService")
+    @patch("grocery_butler.safeway_pipeline.ProductSelector")
+    @patch("grocery_butler.safeway_pipeline.SubstitutionService")
+    @patch("grocery_butler.safeway_pipeline.SafewayClient")
+    @patch("grocery_butler.safeway_pipeline.PantryManager")
+    def test_bootstrap_services(
+        self,
+        mock_pantry: MagicMock,
+        mock_client: MagicMock,
+        mock_sub: MagicMock,
+        mock_selector: MagicMock,
+        mock_search: MagicMock,
+        mock_store: MagicMock,
+        safeway_config: Config,
+    ):
+        """Test that all services are bootstrapped from config."""
+        pipeline = SafewayPipeline(safeway_config, ":memory:")
+
+        mock_client.assert_called_once_with(
+            username="user@example.com",
+            password="secret",
+            store_id="1234",
+        )
+        mock_store.assert_called_once_with(":memory:")
+        mock_search.assert_called_once()
+        mock_selector.assert_called_once()
+        mock_sub.assert_called_once()
+        mock_pantry.assert_called_once()
+        assert pipeline is not None
+
+    def test_missing_credentials_raises(self, incomplete_config: Config):
+        """Test that missing Safeway creds raises error."""
+        with pytest.raises(SafewayPipelineError, match="credentials"):
+            SafewayPipeline(incomplete_config, ":memory:")
+
+    def test_missing_store_id_raises(self):
+        """Test that missing store ID raises error."""
+        cfg = Config(
+            anthropic_api_key="sk-test",
+            safeway_username="user@example.com",
+            safeway_password="secret",
+            safeway_store_id="",
+        )
+        with pytest.raises(SafewayPipelineError, match="store ID"):
+            SafewayPipeline(cfg, ":memory:")
+
+
+# ---------------------------------------------------------------------------
+# Pipeline execution tests
+# ---------------------------------------------------------------------------
+
+
+class TestSafewayPipelineRun:
+    """Tests for SafewayPipeline.run method."""
+
+    @patch("grocery_butler.safeway_pipeline.RecipeStore")
+    @patch("grocery_butler.safeway_pipeline.ProductSearchService")
+    @patch("grocery_butler.safeway_pipeline.ProductSelector")
+    @patch("grocery_butler.safeway_pipeline.SubstitutionService")
+    @patch("grocery_butler.safeway_pipeline.SafewayClient")
+    @patch("grocery_butler.safeway_pipeline.PantryManager")
+    @patch("grocery_butler.safeway_pipeline.CartBuilder")
+    @patch("grocery_butler.safeway_pipeline.OrderService")
+    def test_run_success(
+        self,
+        mock_order_cls: MagicMock,
+        mock_cart_cls: MagicMock,
+        mock_pantry: MagicMock,
+        mock_client_cls: MagicMock,
+        mock_sub: MagicMock,
+        mock_selector: MagicMock,
+        mock_search: MagicMock,
+        mock_store: MagicMock,
+        safeway_config: Config,
+        sample_items: list[ShoppingListItem],
+        mock_cart_summary: CartSummary,
+    ):
+        """Test successful full pipeline run."""
+        mock_client = mock_client_cls.return_value
+        mock_client.is_authenticated = False
+
+        mock_cart_builder = mock_cart_cls.return_value
+        mock_cart_builder.build_cart.return_value = mock_cart_summary
+
+        expected_result = OrderResult(
+            success=True,
+            confirmation=OrderConfirmation(
+                order_id="ORD-001",
+                status="confirmed",
+                estimated_time="2h",
+                total=4.99,
+                fulfillment_type=FulfillmentType.PICKUP,
+                item_count=1,
+            ),
+            items_restocked=0,
+        )
+        mock_order_cls.return_value.submit_order.return_value = expected_result
+
+        pipeline = SafewayPipeline(safeway_config, ":memory:")
+        result = pipeline.run(sample_items)
+
+        mock_client.authenticate.assert_called_once()
+        mock_cart_builder.build_cart.assert_called_once_with(sample_items, None)
+        assert result.success is True
+        assert result.confirmation is not None
+        assert result.confirmation.order_id == "ORD-001"
+
+    @patch("grocery_butler.safeway_pipeline.RecipeStore")
+    @patch("grocery_butler.safeway_pipeline.ProductSearchService")
+    @patch("grocery_butler.safeway_pipeline.ProductSelector")
+    @patch("grocery_butler.safeway_pipeline.SubstitutionService")
+    @patch("grocery_butler.safeway_pipeline.SafewayClient")
+    @patch("grocery_butler.safeway_pipeline.PantryManager")
+    def test_auth_failure_raises(
+        self,
+        mock_pantry: MagicMock,
+        mock_client_cls: MagicMock,
+        mock_sub: MagicMock,
+        mock_selector: MagicMock,
+        mock_search: MagicMock,
+        mock_store: MagicMock,
+        safeway_config: Config,
+        sample_items: list[ShoppingListItem],
+    ):
+        """Test that auth failure raises SafewayPipelineError."""
+        mock_client = mock_client_cls.return_value
+        mock_client.is_authenticated = False
+        mock_client.authenticate.side_effect = RuntimeError("auth failed")
+
+        pipeline = SafewayPipeline(safeway_config, ":memory:")
+
+        with pytest.raises(SafewayPipelineError, match="authentication failed"):
+            pipeline.run(sample_items)
+
+
+# ---------------------------------------------------------------------------
+# Build cart only tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCartOnly:
+    """Tests for SafewayPipeline.build_cart_only method."""
+
+    @patch("grocery_butler.safeway_pipeline.RecipeStore")
+    @patch("grocery_butler.safeway_pipeline.ProductSearchService")
+    @patch("grocery_butler.safeway_pipeline.ProductSelector")
+    @patch("grocery_butler.safeway_pipeline.SubstitutionService")
+    @patch("grocery_butler.safeway_pipeline.SafewayClient")
+    @patch("grocery_butler.safeway_pipeline.PantryManager")
+    @patch("grocery_butler.safeway_pipeline.CartBuilder")
+    def test_build_cart_only_returns_summary(
+        self,
+        mock_cart_cls: MagicMock,
+        mock_pantry: MagicMock,
+        mock_client_cls: MagicMock,
+        mock_sub: MagicMock,
+        mock_selector: MagicMock,
+        mock_search: MagicMock,
+        mock_store: MagicMock,
+        safeway_config: Config,
+        sample_items: list[ShoppingListItem],
+        mock_cart_summary: CartSummary,
+    ):
+        """Test that build_cart_only returns CartSummary."""
+        mock_client = mock_client_cls.return_value
+        mock_client.is_authenticated = True
+
+        mock_cart_cls.return_value.build_cart.return_value = mock_cart_summary
+
+        pipeline = SafewayPipeline(safeway_config, ":memory:")
+        cart = pipeline.build_cart_only(sample_items)
+
+        assert cart is mock_cart_summary
+        mock_client.authenticate.assert_not_called()
+
+    @patch("grocery_butler.safeway_pipeline.RecipeStore")
+    @patch("grocery_butler.safeway_pipeline.ProductSearchService")
+    @patch("grocery_butler.safeway_pipeline.ProductSelector")
+    @patch("grocery_butler.safeway_pipeline.SubstitutionService")
+    @patch("grocery_butler.safeway_pipeline.SafewayClient")
+    @patch("grocery_butler.safeway_pipeline.PantryManager")
+    @patch("grocery_butler.safeway_pipeline.CartBuilder")
+    def test_build_cart_with_restock(
+        self,
+        mock_cart_cls: MagicMock,
+        mock_pantry: MagicMock,
+        mock_client_cls: MagicMock,
+        mock_sub: MagicMock,
+        mock_selector: MagicMock,
+        mock_search: MagicMock,
+        mock_store: MagicMock,
+        safeway_config: Config,
+        sample_items: list[ShoppingListItem],
+        mock_cart_summary: CartSummary,
+    ):
+        """Test build_cart_only passes restock items."""
+        mock_client_cls.return_value.is_authenticated = True
+        mock_cart_cls.return_value.build_cart.return_value = mock_cart_summary
+
+        restock = [
+            ShoppingListItem(
+                ingredient="butter",
+                quantity=1.0,
+                unit="lb",
+                category=IngredientCategory.DAIRY,
+                search_term="butter",
+                from_meals=["restock"],
+            )
+        ]
+
+        pipeline = SafewayPipeline(safeway_config, ":memory:")
+        pipeline.build_cart_only(sample_items, restock_items=restock)
+
+        mock_cart_cls.return_value.build_cart.assert_called_once_with(
+            sample_items, restock
+        )
+
+
+# ---------------------------------------------------------------------------
+# Close tests
+# ---------------------------------------------------------------------------
+
+
+class TestSafewayPipelineClose:
+    """Tests for SafewayPipeline.close method."""
+
+    @patch("grocery_butler.safeway_pipeline.RecipeStore")
+    @patch("grocery_butler.safeway_pipeline.ProductSearchService")
+    @patch("grocery_butler.safeway_pipeline.ProductSelector")
+    @patch("grocery_butler.safeway_pipeline.SubstitutionService")
+    @patch("grocery_butler.safeway_pipeline.SafewayClient")
+    @patch("grocery_butler.safeway_pipeline.PantryManager")
+    def test_close_calls_client_close(
+        self,
+        mock_pantry: MagicMock,
+        mock_client_cls: MagicMock,
+        mock_sub: MagicMock,
+        mock_selector: MagicMock,
+        mock_search: MagicMock,
+        mock_store: MagicMock,
+        safeway_config: Config,
+    ):
+        """Test that close cleans up client resources."""
+        pipeline = SafewayPipeline(safeway_config, ":memory:")
+        pipeline.close()
+
+        mock_client_cls.return_value.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Empty shopping list tests
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyShoppingList:
+    """Tests for handling empty shopping lists."""
+
+    @patch("grocery_butler.safeway_pipeline.RecipeStore")
+    @patch("grocery_butler.safeway_pipeline.ProductSearchService")
+    @patch("grocery_butler.safeway_pipeline.ProductSelector")
+    @patch("grocery_butler.safeway_pipeline.SubstitutionService")
+    @patch("grocery_butler.safeway_pipeline.SafewayClient")
+    @patch("grocery_butler.safeway_pipeline.PantryManager")
+    @patch("grocery_butler.safeway_pipeline.CartBuilder")
+    @patch("grocery_butler.safeway_pipeline.OrderService")
+    def test_empty_list_still_calls_pipeline(
+        self,
+        mock_order_cls: MagicMock,
+        mock_cart_cls: MagicMock,
+        mock_pantry: MagicMock,
+        mock_client_cls: MagicMock,
+        mock_sub: MagicMock,
+        mock_selector: MagicMock,
+        mock_search: MagicMock,
+        mock_store: MagicMock,
+        safeway_config: Config,
+    ):
+        """Test that empty list flows through to order service."""
+        mock_client_cls.return_value.is_authenticated = True
+
+        empty_cart = CartSummary(
+            items=[],
+            failed_items=[],
+            substituted_items=[],
+            skipped_items=[],
+            restock_items=[],
+            subtotal=0.0,
+            fulfillment_options=[],
+            recommended_fulfillment=FulfillmentType.PICKUP,
+            estimated_total=0.0,
+        )
+        mock_cart_cls.return_value.build_cart.return_value = empty_cart
+        mock_order_cls.return_value.submit_order.return_value = OrderResult(
+            success=False,
+            error_message="Cart is empty — nothing to order",
+        )
+
+        pipeline = SafewayPipeline(safeway_config, ":memory:")
+        result = pipeline.run([])
+
+        assert result.success is False
+        assert "empty" in result.error_message.lower()

--- a/tests/test_substitution_service.py
+++ b/tests/test_substitution_service.py
@@ -1,0 +1,439 @@
+"""Tests for grocery_butler.substitution_service module."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from grocery_butler.models import (
+    BrandMatchType,
+    BrandPreference,
+    BrandPreferenceType,
+    IngredientCategory,
+    SafewayProduct,
+    ShoppingListItem,
+    SubstitutionSuitability,
+)
+from grocery_butler.substitution_service import (
+    SubstitutionService,
+    _extract_json_text,
+    _fallback_ranking,
+    _filter_avoided,
+    _format_brand_prefs,
+    _parse_ranking_response,
+    _parse_single_ranking,
+)
+
+# ------------------------------------------------------------------
+# Fixtures
+# ------------------------------------------------------------------
+
+
+def _make_item(
+    ingredient: str = "chicken thighs",
+    search_term: str = "boneless chicken thighs",
+) -> ShoppingListItem:
+    """Create a test ShoppingListItem.
+
+    Args:
+        ingredient: Ingredient name.
+        search_term: Search term.
+
+    Returns:
+        ShoppingListItem for testing.
+    """
+    return ShoppingListItem(
+        ingredient=ingredient,
+        quantity=2.0,
+        unit="lb",
+        category=IngredientCategory.MEAT,
+        search_term=search_term,
+        from_meals=["Test Meal"],
+    )
+
+
+def _make_product(
+    product_id: str = "P001",
+    name: str = "Boneless Chicken Thighs",
+    price: float = 8.99,
+    in_stock: bool = True,
+) -> SafewayProduct:
+    """Create a test SafewayProduct.
+
+    Args:
+        product_id: Product ID.
+        name: Product name.
+        price: Product price.
+        in_stock: Whether in stock.
+
+    Returns:
+        SafewayProduct for testing.
+    """
+    return SafewayProduct(
+        product_id=product_id,
+        name=name,
+        price=price,
+        size="2 lb",
+        in_stock=in_stock,
+    )
+
+
+def _make_pref(
+    brand: str = "Tyson",
+    pref_type: BrandPreferenceType = BrandPreferenceType.PREFERRED,
+) -> BrandPreference:
+    """Create a test BrandPreference.
+
+    Args:
+        brand: Brand name.
+        pref_type: Preference type.
+
+    Returns:
+        BrandPreference for testing.
+    """
+    return BrandPreference(
+        match_target="chicken",
+        match_type=BrandMatchType.INGREDIENT,
+        brand=brand,
+        preference_type=pref_type,
+    )
+
+
+# ------------------------------------------------------------------
+# Tests: _filter_avoided
+# ------------------------------------------------------------------
+
+
+class TestFilterAvoided:
+    """Tests for _filter_avoided."""
+
+    def test_no_prefs(self) -> None:
+        """Test all products returned with no preferences."""
+        products = [_make_product(name="A"), _make_product(name="B")]
+        assert len(_filter_avoided(products, [])) == 2
+
+    def test_removes_avoided(self) -> None:
+        """Test avoided brand products are filtered out."""
+        products = [
+            _make_product(product_id="1", name="Tyson Chicken"),
+            _make_product(product_id="2", name="Perdue Chicken"),
+        ]
+        prefs = [_make_pref("Tyson", BrandPreferenceType.AVOID)]
+        result = _filter_avoided(products, prefs)
+
+        assert len(result) == 1
+        assert result[0].product_id == "2"
+
+
+# ------------------------------------------------------------------
+# Tests: _format_brand_prefs
+# ------------------------------------------------------------------
+
+
+class TestFormatBrandPrefs:
+    """Tests for _format_brand_prefs."""
+
+    def test_empty_prefs(self) -> None:
+        """Test empty preferences returns 'None'."""
+        assert _format_brand_prefs([]) == "None"
+
+    def test_formats_prefs(self) -> None:
+        """Test preferences are formatted correctly."""
+        prefs = [
+            _make_pref("Tyson", BrandPreferenceType.PREFERRED),
+            _make_pref("Generic", BrandPreferenceType.AVOID),
+        ]
+        result = _format_brand_prefs(prefs)
+        assert "prefer Tyson" in result
+        assert "avoid Generic" in result
+
+
+# ------------------------------------------------------------------
+# Tests: _parse_ranking_response
+# ------------------------------------------------------------------
+
+
+class TestParseRankingResponse:
+    """Tests for _parse_ranking_response."""
+
+    def _alts(self) -> list[SafewayProduct]:
+        """Create a list of alternatives.
+
+        Returns:
+            Two SafewayProduct instances.
+        """
+        return [
+            _make_product(product_id="A", name="Alt A"),
+            _make_product(product_id="B", name="Alt B"),
+        ]
+
+    def test_valid_response(self) -> None:
+        """Test parsing a valid ranking response."""
+        text = json.dumps(
+            [
+                {"index": 0, "suitability": "excellent", "reasoning": "Same cut"},
+                {"index": 1, "suitability": "good", "reasoning": "Similar"},
+            ]
+        )
+        result = _parse_ranking_response(text, self._alts())
+
+        assert result is not None
+        assert len(result) == 2
+        assert result[0].product.product_id == "A"
+        assert result[0].suitability == SubstitutionSuitability.EXCELLENT
+        assert result[1].suitability == SubstitutionSuitability.GOOD
+
+    def test_with_form_warning(self) -> None:
+        """Test form warning is captured."""
+        text = json.dumps(
+            [
+                {
+                    "index": 0,
+                    "suitability": "acceptable",
+                    "form_warning": "This is breast, not thighs",
+                    "reasoning": "Different cut",
+                },
+            ]
+        )
+        result = _parse_ranking_response(text, self._alts())
+
+        assert result is not None
+        assert result[0].form_warning == "This is breast, not thighs"
+
+    def test_invalid_json(self) -> None:
+        """Test invalid JSON returns None."""
+        assert _parse_ranking_response("not json", self._alts()) is None
+
+    def test_non_array_returns_none(self) -> None:
+        """Test non-array JSON returns None."""
+        assert _parse_ranking_response('{"a": 1}', self._alts()) is None
+
+    def test_empty_array_returns_none(self) -> None:
+        """Test empty array returns None."""
+        assert _parse_ranking_response("[]", self._alts()) is None
+
+    def test_strips_markdown_fences(self) -> None:
+        """Test markdown fences are stripped."""
+        inner = json.dumps(
+            [
+                {"index": 0, "suitability": "good", "reasoning": "OK"},
+            ]
+        )
+        text = f"```json\n{inner}\n```"
+        result = _parse_ranking_response(text, self._alts())
+
+        assert result is not None
+        assert len(result) == 1
+
+
+# ------------------------------------------------------------------
+# Tests: _parse_single_ranking
+# ------------------------------------------------------------------
+
+
+class TestParseSingleRanking:
+    """Tests for _parse_single_ranking."""
+
+    def _alts(self) -> list[SafewayProduct]:
+        """Create alternatives for testing.
+
+        Returns:
+            List of SafewayProduct.
+        """
+        return [_make_product(product_id="A"), _make_product(product_id="B")]
+
+    def test_valid_entry(self) -> None:
+        """Test parsing a valid entry."""
+        entry = {"index": 0, "suitability": "excellent", "reasoning": "Good"}
+        result = _parse_single_ranking(entry, self._alts())
+
+        assert result is not None
+        assert result.product.product_id == "A"
+        assert result.suitability == SubstitutionSuitability.EXCELLENT
+
+    def test_invalid_index(self) -> None:
+        """Test out-of-range index returns None."""
+        entry = {"index": 99, "suitability": "good", "reasoning": "Bad"}
+        assert _parse_single_ranking(entry, self._alts()) is None
+
+    def test_non_dict_returns_none(self) -> None:
+        """Test non-dict entry returns None."""
+        assert _parse_single_ranking("not a dict", self._alts()) is None  # type: ignore[arg-type]
+
+    def test_unknown_suitability_defaults(self) -> None:
+        """Test unknown suitability defaults to acceptable."""
+        entry = {"index": 0, "suitability": "unknown", "reasoning": "OK"}
+        result = _parse_single_ranking(entry, self._alts())
+
+        assert result is not None
+        assert result.suitability == SubstitutionSuitability.ACCEPTABLE
+
+
+# ------------------------------------------------------------------
+# Tests: _fallback_ranking
+# ------------------------------------------------------------------
+
+
+class TestFallbackRanking:
+    """Tests for _fallback_ranking."""
+
+    def test_sorts_by_price(self) -> None:
+        """Test fallback sorts alternatives by price."""
+        alts = [
+            _make_product(product_id="A", price=9.99),
+            _make_product(product_id="B", price=5.99),
+            _make_product(product_id="C", price=7.49),
+        ]
+        result = _fallback_ranking(alts)
+
+        assert len(result) == 3
+        assert result[0].product.product_id == "B"
+        assert result[1].product.product_id == "C"
+        assert result[2].product.product_id == "A"
+
+    def test_all_marked_acceptable(self) -> None:
+        """Test all fallback options are marked acceptable."""
+        alts = [_make_product()]
+        result = _fallback_ranking(alts)
+        assert result[0].suitability == SubstitutionSuitability.ACCEPTABLE
+
+
+# ------------------------------------------------------------------
+# Tests: _extract_json_text
+# ------------------------------------------------------------------
+
+
+class TestExtractJsonText:
+    """Tests for _extract_json_text."""
+
+    def test_plain_json(self) -> None:
+        """Test plain JSON passes through."""
+        assert _extract_json_text("[1, 2]") == "[1, 2]"
+
+    def test_strips_fences(self) -> None:
+        """Test markdown fences removed."""
+        assert _extract_json_text("```json\n[1]\n```") == "[1]"
+
+
+# ------------------------------------------------------------------
+# Tests: SubstitutionService.find_substitutions
+# ------------------------------------------------------------------
+
+
+class TestFindSubstitutions:
+    """Tests for SubstitutionService.find_substitutions."""
+
+    def _make_service(
+        self,
+        search_results: list[SafewayProduct] | None = None,
+        brand_prefs: list[BrandPreference] | None = None,
+    ) -> SubstitutionService:
+        """Create a SubstitutionService with mocks.
+
+        Args:
+            search_results: Products returned by search.
+            brand_prefs: Brand preferences to return.
+
+        Returns:
+            SubstitutionService with mock dependencies.
+        """
+        mock_client = MagicMock()
+        mock_search = MagicMock()
+        mock_search.search_products.return_value = search_results or []
+        mock_store = MagicMock()
+        mock_store.get_brands_for_ingredient.return_value = brand_prefs or []
+        return SubstitutionService(mock_client, mock_search, mock_store)
+
+    def test_no_alternatives(self) -> None:
+        """Test no alternatives returns no_alternatives status."""
+        service = self._make_service(search_results=[])
+        original = _make_product(in_stock=False)
+        result = service.find_substitutions(_make_item(), original)
+
+        assert result.status == "no_alternatives"
+        assert result.alternatives == []
+
+    def test_filters_original_product(self) -> None:
+        """Test original product is excluded from alternatives."""
+        original = _make_product(product_id="ORIG", in_stock=False)
+        service = self._make_service(
+            search_results=[
+                _make_product(product_id="ORIG", in_stock=True),
+                _make_product(product_id="ALT1", name="Alternative", in_stock=True),
+            ]
+        )
+
+        with patch.object(SubstitutionService, "_rank_with_claude") as mock_rank:
+            mock_rank.return_value = _fallback_ranking(
+                [_make_product(product_id="ALT1")]
+            )
+            result = service.find_substitutions(_make_item(), original)
+
+        assert result.status == "alternatives_found"
+
+    def test_all_avoided(self) -> None:
+        """Test all alternatives from avoided brands."""
+        service = self._make_service(
+            search_results=[
+                _make_product(product_id="A", name="BadBrand Chicken"),
+            ],
+            brand_prefs=[_make_pref("BadBrand", BrandPreferenceType.AVOID)],
+        )
+        original = _make_product(product_id="ORIG", in_stock=False)
+        result = service.find_substitutions(_make_item(), original)
+
+        assert result.status == "all_avoided"
+
+    @patch.object(SubstitutionService, "_call_claude")
+    def test_claude_ranking(self, mock_claude: MagicMock) -> None:
+        """Test Claude ranks alternatives successfully."""
+        mock_claude.return_value = json.dumps(
+            [
+                {"index": 0, "suitability": "excellent", "reasoning": "Same cut"},
+            ]
+        )
+        service = self._make_service(
+            search_results=[
+                _make_product(product_id="ALT1", name="Alt Chicken"),
+            ]
+        )
+        original = _make_product(product_id="ORIG", in_stock=False)
+        result = service.find_substitutions(_make_item(), original)
+
+        assert result.status == "alternatives_found"
+        assert len(result.alternatives) == 1
+        assert result.alternatives[0].suitability == SubstitutionSuitability.EXCELLENT
+
+    @patch.object(SubstitutionService, "_call_claude")
+    def test_fallback_on_claude_failure(self, mock_claude: MagicMock) -> None:
+        """Test fallback ranking when Claude fails."""
+        mock_claude.return_value = None
+        service = self._make_service(
+            search_results=[
+                _make_product(product_id="A", name="Alt A", price=9.99),
+                _make_product(product_id="B", name="Alt B", price=5.99),
+            ]
+        )
+        original = _make_product(product_id="ORIG", in_stock=False)
+        result = service.find_substitutions(_make_item(), original)
+
+        assert result.status == "alternatives_found"
+        assert len(result.alternatives) == 2
+        # Cheapest first
+        assert result.alternatives[0].product.product_id == "B"
+
+    def test_excludes_out_of_stock_alternatives(self) -> None:
+        """Test out-of-stock alternatives are excluded."""
+        service = self._make_service(
+            search_results=[
+                _make_product(product_id="A", in_stock=False),
+                _make_product(product_id="B", in_stock=True, name="Good"),
+            ]
+        )
+        original = _make_product(product_id="ORIG", in_stock=False)
+
+        with patch.object(SubstitutionService, "_rank_with_claude") as mock_rank:
+            mock_rank.return_value = _fallback_ranking([_make_product(product_id="B")])
+            result = service.find_substitutions(_make_item(), original)
+
+        assert result.status == "alternatives_found"

--- a/tests/test_substitution_service.py
+++ b/tests/test_substitution_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock, patch
 
+from grocery_butler.claude_utils import extract_json_text, filter_avoided_brands
 from grocery_butler.models import (
     BrandMatchType,
     BrandPreference,
@@ -16,9 +17,7 @@ from grocery_butler.models import (
 )
 from grocery_butler.substitution_service import (
     SubstitutionService,
-    _extract_json_text,
     _fallback_ranking,
-    _filter_avoided,
     _format_brand_prefs,
     _parse_ranking_response,
     _parse_single_ranking,
@@ -100,17 +99,17 @@ def _make_pref(
 
 
 # ------------------------------------------------------------------
-# Tests: _filter_avoided
+# Tests: filter_avoided_brands
 # ------------------------------------------------------------------
 
 
 class TestFilterAvoided:
-    """Tests for _filter_avoided."""
+    """Tests for filter_avoided_brands."""
 
     def test_no_prefs(self) -> None:
         """Test all products returned with no preferences."""
         products = [_make_product(name="A"), _make_product(name="B")]
-        assert len(_filter_avoided(products, [])) == 2
+        assert len(filter_avoided_brands(products, [])) == 2
 
     def test_removes_avoided(self) -> None:
         """Test avoided brand products are filtered out."""
@@ -119,7 +118,7 @@ class TestFilterAvoided:
             _make_product(product_id="2", name="Perdue Chicken"),
         ]
         prefs = [_make_pref("Tyson", BrandPreferenceType.AVOID)]
-        result = _filter_avoided(products, prefs)
+        result = filter_avoided_brands(products, prefs)
 
         assert len(result) == 1
         assert result[0].product_id == "2"
@@ -299,20 +298,20 @@ class TestFallbackRanking:
 
 
 # ------------------------------------------------------------------
-# Tests: _extract_json_text
+# Tests: extract_json_text
 # ------------------------------------------------------------------
 
 
 class TestExtractJsonText:
-    """Tests for _extract_json_text."""
+    """Tests for extract_json_text."""
 
     def test_plain_json(self) -> None:
         """Test plain JSON passes through."""
-        assert _extract_json_text("[1, 2]") == "[1, 2]"
+        assert extract_json_text("[1, 2]") == "[1, 2]"
 
     def test_strips_fences(self) -> None:
         """Test markdown fences removed."""
-        assert _extract_json_text("```json\n[1]\n```") == "[1]"
+        assert extract_json_text("```json\n[1]\n```") == "[1]"
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Merges the full Safeway pipeline chain (PRs #19–#24) into main and adds a top-level orchestrator
- Creates `SafewayPipeline` class that bootstraps all 6 services and exposes `run()` / `build_cart_only()` 
- Adds `grocery-butler order` CLI subcommand with `--dry-run`, `--items`, `--meals` flags
- Adds `/order` Discord command group (`review`, `submit`, `status`)
- Fixes flaky `test_no_config_uses_default_path` test

## Test plan
- [x] `./scripts/check-all.sh` passes locally (7/7 green)
- [x] 896 tests passing, 94.04% coverage
- [x] New `test_safeway_pipeline.py` covers init, run, build_cart_only, close, empty list, auth failure
- [x] CLI order tests cover dry-run, submit success/failure, missing config, arg parsing
- [x] Bot order tests cover command group registration, formatters, permissions

🤖 Generated with [Claude Code](https://claude.com/claude-code)