### PR TITLE
fix(security): suppress unfixable CVE-2026-3219 in pip

### DIFF
--- a/scripts/security.sh
+++ b/scripts/security.sh
@@ -77,7 +77,19 @@ fi
 
 # PYSEC-2022-42969: py<=1.11.0 ReDoS in py.path.svnwc – dev-only dep of
 # interrogate, not shipped to production. No upstream fix available.
-PIP_AUDIT_ARGS=(--ignore-vuln PYSEC-2022-42969)
+#
+# CVE-2026-3219: vulnerability in pip itself with no fixed version published
+# upstream as of 2026-04-26. Pip is a build/install tool and is not part of
+# the runtime application surface. The vendored copies of pip used by users
+# are out of our control. Alternatives considered:
+#   - Pinning pip: every released pip version is flagged; downgrading offers
+#     no security benefit and breaks setuptools/wheel compatibility.
+#   - Auditing only requirements files: would silently miss transitive deps.
+# Review on 2026-07-25; if a fixed pip is released, drop this suppression.
+PIP_AUDIT_ARGS=(
+    --ignore-vuln PYSEC-2022-42969
+    --ignore-vuln CVE-2026-3219
+)
 
 VENV_PYTHON="${VIRTUAL_ENV:-$PROJECT_ROOT/.venv}/bin/python"
 if [ -x "$VENV_PYTHON" ]; then


### PR DESCRIPTION
## Summary

- CI on main is red because `pip-audit` started flagging **CVE-2026-3219 in pip itself**, and upstream has not published a fixed pip release.
- PR #39 was the last green run; PR #40 (docs only) failed without code changes — confirming this is a vulnerability-database delta, not a code regression.
- Adds `--ignore-vuln CVE-2026-3219` to `scripts/security.sh` alongside the existing `PYSEC-2022-42969` suppression, with a full justification block and a `2026-07-25` review date.

## Why a suppression (per `max-quality-no-shortcuts`)

The skill permits bypasses only for legitimate exceptions with documented justification. This case qualifies:

- **Third-party tool we don't control** — the vulnerability is in pip itself.
- **No upstream fix available** — `pip-audit`'s "Fix Versions" column is empty for this CVE.
- **Bounded blast radius** — pip is a build/install tool, not part of the runtime application surface.
- **Alternatives considered**:
  - Pinning pip: every released pip version is flagged; downgrading offers no security benefit and breaks setuptools/wheel compatibility.
  - Auditing only `requirements*.txt`: would silently drop transitive-dep coverage.
- **Time-boxed** — the comment includes a review date so the suppression is reconsidered when a patched pip lands.

## Test plan

- [x] `./scripts/security.sh` -> "No known vulnerabilities found, 2 ignored"
- [x] `./scripts/check-all.sh` -> all 7 gates pass (lint, format, mypy, security, complexity, tests, coverage 92.95%)
- [x] `interrogate --fail-under=95 ...` -> 99.9%
- [ ] CI pipeline green on this PR


---
_Generated by [Claude Code](https://claude.ai/code/session_01AXgJ8iJCJCUrzvVpSzB9tz)_