### PR TITLE
Add skills and workflows from well-worn-tools

### DIFF
--- a/.claude/skills/address-feedback/SKILL.md
+++ b/.claude/skills/address-feedback/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: address-feedback
+description: >-
+  Iterate on Claude PR review feedback intelligently and merge when ready.
+  Use when the user asks to "address feedback", "respond to Claude's review",
+  "iterate on the PR", "fix review comments", or "merge if Claude said LGTM".
+  The Claude reviewer publishes a top-level PR comment via GitHub Action
+  ending in a `Verdict:` line (LGTM / CHANGES_REQUESTED / COMMENTS) — it is
+  NOT a formal GitHub approval. This skill locates the most recent such
+  comment via GitHub MCP, parses the verdict, triages blockers/problems/nits
+  into a TDD-driven local fix loop, replies and resolves threads, and merges
+  only when the latest verdict is `LGTM`, the comment was posted after the
+  current HEAD's push, and all required checks are green.
+  Do NOT use for giving a review (use comprehensive-pr-review), debugging CI
+  failures themselves (use ci-debugging), general TDD work outside review
+  context (use stay-green), bug RCA (use bug-squashing-methodology), or
+  issue/branch/PR creation (use git-workflow).
+metadata:
+  author: Geoff
+  version: 1.1.0
+---
+
+# Address Feedback
+
+Close the loop on a Claude PR review: find the latest verdict comment, iterate locally with TDD, push once, and merge only when the verdict is `LGTM` for the current HEAD and CI is green.
+
+## How the Claude Review Surfaces
+
+The Claude reviewer runs as a GitHub Action on each push. It posts its findings as a **top-level PR comment** authored by a bot account (e.g. `claude[bot]`, `github-actions[bot]`). The comment follows the `comprehensive-pr-review` format and ends with a line like:
+
+```
+## Verdict: LGTM
+```
+
+Possible verdicts: `LGTM`, `CHANGES_REQUESTED`, `COMMENTS`. There is **no formal GitHub approval** to read — `state == "APPROVED"` will not be set. Treat the comment body as the source of truth.
+
+## Prompt-Engineering Tactics (Brief)
+
+Before touching code, restate each review item as a 6-component micro-prompt so the fix is precise instead of sprawling:
+
+- **Role** — "Engineer addressing a single review comment."
+- **Goal** — the exact change requested (one sentence).
+- **Context** — `file:line`, the surrounding 5-10 lines, the reviewer's quote.
+- **Format** — minimal diff; no drive-by refactors.
+- **Examples** — if the reviewer suggested code, paste it verbatim.
+- **Constraints** — keep blast radius small; preserve public API; add a regression test.
+
+If a comment is ambiguous on any component, reply asking for clarification rather than guessing. See `prompt-engineering` for the full framework.
+
+## Instructions
+
+### Step 1: Locate the Latest Claude Verdict Comment
+
+Use the GitHub MCP tools — never `gh` CLI. The goal is to determine whether a Claude review comment exists for the current HEAD push, and what its verdict is.
+
+1. Get HEAD SHA and the push timestamp:
+   - `mcp__github__pull_request_read` with `method: "get"` → record `head.sha`.
+   - `mcp__github__get_commit` with `sha: head.sha` → record `commit.committer.date` (proxy for the latest push time).
+2. List **top-level PR comments** (not line-level review comments):
+   - `mcp__github__pull_request_read` with `method: "get_comments"` (paginate if the PR is long-running).
+3. Filter the comments:
+   - **Author** is a bot matching the Claude reviewer (`claude[bot]`, `github-actions[bot]`, or whichever account posts the review on this repo). When in doubt, also require the body to contain a `Verdict:` line.
+   - **`created_at >= head commit's committer.date`** — the currency check. Comments posted before the latest push describe an earlier state and are stale.
+4. Sort matching comments by `created_at` desc; the first is the **current** Claude review.
+5. Parse the verdict from that comment's body. Look for a line matching (case-insensitive):
+
+   ```
+   ^\s*(?:##\s+|\*\*)?Verdict[:\*\s]+(LGTM|CHANGES_REQUESTED|COMMENTS)
+   ```
+
+6. Classify and route:
+   - `LGTM` → skip to Step 6 (merge gate).
+   - `CHANGES_REQUESTED` → required fixes; continue to Step 2 with the **Security Concerns**, **Problems**, and any blocking items from the comment body.
+   - `COMMENTS` → optional improvements; user decides whether to address; if skipping, jump to Step 6.
+   - **No qualifying comment** (none after the latest push) → wait for the next review run; do not merge. Optionally post `@claude please review` via `mcp__github__add_issue_comment` if the action did not run.
+   - **Comment exists but no parseable Verdict line** → treat as malformed; ask the user before merging. Do not infer a verdict from prose.
+
+### Step 2: Triage the Comment Body into a Fix Plan
+
+The Claude review is a single comment with sections (Strengths / Security Concerns / Problems / Code Quality / Requests / Verdict). Extract each actionable item into a row:
+
+| id | section | file:line (if cited) | quote | requested change | test idea | severity |
+
+Also pull any **line-level** review threads via `mcp__github__pull_request_read` with `method: "get_review_comments"` and merge them into the same table — these come back with `isResolved` metadata so you can ignore already-resolved threads.
+
+Apply the prompt-engineering framing above. Drop or push back on items that are out of scope, factually wrong, or already addressed — reply with a short justification instead of changing code.
+
+### Step 3: Fix Locally with TDD — Never Push to Probe CI
+
+For each row, smallest unit first:
+
+1. **Red** — write a test that fails because of the bug the reviewer flagged.
+2. **Green** — make the minimal change; the test passes.
+3. **Refactor** — only within the same file, only if it stays green.
+
+Then run the full local gate before any push:
+
+```bash
+# Whatever the project uses; pick the equivalents:
+pre-commit run --all-files
+./scripts/test.sh --all      # or pytest / npm test / go test ./... / cargo test
+./scripts/typecheck.sh       # or mypy / tsc --noEmit / etc.
+```
+
+If a check fails, fix it locally and re-run. **Do not push to use CI as your test runner.** See `stay-green` for the gates and `ci-debugging` only if a local-green change later fails in CI.
+
+### Step 4: Reply, Resolve, Re-Request
+
+For each item, after the fix lands locally:
+
+1. **Line-level threads** — `mcp__github__add_reply_to_pull_request_comment` with a short reply (what changed, where: `src/x.py:42`, and the commit SHA once pushed), then `mcp__github__resolve_review_thread`.
+2. **Top-level Claude review comment** — there is no thread to resolve. Post a single summary reply via `mcp__github__add_issue_comment` listing each addressed item and the SHA(s) that fixed it.
+3. After pushing, request a fresh review by posting `@claude please re-review` via `mcp__github__add_issue_comment`. The GitHub Action runs again and writes a new verdict comment — that becomes the comment you parse on the next pass.
+
+### Step 5: Push Once and Await the Next Verdict
+
+Push the branch (single push, not one per fix). Then delegate the wait to `await-claude-review` — it pins the new HEAD, calls `mcp__github__subscribe_pr_activity`, and ends the turn so the session wakes on the bot's verdict comment via `<github-webhook-activity>`. **Do not poll** with `sleep` or repeated `get_comments` calls, and do not wait on CI passes — the webhook does not deliver them; only the comment event is the wake signal.
+
+When the helper wakes the session:
+
+- Verdict `LGTM` for the current HEAD → continue to Step 6.
+- Verdict `CHANGES_REQUESTED` → loop back to Step 2 with the new comment body.
+- Verdict `COMMENTS` → user decides; if skipping, Step 6.
+- CI failure event for the current HEAD → if the failing job is the reviewer action, the helper retriggers it and stays subscribed; if it's other CI, hand off to `ci-debugging` and keep the subscription open. Either way, do not advance to merge.
+
+### Step 6: Merge Gate — All Must Hold
+
+Merge only when **every** condition is true. If any fails, stop and explain which one.
+
+- Latest qualifying Claude review comment has `Verdict: LGTM`.
+- That comment's `created_at >= head commit's committer.date` (verdict is for the current HEAD, not a pre-push state).
+- All required check runs are `success`:
+  - `mcp__github__pull_request_read` with `method: "get_status"` (combined commit status), and
+  - `mcp__github__pull_request_read` with `method: "get_check_runs"` (per-job detail).
+- No unresolved line-level review threads (`mcp__github__pull_request_read` with `method: "get_review_comments"` — each thread has `isResolved`).
+- The PR is `mergeable` and not `draft` (from the `get` response).
+
+Then:
+
+```
+mcp__github__merge_pull_request
+  pull_number: <N>
+  merge_method: "squash"   # or whatever the repo standard is
+```
+
+Confirm the merge succeeded; do not delete the remote branch unless the user asks.
+
+## Examples
+
+### Example 1: Current `Verdict: LGTM`, Green CI — Merge
+
+1. `pull_request_read get` → `head.sha = abc123`. `get_commit abc123` → `committer.date = 2026-05-01T10:00:00Z`.
+2. `pull_request_read get_comments` → latest bot comment by `claude[bot]` at `2026-05-01T10:04:33Z`, body ends with `## Verdict: LGTM`.
+3. `10:04:33Z >= 10:00:00Z` → comment is current.
+4. `get_status` and `get_check_runs` → all `success`. `get_review_comments` → no unresolved threads. PR `mergeable: true`, `draft: false`.
+5. `merge_pull_request` with `squash`. Report merge URL.
+
+### Example 2: Verdict Comment Predates the Latest Push (Stale)
+
+1. `head.sha = abc123`, `committer.date = 11:30:00Z`.
+2. Latest Claude comment is `Verdict: LGTM` but `created_at = 09:15:00Z` — before the push that produced `abc123`.
+3. The verdict reflects an earlier HEAD. State that the LGTM is stale, post `@claude please re-review` via `add_issue_comment`, and **do not merge**.
+
+### Example 3: `Verdict: CHANGES_REQUESTED` with Two Blockers and a Nit
+
+1. Parse the comment body: two **Problems** (file:line cited) and one **Code Quality** nit. Build the triage table.
+2. Decide the nit is out of scope for this PR — reply on the top-level Claude comment justifying the deferral.
+3. For the two blockers: Red-Green-Refactor locally, then `pre-commit run --all-files` + full test suite + typecheck. All green.
+4. Single `git push`. Post a summary reply via `add_issue_comment` listing the addressed items and the SHA. Then post `@claude please re-review`.
+5. New Claude comment arrives with `Verdict: LGTM` after the new push timestamp → re-enter Step 6.
+
+## Troubleshooting
+
+### Error: Cannot tell which comment is "Claude's"
+
+Match by author login first (`claude[bot]`, `github-actions[bot]`); fall back to `user.type == "Bot"` plus a body that contains a `Verdict:` line. If still ambiguous, ask the user which bot to treat as authoritative — do not guess.
+
+### Error: Verdict line not found or malformed
+
+The reviewer is supposed to end with `## Verdict: LGTM | CHANGES_REQUESTED | COMMENTS`. If the regex does not match, do not infer the verdict from prose ("looks good to me" is not a verdict). Surface the malformed comment to the user, optionally re-request the review, and **do not merge**.
+
+### Error: Verdict comment exists but predates the HEAD push
+
+The LGTM was for an earlier commit. Any push, even a docs-only one, supersedes it. Re-request a review (`add_issue_comment` with `@claude please re-review`), wait for the new comment, and re-enter Step 6 only after a current `Verdict: LGTM` arrives.
+
+### Error: Reviewer's suggestion would break tests or public API
+
+Do not silently ignore. Reply on the relevant thread (or the top-level comment) with the conflict (failing test name, API consumer, or constraint), propose an alternative, and pause until the user or reviewer agrees. Never bypass with `--no-verify` or skip checks; see `max-quality-no-shortcuts`.
+
+### Error: Tempted to push to "see what CI says"
+
+Stop. Reproduce the check locally first (`pre-commit run --all-files`, full test suite, typecheck). Pushing speculatively burns minutes per round trip and trains a sloppy loop. Only push when local gates are green.
+
+### Error: Merge gate passes but `mergeable` is `false`
+
+Conflicts with the base branch. Rebase or merge `main` locally, resolve, re-run local gates, push. The new commit supersedes the LGTM verdict — request a fresh review before re-entering the merge gate.

--- a/.claude/skills/await-claude-review/SKILL.md
+++ b/.claude/skills/await-claude-review/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: await-claude-review
+description: >-
+  Subscribe to GitHub PR activity and wait — without polling — for the
+  Claude reviewer's verdict comment on the current HEAD. Use when a PR
+  has just been pushed and you need to know the verdict
+  (LGTM / CHANGES_REQUESTED / COMMENTS) before merging, addressing
+  feedback, or declaring work done. Wraps
+  `mcp__github__subscribe_pr_activity`, which delivers comments and CI
+  failures (NOT CI passes) as `<github-webhook-activity>` events. The
+  verdict comment itself is a comment event, so the bot's post wakes
+  the session directly — no need to proxy through CI status. After
+  subscribing, end the turn; events resume the session.
+  Called by `address-feedback`, `stay-green`, and
+  `comprehensive-pr-review`.
+  Do NOT use for waiting on arbitrary CI success (not deliverable by
+  the webhook), general PR babysitting unrelated to the verdict gate,
+  debugging CI failures themselves (use `ci-debugging`), or one-off
+  status polling (use `pull_request_read` directly).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# Await Claude Review
+
+Wait for the Claude reviewer's `Verdict:` comment on the current HEAD via PR webhook events. No polling, no `sleep`, no CI-pass proxy.
+
+## What the Subscription Actually Delivers
+
+`mcp__github__subscribe_pr_activity` says, verbatim:
+
+> Once subscribed comments and CI failures will be delivered into this conversation as `<github-webhook-activity>` messages.
+
+So the deliverable set is:
+
+| Event                                         | Delivered? | Notes                                                          |
+| --------------------------------------------- | ---------- | -------------------------------------------------------------- |
+| Top-level PR comment (incl. reviewer verdict) | Yes        | This is the wake signal you want.                              |
+| Line-level review comment / thread reply      | Yes        | Treated as a comment event.                                    |
+| CI **failure** (any required check failing)   | Yes        | Triage on receipt — may indicate the reviewer action failed.   |
+| CI **success / pass**                         | **No**     | Do not write logic that waits on this — it never arrives.      |
+| Successful workflow_run completion            | **No**     | Same as above.                                                 |
+| PR merge / close                              | Implicit   | You should `unsubscribe_pr_activity` on these from the caller. |
+
+**Implication.** Don't treat "CI green" as a proxy for "review posted." The verdict comment is itself a delivered event — wait for it directly.
+
+## Canonical Verdict Line
+
+The reviewer (see `comprehensive-pr-review`) ends its top-level comment with a line matching, case-insensitive:
+
+```
+^\s*(?:##\s+|\*\*)?Verdict[:\*\s]+(LGTM|CHANGES_REQUESTED|COMMENTS)
+```
+
+Examples that match:
+
+- `## Verdict: LGTM`
+- `**Verdict:** CHANGES_REQUESTED`
+- `Verdict: COMMENTS`
+
+If the regex does not match, treat the comment as malformed: do **not** infer a verdict from prose ("looks good to me" is not a verdict). Surface to the user.
+
+## Instructions
+
+### Step 1: Pin the HEAD You're Waiting For
+
+Before subscribing, record what "current" means so you can later distinguish a fresh verdict from a stale one.
+
+1. `mcp__github__pull_request_read` with `method: "get"` → record `head.sha`.
+2. `mcp__github__get_commit` with `sha: head.sha` → record `commit.committer.date` as `headPushedAt` (proxy for the latest push time).
+
+### Step 2: Subscribe and End the Turn
+
+```
+mcp__github__subscribe_pr_activity
+  owner: <owner>
+  repo:  <repo>
+  pullNumber: <N>
+```
+
+Then **stop**. Do not poll. Do not `sleep`. Do not call `pull_request_read get_comments` in a loop. Webhook events arrive as `<github-webhook-activity>` messages and resume the session on their own.
+
+### Step 3: On Wake — Classify the Event
+
+When a `<github-webhook-activity>` message arrives, decide what kind of event it is:
+
+- **Top-level PR comment from a reviewer bot** (`claude[bot]`, `github-actions[bot]`, or whichever account posts reviews on this repo) → go to Step 4.
+- **Line-level review comment** → not a verdict; if you're tracking thread resolutions for `address-feedback`, handle there. Otherwise stay subscribed and wait for the next event.
+- **CI failure event** → go to Step 5.
+- **Anything else** → stay subscribed; wait for the next event.
+
+### Step 4: Validate Currency and Parse Verdict
+
+Re-fetch the comments to read the full body (the webhook payload may be truncated):
+
+1. `mcp__github__pull_request_read` with `method: "get_comments"`.
+2. Filter to bot author + body containing the verdict regex.
+3. Sort by `created_at` desc; take the first.
+4. **Currency check**: require `created_at >= headPushedAt`. A verdict posted before the latest push describes an earlier state; ignore and keep waiting.
+5. Parse with the regex above. Return one of:
+   - `LGTM` → caller proceeds to merge gate.
+   - `CHANGES_REQUESTED` → caller enters fix loop.
+   - `COMMENTS` → caller decides (usually mergeable as-is).
+   - **Malformed** → surface to user; do not guess.
+
+### Step 5: On CI Failure for Current HEAD
+
+A CI failure event for `head.sha` may mean the reviewer action itself failed (timeout, rate limit, permissions) — in which case **the verdict comment will never arrive** and waiting is futile. Inspect the failed check:
+
+1. `mcp__github__pull_request_read` with `method: "get_check_runs"` for `head.sha`.
+2. If the failed run is the **review action** (look for the workflow that runs `@claude` review): post `@claude please review` via `mcp__github__add_issue_comment` to retrigger, then stay subscribed.
+3. If the failed run is **other CI** (lint, tests, build): surface the failure to the user and recommend handing off to `ci-debugging`. Stay subscribed — the reviewer action may still post.
+
+### Step 6: Cleanup
+
+The caller should call `mcp__github__unsubscribe_pr_activity` once the PR merges, closes, or the verdict gate is no longer needed. This helper does not unsubscribe on its own — leave the lifecycle to the caller.
+
+## Examples
+
+### Example 1: Push, Subscribe, Wake on LGTM
+
+1. Caller (`address-feedback` Step 5) finishes pushing fixes.
+2. Pin HEAD: `head.sha = abc123`, `headPushedAt = 2026-05-08T11:00:00Z`.
+3. `subscribe_pr_activity owner=acme repo=widgets pullNumber=42`. End turn.
+4. Wake: `<github-webhook-activity>` for a comment by `claude[bot]`.
+5. `get_comments` → latest matching at `2026-05-08T11:04:33Z`, body ends `## Verdict: LGTM`. `11:04:33Z >= 11:00:00Z` ✓.
+6. Return `LGTM` to caller. Caller proceeds to merge gate.
+
+### Example 2: Stale Verdict After Force-Push
+
+1. Pin HEAD: `head.sha = def456`, `headPushedAt = 2026-05-08T12:00:00Z`.
+2. Subscribe, end turn.
+3. Wake on a comment event. `get_comments` → latest verdict `LGTM` at `11:55:00Z` — that's *before* `headPushedAt`. The push superseded the verdict.
+4. Stay subscribed. Optionally post `@claude please re-review`. Return to waiting.
+
+### Example 3: Reviewer Action Failed in CI
+
+1. Subscribe after push, end turn.
+2. Wake: `<github-webhook-activity>` for a CI failure on `head.sha`.
+3. `get_check_runs` → the failing job is `claude-review` (timeout). No other failures.
+4. Post `@claude please review` to retrigger the action. Stay subscribed.
+5. Subsequent wake delivers the verdict comment normally.
+
+### Example 4: Other CI Failed; Verdict May Still Come
+
+1. Subscribe after push, end turn.
+2. Wake: CI failure on `head.sha`. `get_check_runs` → `pytest` failed; `claude-review` is still in progress.
+3. Surface the test failure to the user and recommend `ci-debugging` for that. Stay subscribed — the reviewer may still post a verdict (which the author will need to address regardless of test failures).
+
+## Troubleshooting
+
+### Error: Tempted to wait on "CI green" / `workflow_run.conclusion == success`
+
+Don't. The subscription does not deliver CI passes. Wait on the comment event directly — that *is* the delivered signal.
+
+### Error: Tempted to poll with `sleep` or `Bash run_in_background`
+
+Don't. The session is woken by `<github-webhook-activity>`. Polling burns time and conflicts with the harness's wake mechanism. Subscribe and end the turn.
+
+### Error: Webhook arrives but `get_comments` shows no matching verdict
+
+Possible causes, in order of likelihood:
+
+1. The event was a line-level review comment, not the top-level verdict. Stay subscribed.
+2. The reviewer posted a non-verdict comment (e.g., a status ping). Stay subscribed.
+3. The bot author login differs on this repo. Confirm the author and update the filter.
+
+### Error: Multiple bot accounts post comments
+
+Match by author login (`claude[bot]`, `github-actions[bot]`) AND require the body to contain the canonical Verdict regex. If still ambiguous, ask the user which account is authoritative — do not guess.
+
+### Error: PR merged or closed while waiting
+
+The caller should detect this and call `unsubscribe_pr_activity`. If you see no further events for a long time, ask the user before assuming the PR is still open.

--- a/.claude/skills/cve-remediation/SKILL.md
+++ b/.claude/skills/cve-remediation/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: cve-remediation
+description: >-
+  Remediate dependency vulnerability scanner failures by verifying live
+  package registry data and upgrading instead of suppressing. Use when an
+  SCA / CVE tool fails or files an alert: npm audit, pnpm audit, yarn audit,
+  pip-audit, safety, Snyk, Dependabot, Trivy, Grype, OSV-Scanner, audit-ci,
+  cargo audit, govulncheck, bundler-audit, Renovate, or any CI step
+  reporting a CVE / GHSA / OSV advisory. The first action is ALWAYS to look
+  up the latest published version on the live registry — training data is
+  months stale and almost never knows the current version. Suppression,
+  ignore, or allowlist entries are the absolute last resort, only after
+  upgrade and override paths are proven unavailable; surrounding GitHub
+  issues and justification docs do not by themselves count as remediation.
+  Do NOT use for vulnerabilities in your own application code (use security
+  skill), general linter or type checker bypasses (use max-quality-no-shortcuts
+  skill), or unrelated CI failures (use ci-debugging skill).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# CVE Remediation
+
+A dependency vulnerability scanner just failed. The fix is almost always a version bump — but you must look up the current version on the live registry, because your training data is months out of date and the version you remember is probably not the latest.
+
+## The Anti-Pattern to Resist
+
+When a CVE alert fires, the path of least resistance feels like:
+
+1. Add a suppression / ignore / allowlist entry.
+2. File a GitHub issue.
+3. Write a justification doc.
+4. Move on.
+
+**Do not start here.** This sequence is correct only as a final fallback after upgrade paths are demonstrably exhausted. Treating it as the default leaves real, fixable vulnerabilities in production behind a paper trail of issues that nobody revisits. Polished documentation around a suppression is not a fix.
+
+## Instructions
+
+### Step 1: Parse the Alert
+
+Extract from the scanner output:
+
+- Package name and ecosystem (npm, PyPI, crates.io, Go module, Maven, RubyGems, NuGet, Composer)
+- Currently installed version
+- Advisory ID (`CVE-YYYY-NNNNN`, `GHSA-xxxx-xxxx-xxxx`, `OSV-YYYY-NNNN`)
+- Severity (critical, high, moderate, low)
+- "Patched versions" range (e.g., `>= 1.4.2`)
+- Whether it is a direct or transitive dependency
+
+If any field is missing, look it up before acting. Do not remediate from a half-read alert.
+
+### Step 2: Look Up the LATEST Published Version (Critical)
+
+**You do not know the current version.** Your training data trails reality by months and most ecosystems publish daily. Whatever version you "know" is the latest is probably wrong. Always query the live registry first.
+
+| Ecosystem | Quick command |
+|-----------|---------------|
+| npm / pnpm / yarn | `npm view <pkg> version` |
+| PyPI              | `pip index versions <pkg>` |
+| crates.io         | `cargo search <pkg> --limit 1` |
+| Go modules        | `go list -m -versions <module>` |
+| Maven Central     | see `references/registry-lookups.md` |
+| RubyGems          | `gem search -re <pkg>` |
+| NuGet             | see `references/registry-lookups.md` |
+| Packagist         | `composer show <pkg> --available --no-interaction` |
+
+See `references/registry-lookups.md` for HTTP fallbacks when the package manager CLI is not available, and for listing the full version history.
+
+### Step 3: Verify the Latest Version Actually Fixes the CVE
+
+A newer version is not automatically a patched version. Confirm the fix:
+
+1. Compare the latest registry version against the advisory's "patched versions" range. If `latest >= fixed-in`, upgrading fixes it.
+2. Read the changelog / release notes for the version that introduced the fix.
+3. For GHSA: `gh api /advisories/<GHSA-id> --jq '.vulnerabilities[].patched_versions'`
+4. For OSV: `curl -s https://api.osv.dev/v1/vulns/<id> | jq '.affected[].ranges'`
+
+If the latest version is still vulnerable, the CVE is genuinely unpatched. Skip to Step 6.
+
+### Step 4: Apply the Upgrade
+
+**Direct dependency** — bump the version constraint, regenerate the lockfile, test:
+
+```bash
+npm install <pkg>@<fixed-version>
+uv add "<pkg>>=<fixed-version>"
+poetry add "<pkg>@^<fixed-version>"
+cargo update -p <pkg> --precise <fixed-version>
+go get <module>@<fixed-version> && go mod tidy
+bundle update <pkg> --conservative
+```
+
+**Transitive dependency** — find the direct dependency that pulls it in, and either bump that direct dependency to a version whose tree includes the patched transitive, or override the transitive directly:
+
+| Ecosystem | Override mechanism |
+|-----------|--------------------|
+| npm       | `"overrides"` in `package.json` |
+| Yarn      | `"resolutions"` in `package.json` |
+| pnpm      | `"pnpm.overrides"` in `package.json` |
+| pip       | constraints file via `pip install -c constraints.txt` |
+| Poetry / uv | direct entry in `[tool.poetry.dependencies]` / `[project.dependencies]` |
+| Cargo     | `[patch.crates-io]` in `Cargo.toml` |
+| Go        | `replace` directive in `go.mod` |
+| Bundler   | explicit entry in `Gemfile` |
+
+Confirm the override took effect:
+
+```bash
+npm ls <pkg>
+pip show <pkg>
+cargo tree -i <pkg>
+go mod why <module>
+```
+
+### Step 5: Verify the Fix
+
+1. Re-run the scanner that failed. It must pass.
+2. Run the project's test suite, type checker, and linter. Upgrades can introduce breakage.
+3. For major version bumps, read the upstream changelog and adapt callers as needed.
+
+If tests break, fix the breakage. Do not roll back the upgrade unless the breakage is genuinely insurmountable — and if it is, treat the upgrade as blocked and escalate, do not silently suppress.
+
+### Step 6: Last Resort — Suppression (Only If Truly Unfixable)
+
+You may add a suppression / ignore / allowlist entry only if ALL of these hold:
+
+- [ ] Step 2 confirmed: no patched version exists on the live registry yet.
+- [ ] Step 3 confirmed: the latest published version is still vulnerable.
+- [ ] Upstream maintainers have a tracking issue or PR you can link to (or, if not, you have opened one).
+- [ ] You have considered and rejected: forking, applying a `patch-package` / `cargo patch` / equivalent local patch, swapping libraries.
+- [ ] You have explicitly assessed exposure: severity × reachability × runtime context.
+
+If all five hold, suppress using `references/suppression-template.md`. The suppression must include:
+
+1. Advisory ID and link
+2. Why no upgrade exists, with link to upstream tracking
+3. Reachability and exposure assessment
+4. Concrete review date, no more than 30 days out
+5. Linked GitHub issue tracking re-evaluation
+
+A bare `# noqa`, `audit-ci.json` allowlist, or `.snyk` entry without these is incomplete. Reject your own work if any of the five is missing.
+
+### Step 7: Commit and Document
+
+- Upgrade commit: `fix(deps): bump <pkg> to <version> for <CVE-id>`
+- Suppression commit: include the GitHub issue number, and the issue must encode the review date as a label or due date so it is rediscoverable.
+
+## Examples
+
+### Example 1: Direct npm Dependency, Patched Version Available
+
+**Alert**: `lodash 4.17.20` has CVE-2021-23337 (high). Fixed in `>= 4.17.21`.
+
+```bash
+$ npm view lodash version
+4.17.21
+$ npm install lodash@4.17.21
+$ npm audit                # passes
+$ npm test                 # passes
+```
+
+Commit: `fix(deps): bump lodash to 4.17.21 for CVE-2021-23337`.
+
+### Example 2: Transitive Python Dependency
+
+**Alert**: `urllib3 1.26.5` (transitive via `requests`) has GHSA-v845-jxx5-vc9f. Fixed in `>= 1.26.18`.
+
+```bash
+$ pip index versions urllib3
+Available versions: 2.2.3, 2.2.2, ..., 1.26.20, 1.26.18
+$ pip show requests | grep Requires      # confirms requests pins urllib3<2
+$ uv add "urllib3>=1.26.18,<2"
+$ uv lock && uv sync
+$ pip-audit                              # passes
+```
+
+### Example 3: No Patch Available — Genuine Last Resort
+
+**Alert**: `obscure-lib 0.3.1` has CVE-2025-XXXXX. No fixed version listed.
+
+```bash
+$ npm view obscure-lib version
+0.3.1                                    # latest is still vulnerable
+$ gh api /advisories/GHSA-xxxx-yyyy-zzzz --jq '.vulnerabilities[].patched_versions'
+""                                       # no patch exists
+$ gh search issues --repo upstream/obscure-lib "CVE-2025-XXXXX"
+# Found: upstream/obscure-lib#42 — fix in progress
+```
+
+Open project issue, link to upstream issue #42, set review date 30 days out, suppress using the template in `references/suppression-template.md`.
+
+## Troubleshooting
+
+### Error: "I'm sure version X.Y.Z is the latest"
+
+You are not. Run the registry lookup command from Step 2. Training data lag is the single most common reason this skill exists.
+
+### Error: "The override didn't change the resolved version"
+
+Override syntax wrong, or lockfile not regenerated. After editing the override:
+
+- npm: delete `node_modules` and `package-lock.json`, then `npm install`
+- pnpm: `pnpm install --force`
+- Cargo: `cargo update`
+- Verify with `<package-manager> ls <pkg>` or `cargo tree -i <pkg>`.
+
+### Error: "Tests break after the upgrade"
+
+Not a reason to suppress. Read the changelog, fix the breakage. If a major version jump is too disruptive right now, pin to the highest minor / patch within your current major that contains the fix.
+
+### Error: "The vulnerable code path is unreachable from our app"
+
+Reachability is supporting evidence for prioritization, never a substitute for upgrading when a fix exists. Reachability arguments belong only in Step 6, when no fix exists at all.
+
+### Error: "Just adding the suppression and an issue is faster"
+
+Yes, and the suppression has no expiry the tooling enforces. Every "temporary" suppression added without an enforced review date is a permanent unfixed CVE wearing a costume.

--- a/.claude/skills/cve-remediation/references/registry-lookups.md
+++ b/.claude/skills/cve-remediation/references/registry-lookups.md
@@ -1,0 +1,147 @@
+# Live Registry Lookups
+
+Your training data is stale. Always query the registry. CLI commands are preferred when available; HTTP fallbacks let you confirm versions when the package manager is not installed in the current environment.
+
+## npm / pnpm / yarn (npm registry)
+
+```bash
+# Latest version
+npm view <pkg> version
+
+# All versions, newest last
+npm view <pkg> versions --json
+
+# Latest version of a specific dist-tag
+npm view <pkg> dist-tags
+
+# HTTP fallback (no Node toolchain required)
+curl -s "https://registry.npmjs.org/<pkg>/latest" | jq -r '.version'
+curl -s "https://registry.npmjs.org/<pkg>" | jq -r '.["dist-tags"].latest'
+```
+
+## PyPI (Python)
+
+```bash
+# Latest version (modern pip)
+pip index versions <pkg>
+
+# Show installed and latest in one go
+pip install <pkg>==                      # error message lists all versions
+
+# HTTP fallback
+curl -s "https://pypi.org/pypi/<pkg>/json" | jq -r '.info.version'
+curl -s "https://pypi.org/pypi/<pkg>/json" | jq -r '.releases | keys[]' | sort -V | tail
+```
+
+## crates.io (Rust)
+
+```bash
+cargo search <pkg> --limit 1
+
+# HTTP fallback
+curl -s "https://crates.io/api/v1/crates/<pkg>" | jq -r '.crate.max_stable_version'
+```
+
+## Go modules
+
+```bash
+go list -m -versions <module>            # space-separated, oldest first
+
+# HTTP fallback (proxy)
+curl -s "https://proxy.golang.org/<module>/@latest" | jq -r '.Version'
+curl -s "https://proxy.golang.org/<module>/@v/list"   # all versions
+```
+
+Lowercase module path components that contain capitals: `proxy.golang.org` requires `!` escaping (e.g. `gitHub.com` -> `git!hub.com`). Easier path: use `go list`.
+
+## Maven Central (Java / Kotlin / Scala)
+
+```bash
+# Latest version of group:artifact
+curl -s "https://search.maven.org/solrsearch/select?q=g:<group>+AND+a:<artifact>&rows=1&wt=json" \
+  | jq -r '.response.docs[0].latestVersion'
+
+# All versions
+curl -s "https://search.maven.org/solrsearch/select?q=g:<group>+AND+a:<artifact>&core=gav&rows=50&wt=json" \
+  | jq -r '.response.docs[].v'
+```
+
+## RubyGems
+
+```bash
+gem search -re <pkg>                     # remote, exact match
+
+# HTTP fallback
+curl -s "https://rubygems.org/api/v1/gems/<pkg>.json" | jq -r '.version'
+curl -s "https://rubygems.org/api/v1/versions/<pkg>.json" | jq -r '.[].number'
+```
+
+## NuGet (.NET)
+
+```bash
+# HTTP — flat container index, last entry is the latest
+curl -s "https://api.nuget.org/v3-flatcontainer/<pkg-lowercase>/index.json" \
+  | jq -r '.versions[-1]'
+```
+
+## Packagist (PHP / Composer)
+
+```bash
+composer show <pkg> --available --no-interaction
+
+# HTTP fallback
+curl -s "https://repo.packagist.org/p2/<vendor>/<pkg>.json" \
+  | jq -r '.packages."<vendor>/<pkg>"[0].version'
+```
+
+## Hex (Elixir / Erlang)
+
+```bash
+mix hex.info <pkg>
+
+# HTTP fallback
+curl -s "https://hex.pm/api/packages/<pkg>" | jq -r '.releases[0].version'
+```
+
+## Pub (Dart / Flutter)
+
+```bash
+curl -s "https://pub.dev/api/packages/<pkg>" | jq -r '.latest.version'
+```
+
+## Container images (Trivy / Grype findings)
+
+When the alert is on a base image rather than a language package:
+
+```bash
+# Docker Hub tags
+curl -s "https://hub.docker.com/v2/repositories/<org>/<image>/tags/?page_size=50&ordering=last_updated" \
+  | jq -r '.results[].name'
+
+# GitHub Container Registry
+gh api "/orgs/<org>/packages/container/<image>/versions" --jq '.[].metadata.container.tags[]'
+```
+
+## Advisory Databases
+
+Confirm the *patched-in* version, not just the latest:
+
+```bash
+# GitHub Security Advisories
+gh api /advisories/<GHSA-id> --jq '{summary, severity, vulnerabilities: .vulnerabilities[] | {package, vulnerable_version_range, patched_versions, ecosystem: .package.ecosystem}}'
+
+# OSV.dev (cross-ecosystem)
+curl -s https://api.osv.dev/v1/vulns/<id> | jq '{summary, affected: .affected[] | {package: .package, ranges: .ranges, fixed: [.ranges[].events[] | select(.fixed) | .fixed]}}'
+
+# NVD (CVE-only)
+curl -s "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=<CVE-id>" | jq '.vulnerabilities[0].cve.descriptions[0].value'
+```
+
+## Verifying You Got the Live Answer
+
+Two sanity checks before acting:
+
+1. The version returned is greater than the version installed locally. If they match, you may be looking at a cached metadata file — retry without cache (`npm view --no-cache`, `pip cache purge`).
+2. The publish date on the latest version is recent. `npm view <pkg> time.modified` and `pip show <pkg>` (after install) confirm freshness.
+
+If a registry call fails or returns stale-looking data, prefer to escalate over guessing. A wrong version number causes either an unnecessary suppression or a broken upgrade.

--- a/.claude/skills/cve-remediation/references/suppression-template.md
+++ b/.claude/skills/cve-remediation/references/suppression-template.md
@@ -1,0 +1,133 @@
+# Suppression Template (Last Resort)
+
+Use ONLY after Steps 2-5 of `SKILL.md` have been exhausted. A suppression that omits any of the five required fields is incomplete and must not be merged.
+
+## Required Fields
+
+Every suppression — wherever it lives (`audit-ci.json`, `.snyk`, `pip-audit --ignore-vuln`, `cargo-deny.toml`, `go.work` exclusions, GitHub Dependabot dismissals, inline tool comments) — must carry these five fields, either inline or in a linked tracking issue:
+
+1. **Advisory ID** — `CVE-YYYY-NNNNN`, `GHSA-xxxx-xxxx-xxxx`, or `OSV-YYYY-NNNN` plus a link to the canonical advisory page.
+2. **Why no upgrade exists** — one sentence stating that the latest registry version is still vulnerable, plus a link to the upstream tracking issue or PR.
+3. **Reachability and exposure assessment** — whether the vulnerable code path is reachable from this app, what data it touches, and what the realistic blast radius is.
+4. **Review date** — concrete ISO 8601 date, no more than 30 days from today. Encoded as a label or due date on the tracking issue so it is rediscoverable.
+5. **Tracking issue** — link to the project issue created to re-evaluate. The issue references the upstream tracking link and carries the review date.
+
+## Justification Block (paste into the suppression file)
+
+```text
+Advisory:        <CVE / GHSA / OSV id>            (<link>)
+Latest version:  <version>  confirmed via <registry command>  on <YYYY-MM-DD>
+Patched in:      none yet
+Upstream:        <link to upstream issue or PR>
+Reachability:    <reachable | not reachable | unknown>  - <one-line evidence>
+Exposure:        <data touched, runtime context, public/internal>
+Reviewed by:     <name>                                       on <YYYY-MM-DD>
+Review by:       <YYYY-MM-DD>   (issue: <link>)
+```
+
+## Per-Tool Examples
+
+### `audit-ci.json` (npm / pnpm / yarn)
+
+```json
+{
+  "high": true,
+  "allowlist": [
+    {
+      "advisory": "GHSA-xxxx-yyyy-zzzz",
+      "comment": "Latest obscure-lib (0.3.1) still vulnerable. Upstream fix in obscure-lib#42. Not reachable from runtime (build-only). Review by 2026-05-30, tracking issue #138."
+    }
+  ]
+}
+```
+
+### `.snyk`
+
+```yaml
+ignore:
+  SNYK-JS-OBSCURELIB-12345:
+    - "*":
+        reason: |
+          Latest obscure-lib 0.3.1 still vulnerable (verified 2026-05-02 via npm view).
+          Upstream fix in obscure-lib#42. Build-only path, not reachable at runtime.
+          Tracking: github.com/our-org/our-repo/issues/138.
+        expires: 2026-05-30T00:00:00.000Z
+```
+
+### `pip-audit`
+
+```bash
+pip-audit --ignore-vuln GHSA-xxxx-yyyy-zzzz \
+  --desc "obscure-lib 0.3.1 latest, no patch; upstream PR #42; review 2026-05-30; issue #138"
+```
+
+Prefer encoding the same justification in a checked-in `pyproject.toml` block so it survives across runs:
+
+```toml
+[tool.pip-audit]
+# obscure-lib 0.3.1 latest, no patch yet.
+# Upstream: https://github.com/upstream/obscure-lib/pull/42
+# Reachability: build-time only.
+# Tracking issue: #138, review by 2026-05-30.
+ignore-vulns = ["GHSA-xxxx-yyyy-zzzz"]
+```
+
+### `cargo-deny.toml`
+
+```toml
+[advisories]
+ignore = [
+  # GHSA-xxxx-yyyy-zzzz: obscure-crate 0.3.1 latest, no patch yet.
+  # Upstream: https://github.com/upstream/obscure-crate/issues/42
+  # Reachability: not exercised in our binary (feature-gated).
+  # Tracking: #138, review by 2026-05-30.
+  "RUSTSEC-2025-XXXX",
+]
+```
+
+### Dependabot (`.github/dependabot.yml`)
+
+Dependabot does not natively support time-boxed ignores; encode the review date in the tracking issue title and re-enable the alert when revisiting.
+
+```yaml
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule: { interval: "weekly" }
+    ignore:
+      - dependency-name: "obscure-lib"
+        # Tracking: #138 (review 2026-05-30) - latest 0.3.1 still vulnerable
+```
+
+## Tracking Issue Template
+
+Title: `[CVE] <advisory-id> in <package> — review by <YYYY-MM-DD>`
+
+Body:
+
+```markdown
+**Advisory:** <link>
+**Package:** <ecosystem>/<package> @ <currently-installed-version>
+**Latest registry version:** <version> (confirmed <YYYY-MM-DD>)
+**Patched in:** none yet
+**Upstream tracking:** <link to upstream issue/PR>
+
+**Reachability:** <reachable | not reachable | unknown>
+<one paragraph evidence>
+
+**Exposure:** <data touched, runtime context, public/internal>
+
+**Suppression location:** `<path/to/file>` line <N>
+
+**Review by:** <YYYY-MM-DD>
+On the review date, re-run the scanner and check the upstream tracking link.
+If a patched version exists, remove the suppression and upgrade.
+If still no patch, re-justify and bump the review date by no more than 30 days,
+or escalate to the security team.
+```
+
+Apply labels: `security`, `cve-suppression`, and a date label (e.g. `review:2026-05-30`) so the backlog can be queried.
+
+## What This Template is NOT
+
+This is not a substitute for upgrading. If you find yourself filling it out without having completed Steps 2-5 of the main workflow, stop and go back. The completeness of this paperwork has zero correlation with the soundness of the suppression — only the upstream registry state and your reachability analysis do.

--- a/.claude/skills/user-facing-error-messages/SKILL.md
+++ b/.claude/skills/user-facing-error-messages/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: user-facing-error-messages
+description: >-
+  Audit and rewrite user-facing error messages so users can self-serve instead
+  of emailing support. Use when auditing error messages across an app,
+  improving or rewriting error wording, reviewing toasts, alerts, flash
+  messages, form validation copy, or empty/failure states, or when a message
+  feels opaque, blame-y, or ends in "contact support". Covers the four-part
+  rubric (what / why / next / escape), an inventory-and-triage audit workflow,
+  rewrite templates, and security-safe disclosure rules.
+  Do NOT use for exception architecture, typed errors, or developer-facing
+  logging (use error-handling skill); for the security rules around what
+  errors may safely disclose in auth/crypto paths (use security skill); or
+  for the visual styling of alerts, toasts, and banners (use
+  frontend-aesthetics skill).
+metadata:
+  author: Geoff
+  version: 1.0.0
+---
+
+# User-Facing Error Messages
+
+Write every error message as if you are the user reading it at 2am trying to get unstuck. The goal is self-service, not a support ticket.
+
+## Core Principle
+
+If a user hits this error, they have exactly one question: **"What do I do now?"** An error message that cannot answer that question has failed, no matter how technically accurate it is.
+
+"Contact support" is never a primary call-to-action. It is the last-resort escape hatch after you have done everything you can to let the user self-serve.
+
+## Instructions
+
+### Step 1: Adopt the User Empathy Lens
+
+Before writing or reviewing any message, answer these out loud:
+
+1. **Who hits this?** (End user? Admin? Developer integrating the API?)
+2. **What were they trying to do?** (The task, not the code path.)
+3. **What can they actually change?** (Their input? A setting? Wait and retry? Nothing?)
+4. **What is the emotional state?** (Lost work = high stakes. Typo in a form = low stakes. Tone must match.)
+
+If the answer to #3 is "nothing", the message must say so explicitly and offer an escape (status page, support link with a pre-filled trace ID, retry button).
+
+### Step 2: Apply the Four-Part Rubric
+
+Every user-facing error message is scored on four components. A passing message hits all four in plain language.
+
+| Component | Question it answers | Example |
+|-----------|--------------------|---------|
+| **What** | What went wrong, in human terms? | "We couldn't save your draft." |
+| **Why** | Why it happened — only if the user can act on it | "Your network dropped mid-save." |
+| **Next** | The single most useful next action | "Check your connection and tap Retry." |
+| **Escape** | Where to go if Next fails | "Still stuck? [Open a ticket] (ref: 7F3A2)" |
+
+Skip **Why** when it leaks internals, blames the user, or gives them no lever. Skip it; don't lie or filler.
+
+### Step 3: Run the Audit Workflow
+
+For a full-app audit, follow `references/audit-workflow.md`. The short version:
+
+1. **Inventory** every user-facing error source: `raise`/`throw`, toast/flash/snackbar calls, HTTP error responses rendered to users, form validation strings, empty-state copy, 4xx/5xx pages, email/SMS failures.
+2. **Classify** each string: user-facing vs. developer-facing (logs, stack traces). Only user-facing strings are in scope.
+3. **Score** each against the four-part rubric. Flag any message that scores below 3/4 or contains an anti-pattern from Step 4.
+4. **Triage** by blast radius: high-traffic paths first (login, checkout, save), then happy-path adjacent, then rare edge cases.
+5. **Rewrite** using the templates in `references/rewrite-templates.md`.
+6. **Preserve debuggability**: surface a short trace ID/error code so support can find the log line, but never make the code the whole message.
+
+### Step 4: Eliminate the Anti-Patterns
+
+Reject and rewrite any message matching these:
+
+- **The shrug**: "An error occurred." / "Something went wrong." / "Oops!"
+- **The opaque code**: "Error 0x80042108" with no human sentence.
+- **The blame**: "You entered an invalid email." (Use "That email is missing an @ — did you mean `name@example.com`?")
+- **The dev leak**: "NullPointerException in UserService.load()" / "ECONNREFUSED 127.0.0.1:5432".
+- **The dead-end**: ends in "contact support" with no trace ID, no link, and no attempt at self-serve.
+- **The jargon**: "Malformed payload", "Constraint violation", "Upstream 502" — translate.
+- **The panic**: ALL CAPS, stacked exclamation points, red-on-red screaming banners for recoverable cases.
+- **The liar**: "Please try again" when the request will deterministically fail again (e.g., invalid credentials, validation errors).
+- **The thief**: silently loses the user's work. Always confirm what was saved/preserved.
+
+### Step 5: Respect Security Boundaries
+
+Some errors intentionally stay vague. Coordinate with the `security` skill for these categories:
+
+- **Auth failures**: "Email or password is incorrect" (do not confirm which). Still actionable: "Reset password" link.
+- **Authorization**: "You don't have access to this project. Ask the project owner to invite you." Do not reveal existence of protected resources to unauthenticated users.
+- **Rate limits on sensitive endpoints**: give a cooldown window, not the exact counter state.
+
+Security vagueness is not an excuse for useless messages — the **Next** and **Escape** components still apply.
+
+### Step 6: Apply the Self-Service Sanity Check
+
+Before shipping, read the rewritten message aloud and ask:
+
+- [ ] Can a non-technical user name what broke?
+- [ ] Does it tell them exactly what to try next?
+- [ ] Does it preserve their work, or tell them it's lost?
+- [ ] Is there a trace ID or error code they can quote to support?
+- [ ] Does the tone match the severity (calm for recoverable, serious for data loss)?
+- [ ] Would I, half-asleep at 2am, know what to do?
+
+If any checkbox fails, rewrite.
+
+## Examples
+
+### Example 1: Form Validation — Specific, Actionable, Kind
+
+**Before:** `Invalid input.`
+
+**After:** `Phone number must be 10 digits — you entered 9. Example: (555) 123-4567.`
+
+- **What**: phone number wrong length
+- **Why**: 9 vs 10 digits (specific)
+- **Next**: implicit — add the missing digit, format example shown
+- **Escape**: not needed at this severity
+
+### Example 2: Server Error — Preserve Work, Offer Trace
+
+**Before:** `An unexpected error occurred. Please try again or contact support.`
+
+**After:**
+> We couldn't publish your post, but your draft is saved.
+>
+> Our servers hiccuped on the way to the database. Try again in a minute — if it happens twice, [open a ticket] and mention **ref: 7F3A2-B9**.
+
+- **What**: publish failed, draft safe
+- **Why**: brief, non-blaming, non-technical
+- **Next**: wait and retry
+- **Escape**: ticket link with pre-filled trace ID
+
+### Example 3: Auth Failure — Security-Safe Without Being Useless
+
+**Before:** `Login failed.`
+
+**After:** `That email and password don't match. [Reset password] or [create an account] if you're new here.`
+
+Note: does not confirm which field is wrong (security), but still points to the two real next actions.
+
+### Example 4: Full-App Audit Kickoff
+
+User says: *"We keep getting support emails that are just screenshots of error toasts. Do an audit."*
+
+1. Run Step 3 inventory (`references/audit-workflow.md` for grep patterns by stack).
+2. Produce a spreadsheet: message text, file:line, trigger frequency (from logs if available), rubric score, proposed rewrite.
+3. Sort by frequency × severity; fix the top decile first.
+4. For each rewrite, add a trace ID surface if one doesn't exist.
+5. Open a PR per subsystem, not one giant PR, so each is reviewable.
+
+## Troubleshooting
+
+### Error: The "why" would leak implementation details
+
+Drop the **Why** line. Keep **What** / **Next** / **Escape**. "Why" is optional; it is never worth a security or confusion cost to force one in.
+
+### Error: There's genuinely nothing the user can do
+
+Say so, and redirect energy usefully: "Our payments provider is down. You don't need to do anything — we'll retry automatically and email you when the charge goes through. [Status page]." The user's next action is "close this and stop worrying", which is a real, valid **Next**.
+
+### Error: Product/legal pushes back on specifics
+
+Push back with data: support-ticket volume traceable to opaque messages. If specifics are truly blocked (compliance, trade secret), the compromise is a trace ID the user can quote — never just "contact support".
+
+### Error: The message has to be short (toast, inline)
+
+Layer the disclosure: short message + "Details" link or expandable. The 4 components don't have to be in one sentence, they have to be in one experience.
+
+### Error: Message is internationalized and rewrite must pass translation
+
+Avoid idioms, contractions, and puns. Keep trace IDs and example values out of the translated string (interpolate them). See `references/rewrite-templates.md` for i18n-safe patterns.

--- a/.claude/skills/user-facing-error-messages/references/audit-workflow.md
+++ b/.claude/skills/user-facing-error-messages/references/audit-workflow.md
@@ -1,0 +1,111 @@
+# Audit Workflow
+
+A repeatable process for auditing every user-facing error message in an application. Use this when the task is "go wide" rather than "fix this one message".
+
+## 1. Inventory
+
+Cast a wide net. The goal is to collect every string that could ever reach a user in a failure state.
+
+### Where user-facing errors live
+
+- **Form validation**: inline field errors, form-level summary errors
+- **Toast / snackbar / flash messages**: ephemeral notifications
+- **Alert / banner / modal dialogs**: blocking or prominent errors
+- **4xx / 5xx pages**: 400, 401, 403, 404, 409, 422, 429, 500, 502, 503, 504
+- **Empty states with failure context**: "We couldn't load your projects"
+- **Email / SMS / push failures**: both the user's copy and the admin's copy
+- **API error bodies**: if the API is consumed by a third-party UI or CLI
+- **CLI stderr**: for developer-facing tools, the CLI *is* the UI
+- **Webhook failure notifications**: delivery retries, dead-letter queues
+- **Payment / billing failures**: card declines, subscription lapses
+
+### Grep patterns by stack
+
+Adjust to your codebase. Start broad, then narrow.
+
+```bash
+# Python (Flask/Django/FastAPI)
+rg -n 'flash\(|messages\.error|raise.*Error\(|HTTPException\(|abort\(' --glob '*.py'
+
+# JavaScript / TypeScript
+rg -n 'toast\.|showError|throw new \w*Error|res\.status\(\d+\)\.(json|send)' --glob '*.{ts,tsx,js,jsx}'
+
+# Templates (Jinja2 / ERB / Blade)
+rg -n 'error|alert' --glob '*.{html,jinja,erb,blade.php}'
+
+# Generic: quoted strings near error handling
+rg -B1 -A1 'error|failed|invalid|unable' --glob '!*.{lock,min.js}'
+```
+
+### Output shape
+
+Put the inventory in a spreadsheet or markdown table — one row per message:
+
+| # | File:Line | Trigger path | Current text | User-facing? | Frequency (30d) |
+|---|-----------|--------------|--------------|--------------|-----------------|
+| 1 | `auth/login.py:42` | POST /login bad creds | "Login failed." | Yes | 18,400 |
+| 2 | `api/users.py:88` | 500 fallback | "Internal server error" | Yes | 230 |
+
+## 2. Classify
+
+Mark each message:
+
+- **User-facing** — rendered to a human through the product UI. In scope.
+- **Developer-facing** — logs, stack traces, telemetry. Out of scope for this audit (see `error-handling` skill).
+- **Mixed** — e.g., an API error body that both logs emit *and* consumers render. Treat as user-facing; developers can read user-friendly text too.
+
+If classification is unclear, ask: *"If my parent hit this, would they see this exact string?"*
+
+## 3. Score
+
+For each user-facing message, score 0 or 1 on each rubric component:
+
+- [ ] **What**: names what failed in human terms
+- [ ] **Why**: gives a cause the user can act on (skip safely if N/A)
+- [ ] **Next**: specifies a concrete next action
+- [ ] **Escape**: offers a path when Next fails (trace ID, status page, support link)
+
+Also flag any message containing an anti-pattern (shrug, opaque code, blame, dev leak, dead-end, jargon, panic, liar, thief — see SKILL.md Step 4).
+
+A message passing fewer than 3/4 components or containing any anti-pattern is a rewrite candidate.
+
+## 4. Triage
+
+Sort rewrite candidates by **blast radius**:
+
+```
+priority_score = frequency × severity × stuck_factor
+```
+
+- **Frequency**: how often this message is seen (from logs, analytics, or support tickets).
+- **Severity**: 3 for data loss / payment / auth, 2 for core workflow, 1 for edge cases.
+- **Stuck factor**: 3 if no self-serve path exists, 2 if partial, 1 if easy workaround.
+
+Fix the top decile first. A full audit that ships nothing is worse than a focused audit that ships the top 20 messages.
+
+## 5. Rewrite
+
+Use templates from `rewrite-templates.md`. Each rewrite includes:
+
+- New message text
+- Trace ID surface (add one if missing — even a short hash of request ID helps support)
+- Severity / tone check (calm vs. serious)
+- Preservation statement if applicable ("your draft is saved")
+
+Keep the old error code or create a new one; map it in a lookup table so support can still match tickets to log lines.
+
+## 6. Ship in Reviewable Chunks
+
+- One PR per subsystem (auth, billing, forms, API, etc.), not one mega-PR.
+- Include before/after in the PR description so reviewers can feel the improvement.
+- Add a regression test or snapshot where feasible, so future commits can't quietly downgrade a message back to "An error occurred".
+
+## 7. Measure
+
+After shipping, watch:
+
+- Support-ticket volume tagged with the subsystem.
+- "Same user retried same action" rate (are they getting unstuck?).
+- Error-toast dismiss time (too fast = they didn't read; too slow = confusion).
+
+A good audit reduces support-ticket volume in the audited subsystem within the first month.

--- a/.claude/skills/user-facing-error-messages/references/rewrite-templates.md
+++ b/.claude/skills/user-facing-error-messages/references/rewrite-templates.md
@@ -1,0 +1,190 @@
+# Rewrite Templates
+
+Copy-pasteable before/after pairs organized by error category. Each template applies the four-part rubric (What / Why / Next / Escape) from `SKILL.md`.
+
+## Form & Input Validation
+
+### Required field missing
+
+- **Bad:** `This field is required.`
+- **Good:** `Email address is required — we'll send your receipt here.`
+
+Include the *purpose* of the field so the user sees why we're asking.
+
+### Format mismatch
+
+- **Bad:** `Invalid date.`
+- **Good:** `Use the format MM/DD/YYYY — for example, 04/13/2026.`
+
+Always show one concrete example in the right format.
+
+### Length / range
+
+- **Bad:** `Password does not meet requirements.`
+- **Good:** `Passwords need at least 12 characters. Yours has 7 — try a memorable passphrase like "tree-river-sunset".`
+
+Name the requirement, name the actual value, and suggest an approach.
+
+### Uniqueness / taken
+
+- **Bad:** `Username unavailable.`
+- **Good:** `"geoff" is taken. Try **geoff2026**, **geoff-g**, or [sign in] if it's you.`
+
+Offer suggestions derived from the user's input.
+
+## Authentication & Authorization
+
+### Bad credentials
+
+- **Bad:** `Authentication failed.`
+- **Good:** `That email and password don't match. [Reset password] or [create an account].`
+
+Do not disclose which field was wrong. Both next actions still work.
+
+### Session expired
+
+- **Bad:** `Unauthorized.`
+- **Good:** `You were signed out after 30 minutes of inactivity. [Sign in again] — your draft is saved.`
+
+Name the cause in user terms. Confirm preserved work.
+
+### Permission denied
+
+- **Bad:** `403 Forbidden.`
+- **Good:** `You don't have access to the "Marketing" workspace. Ask its owner, **Sam Rivera**, to invite you — or [switch workspaces].`
+
+Name the missing grant and the person who can give it.
+
+### MFA / 2FA failure
+
+- **Bad:** `Invalid code.`
+- **Good:** `That 6-digit code didn't match. Codes expire every 30 seconds — open your authenticator app and try the newest one. [Lost access?]`
+
+Explain the time-boxing and give the lost-device escape hatch.
+
+## Network / Service Failures
+
+### Transient server error
+
+- **Bad:** `Something went wrong. Please try again.`
+- **Good:**
+  > We couldn't save your changes — our server hiccuped.
+  >
+  > Your work is still in the form. [Try again] — if it fails twice, check [status.example.com] or [open a ticket] (ref: 7F3A2).
+
+Confirm preserved state; give retry, status page, and ticket path.
+
+### Offline / network down
+
+- **Bad:** `Network error.`
+- **Good:** `You're offline. We'll save your changes as soon as you're back on the internet — don't close this tab.`
+
+Own the user's fear (data loss). Tell them the action they *shouldn't* take.
+
+### Upstream/3rd-party down
+
+- **Bad:** `Gateway timeout.`
+- **Good:** `Our payment processor (Stripe) is slow right now. Your card wasn't charged. [Try again] in a minute, or [choose a different payment method].`
+
+Name the upstream plainly. Confirm no side effects.
+
+### Rate limited
+
+- **Bad:** `429 Too Many Requests.`
+- **Good:** `You've hit the limit of 60 messages per minute. You can send again in **42 seconds**.`
+
+Quantify the limit and the countdown. Avoid giving attackers exact state on sensitive endpoints — coordinate with `security` skill.
+
+## Payment & Billing
+
+### Card declined
+
+- **Bad:** `Payment failed.`
+- **Good:** `Your card ending in **1234** was declined by the issuing bank. Try a different card or contact your bank — we never see why they declined.`
+
+Say what you know and what you *don't* know. Prevent users from blaming you.
+
+### Subscription lapsed
+
+- **Bad:** `Access denied.`
+- **Good:** `Your Pro subscription ended on April 1. [Renew now] to restore team members, integrations, and analytics — nothing has been deleted.`
+
+Reassure about data. List what they're missing to create a clear value case.
+
+## Data / Storage
+
+### Not found
+
+- **Bad:** `404 Not Found.`
+- **Good:** `We couldn't find a project at that link. It may have been deleted or renamed. [See all your projects] or [search].`
+
+Offer two ways to rediscover.
+
+### Conflict / stale edit
+
+- **Bad:** `409 Conflict.`
+- **Good:** `Alex edited this page after you opened it. [See their changes], [overwrite with yours], or [merge both].`
+
+Name the other actor. Give a real choice.
+
+### Upload too large
+
+- **Bad:** `File too large.`
+- **Good:** `That file is **18 MB** — the limit is **10 MB**. [Compress it here] or email it as a link instead.`
+
+Actual size, actual limit, actual alternative.
+
+## CLI / Developer Tools
+
+CLIs *are* a UI. The same rubric applies, adjusted for a technical audience.
+
+- **Bad:** `ENOENT`
+- **Good:**
+  ```
+  ✗ Couldn't find config file at ./well-worn.toml
+
+    We checked: .  ../  ~/
+    Run `well-worn init` to create one, or pass --config <path>.
+  ```
+
+Show the search path. Name the fix command.
+
+## Empty / Zero-State Failures
+
+Failure isn't always red. Sometimes it's an empty page.
+
+- **Bad:** `No results.`
+- **Good:** `No projects match "archive 2019". Try removing a filter, or [clear all filters] to start over.`
+
+Name the query, name the levers.
+
+## i18n-Safe Patterns
+
+Messages that must translate cleanly:
+
+- Interpolate variables — don't concatenate strings.
+- Avoid contractions, idioms, puns.
+- Keep trace IDs, example values, and numbers out of the translatable string.
+
+```python
+# Bad
+msg = "Couldn't find " + name + " — did you mean " + suggestion + "?"
+
+# Good
+msg = _("We couldn't find {name}. Did you mean {suggestion}?").format(
+    name=name, suggestion=suggestion
+)
+```
+
+## Tone Ladder
+
+Pick severity, match tone:
+
+| Severity | Example scenario | Tone | Example opening |
+|----------|-----------------|------|-----------------|
+| Low | Typo in form | Helpful, light | "Almost! …" |
+| Medium | Request failed, recoverable | Calm, factual | "We couldn't save …" |
+| High | Data loss possible | Serious, direct | "Your changes weren't saved …" |
+| Critical | Security / account takeover | Urgent, action-first | "Sign out of all devices now …" |
+
+Never use exclamation points on Medium+. Never use "Oops" or "Uh oh" on High+.

--- a/.github/workflows/iteration-trigger.yml
+++ b/.github/workflows/iteration-trigger.yml
@@ -1,0 +1,95 @@
+name: Iteration Trigger
+
+# Posts a brief executive summary on a PR (commenting as Geoffe-Ga via PAT)
+# whenever CI completes fully green AND a Claude review has been posted.
+# The comment is intended to fire a webhook that wakes the Claude Code mobile
+# app via MCP so it can continue iterating on feedback. Capped at 10 self-posts
+# per PR to avoid runaway loops.
+#
+# Required secrets:
+#   GEOFFE_GA_PAT  - personal access token for Geoffe-Ga with `pull-requests: write`.
+#                    Without this the comment would post as github-actions[bot]
+#                    and the mobile webhook would not recognize the author.
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: read
+
+jobs:
+  nudge:
+    name: Post executive summary
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve PR number from head branch
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          PR=$(gh pr list -R "$REPO" --head "$BRANCH" --state open \
+                 --json number --jq '.[0].number // empty')
+          echo "number=$PR" >> "$GITHUB_OUTPUT"
+
+      - name: Compose and post summary
+        if: steps.pr.outputs.number != ''
+        env:
+          GH_TOKEN: ${{ secrets.GEOFFE_GA_PAT }}
+          REPO: ${{ github.repository }}
+          PR: ${{ steps.pr.outputs.number }}
+          SHA: ${{ github.event.workflow_run.head_sha }}
+          MARKER: '<!-- iteration-trigger -->'
+        run: |
+          set -euo pipefail
+
+          # Pull PR comments once (first 100 is plenty for an active PR).
+          gh api "repos/$REPO/issues/$PR/comments?per_page=100" > comments.json
+
+          # Cap: stop after 10 prior self-posts on this PR.
+          PRIOR=$(grep -c "$MARKER" comments.json || true)
+          if [ "$PRIOR" -ge 10 ]; then
+            echo "Cap reached ($PRIOR/10) - skipping"
+            exit 0
+          fi
+
+          # Find latest Claude review comment (its body contains 'Verdict').
+          CLAUDE=$(jq -c '[.[] | select(.body | test("Verdict"))] | last // empty' comments.json)
+          if [ -z "$CLAUDE" ]; then
+            echo "No Claude review yet - skipping"
+            exit 0
+          fi
+          ID=$(jq -r '.id'   <<<"$CLAUDE")
+          BODY=$(jq -r '.body' <<<"$CLAUDE")
+
+          # Summarize verdict via grep on the Claude comment body.
+          if   grep -qE 'CHANGES[_ ]REQUESTED' <<<"$BODY"; then VERDICT='CHANGES REQUESTED'
+          elif grep -q   'LGTM'                <<<"$BODY"; then VERDICT='LGTM'
+          else                                                  VERDICT='COMMENTS'
+          fi
+
+          # CI status from check-runs on the head SHA.
+          gh api "repos/$REPO/commits/$SHA/check-runs?per_page=100" > runs.json
+          TOTAL=$(jq '.check_runs | length'                                       runs.json)
+          GREEN=$(jq '[.check_runs[] | select(.conclusion=="success")] | length' runs.json)
+
+          if [ "$GREEN" = "$TOTAL" ] && [ "$VERDICT" = "LGTM" ]; then
+            ACTION="You are cleared to squash merge, delete the branch, clean any worktrees, and unsubscribe from webhooks. Please proceed."
+          else
+            ACTION="pull comment ${ID} to see in-depth feedback and continue iterating"
+          fi
+
+          BODY=$(printf '%s\n%s\n%s\n%s\n' \
+            "$MARKER" \
+            "**CI**: ${GREEN}/${TOTAL} Green" \
+            "**VERDICT**: ${VERDICT}" \
+            "**Action**: ${ACTION}")
+          gh api -X POST "repos/$REPO/issues/$PR/comments" -f body="$BODY"


### PR DESCRIPTION
## Summary

Adds 4 skill(s) and 1 workflow(s) from [`Geoffe-Ga/well-worn-tools`](https://github.com/Geoffe-Ga/well-worn-tools/tree/22ee048) to this repo.

## Skills

- **address-feedback** — - Iterate on Claude PR review feedback intelligently and merge when ready.
- **await-claude-review** — - Subscribe to GitHub PR activity and wait — without polling — for the Claude reviewer's verdict comment on the current HEAD.
- **cve-remediation** — - Remediate dependency vulnerability scanner failures by verifying live package registry data and upgrading instead of suppressing.
- **user-facing-error-messages** — - Audit and rewrite user-facing error messages so users can self-serve instead of emailing support.

## Workflows

- **iteration-trigger.yml** — Posts a brief CI / Claude-verdict / next-action summary comment (as the repo owner via PAT) whenever CI completes fully green and a Claude review comment exists, capped at 10 self-posts per PR. Designed to wake a Claude Code mobile session via webhook so it can keep iterating on review feedback.
  - **Requires:** (a) a workflow named `CI` in the target repo so the `workflow_run` trigger matches; (b) repo secret `GEOFFE_GA_PAT` — a PAT with `pull-requests: write` so the comment posts under the owner's identity rather than github-actions[bot]; (c) an active Claude review workflow whose comments include a `Verdict` line (see `claude-code-review.yml` upstream).

## Provenance

Source SHA: `22ee0481d6609a647feef742417b02692434cd08`
Distributed via the `distribute-skills` skill (`metadata.distribute: false`, stays in well-worn-tools).

## Test plan

- [ ] Confirm `.claude/skills/` directory structure looks right
- [ ] Spot-check one SKILL.md frontmatter for syntax
- [ ] Decide whether each skill's triggers fit this repo's workflows
- [ ] Confirm each new file under `.github/workflows/` parses (actionlint)
- [ ] Wire any required secrets noted under **Workflows** above
- [ ] Confirm any referenced workflow names exist in this repo