### PR TITLE
feat: pending_actions table + db adapter functions (audit log for staged actions)

### DIFF
--- a/grocery_butler/db/adapter.py
+++ b/grocery_butler/db/adapter.py
@@ -385,6 +385,30 @@ def _inject_returning(sql: str) -> tuple[str, bool]:
     return sql, False
 
 
+_LINE_COMMENT_RE: re.Pattern[str] = re.compile(r"--[^\n]*")
+_BLOCK_COMMENT_RE: re.Pattern[str] = re.compile(r"/\*.*?\*/", re.DOTALL)
+
+
+def _has_executable_sql(sql: str) -> bool:
+    """Check whether a SQL script contains any executable statements.
+
+    Strips ``--`` line comments and ``/* ... */`` block comments; if
+    nothing but whitespace remains, the script is a no-op. Comment
+    markers inside string literals are not special-cased — migration
+    scripts don't embed them, and a false negative would only skip a
+    script that also contains no other statements.
+
+    Args:
+        sql: Multi-statement SQL string.
+
+    Returns:
+        True if at least one non-comment token remains.
+    """
+    without_blocks = _BLOCK_COMMENT_RE.sub("", sql)
+    without_comments = _LINE_COMMENT_RE.sub("", without_blocks)
+    return bool(without_comments.strip())
+
+
 class PostgresCursorResult:
     """Wraps a ``psycopg2`` cursor to satisfy :class:`CursorResult`.
 
@@ -512,9 +536,15 @@ class PostgresConnection:
         Unlike SQLite's ``executescript()``, psycopg2 handles
         multi-statement strings in a single ``execute()`` call.
 
+        Comment-only scripts (e.g. no-op migration markers) are
+        skipped: sqlite3 tolerates them, but psycopg2 raises
+        ``can't execute an empty query``.
+
         Args:
             sql: Multi-statement SQL string.
         """
+        if not _has_executable_sql(sql):
+            return
         cursor = self._conn.cursor()
         cursor.execute(sql)
         self._conn.commit()

--- a/grocery_butler/db/migrate.py
+++ b/grocery_butler/db/migrate.py
@@ -119,15 +119,20 @@ def _record_migration(conn: DatabaseConnection, version: int, name: str) -> None
     Uses ``?`` placeholders which the adapter layer translates to
     ``%s`` for PostgreSQL (see :meth:`PostgresConnection.execute`).
 
+    The explicit ``RETURNING version`` prevents the PostgreSQL adapter
+    from injecting ``RETURNING id`` (schema_migrations has no ``id``
+    column; its primary key is ``version``).
+
     Args:
         conn: Active database connection.
         version: Migration version number.
         name: Migration name.
     """
-    conn.execute(
-        "INSERT INTO schema_migrations (version, name) VALUES (?, ?)",
+    result = conn.execute(
+        "INSERT INTO schema_migrations (version, name) VALUES (?, ?) RETURNING version",
         (version, name),
     )
+    result.fetchall()  # drain RETURNING so commit sees no open cursor
     conn.commit()
 
 

--- a/grocery_butler/db/migrations/004_pending_actions.sql
+++ b/grocery_butler/db/migrations/004_pending_actions.sql
@@ -1,0 +1,18 @@
+-- Migration 004: pending_actions staging table (SQLite).
+-- Server-side staging + audit log for destructive actions
+-- (e.g. Safeway order submissions) awaiting confirmation.
+-- Payload is stored as JSON-encoded TEXT on SQLite.
+
+CREATE TABLE IF NOT EXISTS pending_actions (
+    action_id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    payload TEXT NOT NULL,                    -- JSON-encoded action payload
+    status TEXT NOT NULL DEFAULT 'pending',   -- pending | approved | denied | expired
+    requester TEXT NOT NULL DEFAULT 'rubotpaul',
+    expires_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    resolved_at TIMESTAMP
+);
+
+CREATE INDEX IF NOT EXISTS idx_pending_actions_status
+    ON pending_actions(status, expires_at);

--- a/grocery_butler/db/migrations/004_pending_actions_pg.sql
+++ b/grocery_butler/db/migrations/004_pending_actions_pg.sql
@@ -1,0 +1,17 @@
+-- Migration 004: pending_actions staging table (PostgreSQL).
+-- Server-side staging + audit log for destructive actions
+-- (e.g. Safeway order submissions) awaiting confirmation.
+
+CREATE TABLE IF NOT EXISTS pending_actions (
+    action_id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',   -- pending | approved | denied | expired
+    requester TEXT NOT NULL DEFAULT 'rubotpaul',
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    resolved_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_pending_actions_status
+    ON pending_actions(status, expires_at);

--- a/grocery_butler/models.py
+++ b/grocery_butler/models.py
@@ -6,6 +6,7 @@ including future Safeway models that aren't used yet.
 
 from __future__ import annotations
 
+import datetime as dt
 from enum import StrEnum
 from typing import Any
 
@@ -400,3 +401,49 @@ class CartSummary(BaseModel):
     fulfillment_options: list[FulfillmentOption]
     recommended_fulfillment: FulfillmentType
     estimated_total: float
+
+
+class PendingActionStatus(StrEnum):
+    """Lifecycle status of a staged pending action."""
+
+    PENDING = "pending"
+    APPROVED = "approved"
+    DENIED = "denied"
+    EXPIRED = "expired"
+
+
+class PendingAction(BaseModel):
+    """A destructive action staged for confirmation (audit-log row).
+
+    Rows live in the ``pending_actions`` table and record every staged
+    Safeway submission or preference change, whether it was ultimately
+    approved, denied, or expired.
+    """
+
+    action_id: str
+    kind: str
+    payload: dict[str, Any]
+    status: PendingActionStatus = PendingActionStatus.PENDING
+    requester: str = "rubotpaul"
+    expires_at: dt.datetime
+    created_at: dt.datetime | None = None
+    resolved_at: dt.datetime | None = None
+
+    def is_expired(self, now: dt.datetime | None = None) -> bool:
+        """Check whether the confirmation deadline has passed.
+
+        Naive datetimes (as stored by SQLite) are interpreted as UTC.
+
+        Args:
+            now: Reference time; defaults to the current UTC time.
+
+        Returns:
+            True if ``expires_at`` is earlier than ``now``.
+        """
+        reference = now if now is not None else dt.datetime.now(dt.UTC)
+        expires = self.expires_at
+        if expires.tzinfo is None:
+            expires = expires.replace(tzinfo=dt.UTC)
+        if reference.tzinfo is None:
+            reference = reference.replace(tzinfo=dt.UTC)
+        return reference > expires

--- a/grocery_butler/pending_actions.py
+++ b/grocery_butler/pending_actions.py
@@ -1,0 +1,207 @@
+"""Data access layer for staged pending actions.
+
+The ``pending_actions`` table is the server-side staging area and audit
+log for destructive operations (Safeway order submissions, brand and
+preference changes). Rows are inserted as ``pending`` and resolved to
+``approved``, ``denied``, or ``expired`` exactly once.
+
+Uses the same connection-per-operation pattern as
+:class:`grocery_butler.recipe_store.RecipeStore`, so it works against
+both SQLite and PostgreSQL through the adapter layer.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+from typing import TYPE_CHECKING, Any
+
+from grocery_butler.db import get_connection
+from grocery_butler.models import PendingAction, PendingActionStatus
+
+if TYPE_CHECKING:
+    from grocery_butler.db.adapter import DatabaseConnection, DictRow
+
+
+def _row_to_pending_action(row: DictRow) -> PendingAction:
+    """Convert a database row to a PendingAction model.
+
+    SQLite returns the JSON payload as a string and timestamps as ISO
+    strings; PostgreSQL returns a dict (JSONB) and datetime objects.
+    Both shapes are normalized here (pydantic parses ISO datetimes).
+
+    Args:
+        row: Row from the pending_actions table.
+
+    Returns:
+        PendingAction model instance.
+    """
+    payload = row["payload"]
+    if isinstance(payload, str):
+        payload = json.loads(payload)
+    return PendingAction(
+        action_id=row["action_id"],
+        kind=row["kind"],
+        payload=payload,
+        status=PendingActionStatus(row["status"]),
+        requester=row["requester"],
+        expires_at=row["expires_at"],
+        created_at=row["created_at"],
+        resolved_at=row["resolved_at"],
+    )
+
+
+class PendingActionsStore:
+    """CRUD operations for the pending_actions staging table."""
+
+    def __init__(self, db_path: str) -> None:
+        """Initialize the store with a database path or URL.
+
+        Args:
+            db_path: SQLite file path or PostgreSQL URL.
+        """
+        self.db_path = db_path
+
+    def _connect(self) -> DatabaseConnection:
+        """Open a new database connection.
+
+        Returns:
+            Configured DatabaseConnection.
+        """
+        return get_connection(self.db_path)
+
+    def insert_pending_action(
+        self,
+        *,
+        action_id: str,
+        kind: str,
+        payload: dict[str, Any],
+        expires_at: dt.datetime,
+        requester: str = "rubotpaul",
+    ) -> PendingAction:
+        """Stage a new pending action.
+
+        Args:
+            action_id: Unique identifier (typically a UUID4 string).
+            kind: Action kind, e.g. ``safeway_order_submit``.
+            payload: JSON-serializable action payload.
+            expires_at: Deadline after which the action should not run.
+            requester: Origin of the request (defaults to ``rubotpaul``).
+
+        Returns:
+            The stored row as a PendingAction (including DB defaults).
+
+        Raises:
+            IntegrityError: If ``action_id`` already exists.
+            RuntimeError: If the inserted row cannot be read back.
+        """
+        conn = self._connect()
+        try:
+            result = conn.execute(
+                "INSERT INTO pending_actions "
+                "(action_id, kind, payload, status, requester, expires_at) "
+                "VALUES (?, ?, ?, ?, ?, ?) RETURNING action_id",
+                (
+                    action_id,
+                    kind,
+                    json.dumps(payload),
+                    PendingActionStatus.PENDING.value,
+                    requester,
+                    expires_at.isoformat(),
+                ),
+            )
+            result.fetchall()  # drain RETURNING so commit sees no open cursor
+            conn.commit()
+        finally:
+            conn.close()
+        inserted = self.get_pending_action(action_id)
+        if inserted is None:
+            raise RuntimeError(f"pending action {action_id} vanished after insert")
+        return inserted
+
+    def get_pending_action(self, action_id: str) -> PendingAction | None:
+        """Fetch a pending action by id.
+
+        Args:
+            action_id: Identifier to look up.
+
+        Returns:
+            The PendingAction, or None if not found.
+        """
+        conn = self._connect()
+        try:
+            result = conn.execute(
+                "SELECT action_id, kind, payload, status, requester, "
+                "expires_at, created_at, resolved_at "
+                "FROM pending_actions WHERE action_id = ?",
+                (action_id,),
+            )
+            row = result.fetchone()
+        finally:
+            conn.close()
+        if row is None:
+            return None
+        return _row_to_pending_action(row)
+
+    def mark_pending_approved(self, action_id: str) -> bool:
+        """Resolve a pending action as approved.
+
+        Args:
+            action_id: Identifier of the action to approve.
+
+        Returns:
+            True if the action was pending and is now approved.
+        """
+        return self._resolve(action_id, PendingActionStatus.APPROVED)
+
+    def mark_pending_denied(self, action_id: str) -> bool:
+        """Resolve a pending action as denied.
+
+        Args:
+            action_id: Identifier of the action to deny.
+
+        Returns:
+            True if the action was pending and is now denied.
+        """
+        return self._resolve(action_id, PendingActionStatus.DENIED)
+
+    def mark_pending_expired(self, action_id: str) -> bool:
+        """Resolve a pending action as expired.
+
+        Args:
+            action_id: Identifier of the action to expire.
+
+        Returns:
+            True if the action was pending and is now expired.
+        """
+        return self._resolve(action_id, PendingActionStatus.EXPIRED)
+
+    def _resolve(self, action_id: str, new_status: PendingActionStatus) -> bool:
+        """Transition an action from pending to a terminal status.
+
+        The UPDATE is guarded on ``status = 'pending'`` so an action can
+        only be resolved once; later attempts (or unknown ids) fail.
+
+        Args:
+            action_id: Identifier of the action to resolve.
+            new_status: Terminal status to apply.
+
+        Returns:
+            True if exactly one pending row was transitioned.
+        """
+        conn = self._connect()
+        try:
+            result = conn.execute(
+                "UPDATE pending_actions SET status = ?, resolved_at = ? "
+                "WHERE action_id = ? AND status = ?",
+                (
+                    new_status.value,
+                    dt.datetime.now(dt.UTC).isoformat(),
+                    action_id,
+                    PendingActionStatus.PENDING.value,
+                ),
+            )
+            conn.commit()
+            return result.rowcount == 1
+        finally:
+            conn.close()

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -16,7 +16,9 @@ from grocery_butler.db.adapter import (
     CursorResult,
     DatabaseConnection,
     IntegrityError,
+    PostgresConnection,
     SQLiteConnection,
+    _has_executable_sql,
     _inject_returning,
     _translate_placeholders,
     create_connection,
@@ -358,6 +360,62 @@ class TestInjectReturning:
         result, injected = _inject_returning(sql)
         assert result == "insert into t (name) values (%s) RETURNING id"
         assert injected is True
+
+
+class TestHasExecutableSql:
+    """Tests for the _has_executable_sql helper."""
+
+    def test_true_for_plain_statement(self) -> None:
+        """Test a real statement is detected as executable."""
+        assert _has_executable_sql("CREATE TABLE t (id INTEGER)") is True
+
+    def test_false_for_empty_string(self) -> None:
+        """Test an empty script has nothing to execute."""
+        assert _has_executable_sql("") is False
+
+    def test_false_for_whitespace_only(self) -> None:
+        """Test a whitespace-only script has nothing to execute."""
+        assert _has_executable_sql("   \n\t\n") is False
+
+    def test_false_for_line_comments_only(self) -> None:
+        """Test a script of only -- comments has nothing to execute."""
+        sql = "-- Migration 003: no-op marker.\n-- Logic lives elsewhere.\n"
+        assert _has_executable_sql(sql) is False
+
+    def test_false_for_block_comments_only(self) -> None:
+        """Test a script of only /* */ comments has nothing to execute."""
+        assert _has_executable_sql("/* nothing\n to run */") is False
+
+    def test_true_for_statement_after_comments(self) -> None:
+        """Test comments followed by a statement is executable."""
+        sql = "-- header comment\nCREATE INDEX idx ON t(c);\n"
+        assert _has_executable_sql(sql) is True
+
+
+class TestPostgresExecutescriptSkipsNoOps:
+    """PostgresConnection.executescript skips comment-only scripts."""
+
+    def test_comment_only_script_is_skipped(self) -> None:
+        """Test no cursor is opened for a comment-only script."""
+        from unittest.mock import MagicMock
+
+        raw = MagicMock()
+        conn = PostgresConnection(raw)
+        conn.executescript("-- no-op migration marker\n")
+        raw.cursor.assert_not_called()
+        raw.commit.assert_not_called()
+
+    def test_real_script_still_executes(self) -> None:
+        """Test scripts with statements execute and commit."""
+        from unittest.mock import MagicMock
+
+        raw = MagicMock()
+        conn = PostgresConnection(raw)
+        conn.executescript("CREATE TABLE t (id INTEGER);")
+        raw.cursor.return_value.execute.assert_called_once_with(
+            "CREATE TABLE t (id INTEGER);"
+        )
+        raw.commit.assert_called_once()
 
 
 # ------------------------------------------------------------------

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -196,9 +196,11 @@ class TestRecordMigration:
         mock_conn = MagicMock()
         _record_migration(mock_conn, 5, "test_mig")
         mock_conn.execute.assert_called_once_with(
-            "INSERT INTO schema_migrations (version, name) VALUES (?, ?)",
+            "INSERT INTO schema_migrations (version, name) VALUES (?, ?) "
+            "RETURNING version",
             (5, "test_mig"),
         )
+        mock_conn.execute.return_value.fetchall.assert_called_once()
         mock_conn.commit.assert_called_once()
 
 

--- a/tests/test_pending_actions.py
+++ b/tests/test_pending_actions.py
@@ -1,0 +1,394 @@
+"""Tests for grocery_butler.pending_actions (staged-action audit log)."""
+
+from __future__ import annotations
+
+import datetime as dt
+import os
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from grocery_butler.db import get_connection, init_db
+from grocery_butler.db.adapter import IntegrityError
+from grocery_butler.db.migrate import migrate
+from grocery_butler.models import PendingAction, PendingActionStatus
+from grocery_butler.pending_actions import PendingActionsStore
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _in_five_minutes() -> dt.datetime:
+    return dt.datetime.now(dt.UTC) + dt.timedelta(minutes=5)
+
+
+def _payload() -> dict[str, Any]:
+    return {"cart": [{"item": "milk", "qty": 2}], "total": "12.50"}
+
+
+@pytest.fixture
+def db_path(tmp_path: Path) -> str:
+    path = str(tmp_path / "test.db")
+    init_db(path)
+    return path
+
+
+@pytest.fixture
+def store(db_path: str) -> PendingActionsStore:
+    return PendingActionsStore(db_path)
+
+
+class TestMigration:
+    """The pending_actions migration applies via the standard runner."""
+
+    def test_creates_pending_actions_table(self, db_path: str) -> None:
+        """Test init_db creates the pending_actions table."""
+        conn = get_connection(db_path)
+        try:
+            cursor = conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name='pending_actions'"
+            )
+            row = cursor.fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+
+    def test_creates_status_expiry_index(self, db_path: str) -> None:
+        """Test the (status, expires_at) index exists."""
+        conn = get_connection(db_path)
+        try:
+            cursor = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' "
+                "AND name='idx_pending_actions_status'"
+            )
+            row = cursor.fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+
+    def test_migration_recorded_and_idempotent(self, db_path: str) -> None:
+        """Test the migration is tracked and safe to re-run."""
+        assert migrate(db_path) == 0  # already applied by init_db
+        conn = get_connection(db_path)
+        try:
+            cursor = conn.execute(
+                "SELECT name FROM schema_migrations WHERE name='pending_actions'"
+            )
+            row = cursor.fetchone()
+        finally:
+            conn.close()
+        assert row is not None
+
+
+class TestInsertPendingAction:
+    """Tests for PendingActionsStore.insert_pending_action."""
+
+    def test_insert_returns_pending_action(self, store: PendingActionsStore) -> None:
+        """Test insert returns the stored row as a model."""
+        expires = _in_five_minutes()
+        action = store.insert_pending_action(
+            action_id="a1",
+            kind="safeway_order_submit",
+            payload=_payload(),
+            expires_at=expires,
+        )
+        assert isinstance(action, PendingAction)
+        assert action.action_id == "a1"
+        assert action.kind == "safeway_order_submit"
+        assert action.status is PendingActionStatus.PENDING
+        assert action.resolved_at is None
+
+    def test_insert_defaults_requester_to_rubotpaul(
+        self, store: PendingActionsStore
+    ) -> None:
+        """Test the requester column defaults to 'rubotpaul'."""
+        action = store.insert_pending_action(
+            action_id="a2",
+            kind="brands_set",
+            payload={},
+            expires_at=_in_five_minutes(),
+        )
+        assert action.requester == "rubotpaul"
+
+    def test_insert_honors_custom_requester(self, store: PendingActionsStore) -> None:
+        """Test a custom requester value is persisted."""
+        action = store.insert_pending_action(
+            action_id="a3",
+            kind="brands_set",
+            payload={},
+            expires_at=_in_five_minutes(),
+            requester="webui",
+        )
+        assert action.requester == "webui"
+
+    def test_insert_sets_created_at(self, store: PendingActionsStore) -> None:
+        """Test created_at is stamped by the database."""
+        action = store.insert_pending_action(
+            action_id="a4",
+            kind="preferences_set",
+            payload={},
+            expires_at=_in_five_minutes(),
+        )
+        assert action.created_at is not None
+
+    def test_payload_round_trips_nested_structure(
+        self, store: PendingActionsStore
+    ) -> None:
+        """Test a nested JSON payload survives the write/read cycle."""
+        payload = _payload()
+        store.insert_pending_action(
+            action_id="a5",
+            kind="safeway_order_submit",
+            payload=payload,
+            expires_at=_in_five_minutes(),
+        )
+        fetched = store.get_pending_action("a5")
+        assert fetched is not None
+        assert fetched.payload == payload
+
+    def test_duplicate_action_id_raises_integrity_error(
+        self, store: PendingActionsStore
+    ) -> None:
+        """Test the primary key rejects duplicate action ids."""
+        store.insert_pending_action(
+            action_id="dup",
+            kind="brands_set",
+            payload={},
+            expires_at=_in_five_minutes(),
+        )
+        with pytest.raises(IntegrityError):
+            store.insert_pending_action(
+                action_id="dup",
+                kind="brands_set",
+                payload={},
+                expires_at=_in_five_minutes(),
+            )
+
+    def test_insert_raises_if_row_unreadable(
+        self, store: PendingActionsStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test a defensive error if the inserted row cannot be re-read."""
+        monkeypatch.setattr(store, "get_pending_action", lambda action_id: None)
+        with pytest.raises(RuntimeError, match="a6"):
+            store.insert_pending_action(
+                action_id="a6",
+                kind="brands_set",
+                payload={},
+                expires_at=_in_five_minutes(),
+            )
+
+
+class TestGetPendingAction:
+    """Tests for PendingActionsStore.get_pending_action."""
+
+    def test_missing_action_returns_none(self, store: PendingActionsStore) -> None:
+        """Test lookup of an unknown id returns None."""
+        assert store.get_pending_action("nope") is None
+
+    def test_returns_datetime_fields(self, store: PendingActionsStore) -> None:
+        """Test expires_at round-trips as a datetime."""
+        expires = _in_five_minutes()
+        store.insert_pending_action(
+            action_id="g1",
+            kind="brands_set",
+            payload={},
+            expires_at=expires,
+        )
+        fetched = store.get_pending_action("g1")
+        assert fetched is not None
+        assert isinstance(fetched.expires_at, dt.datetime)
+        assert fetched.expires_at == expires
+
+
+class TestStatusTransitions:
+    """Tests for the mark_pending_* transition functions."""
+
+    def _staged(self, store: PendingActionsStore, action_id: str) -> PendingAction:
+        return store.insert_pending_action(
+            action_id=action_id,
+            kind="safeway_order_submit",
+            payload=_payload(),
+            expires_at=_in_five_minutes(),
+        )
+
+    def test_mark_approved(self, store: PendingActionsStore) -> None:
+        """Test a pending action can be approved."""
+        self._staged(store, "t1")
+        assert store.mark_pending_approved("t1") is True
+        action = store.get_pending_action("t1")
+        assert action is not None
+        assert action.status is PendingActionStatus.APPROVED
+        assert action.resolved_at is not None
+
+    def test_mark_denied(self, store: PendingActionsStore) -> None:
+        """Test a pending action can be denied."""
+        self._staged(store, "t2")
+        assert store.mark_pending_denied("t2") is True
+        action = store.get_pending_action("t2")
+        assert action is not None
+        assert action.status is PendingActionStatus.DENIED
+        assert action.resolved_at is not None
+
+    def test_mark_expired(self, store: PendingActionsStore) -> None:
+        """Test a pending action can be expired."""
+        self._staged(store, "t3")
+        assert store.mark_pending_expired("t3") is True
+        action = store.get_pending_action("t3")
+        assert action is not None
+        assert action.status is PendingActionStatus.EXPIRED
+        assert action.resolved_at is not None
+
+    def test_approve_after_deny_fails(self, store: PendingActionsStore) -> None:
+        """Test a denied action cannot later be approved."""
+        self._staged(store, "t4")
+        store.mark_pending_denied("t4")
+        assert store.mark_pending_approved("t4") is False
+        action = store.get_pending_action("t4")
+        assert action is not None
+        assert action.status is PendingActionStatus.DENIED
+
+    def test_deny_after_approve_fails(self, store: PendingActionsStore) -> None:
+        """Test an approved action cannot later be denied."""
+        self._staged(store, "t5")
+        store.mark_pending_approved("t5")
+        assert store.mark_pending_denied("t5") is False
+        action = store.get_pending_action("t5")
+        assert action is not None
+        assert action.status is PendingActionStatus.APPROVED
+
+    def test_expire_after_approve_fails(self, store: PendingActionsStore) -> None:
+        """Test an approved action cannot later be expired."""
+        self._staged(store, "t6")
+        store.mark_pending_approved("t6")
+        assert store.mark_pending_expired("t6") is False
+
+    def test_double_approve_fails(self, store: PendingActionsStore) -> None:
+        """Test approving twice reports failure the second time."""
+        self._staged(store, "t7")
+        assert store.mark_pending_approved("t7") is True
+        assert store.mark_pending_approved("t7") is False
+
+    def test_transitions_on_missing_id_return_false(
+        self, store: PendingActionsStore
+    ) -> None:
+        """Test all transitions report failure for unknown ids."""
+        assert store.mark_pending_approved("ghost") is False
+        assert store.mark_pending_denied("ghost") is False
+        assert store.mark_pending_expired("ghost") is False
+
+
+class TestExpirySemantics:
+    """Tests for expiry deadline handling."""
+
+    def test_is_expired_false_before_deadline(self, store: PendingActionsStore) -> None:
+        """Test is_expired is False while the deadline is in the future."""
+        action = store.insert_pending_action(
+            action_id="e1",
+            kind="brands_set",
+            payload={},
+            expires_at=_in_five_minutes(),
+        )
+        assert action.is_expired() is False
+
+    def test_is_expired_true_after_deadline(self, store: PendingActionsStore) -> None:
+        """Test is_expired is True once the deadline has passed."""
+        past = dt.datetime.now(dt.UTC) - dt.timedelta(minutes=1)
+        action = store.insert_pending_action(
+            action_id="e2",
+            kind="brands_set",
+            payload={},
+            expires_at=past,
+        )
+        assert action.is_expired() is True
+
+    def test_is_expired_accepts_explicit_reference_time(self) -> None:
+        """Test is_expired compares against a caller-supplied clock."""
+        expires = dt.datetime(2026, 1, 1, 12, 0, tzinfo=dt.UTC)
+        action = PendingAction(
+            action_id="e3",
+            kind="brands_set",
+            payload={},
+            expires_at=expires,
+        )
+        before = dt.datetime(2026, 1, 1, 11, 59, tzinfo=dt.UTC)
+        after = dt.datetime(2026, 1, 1, 12, 1, tzinfo=dt.UTC)
+        assert action.is_expired(now=before) is False
+        assert action.is_expired(now=after) is True
+
+    def test_is_expired_handles_naive_expiry(self) -> None:
+        """Test a naive expires_at is treated as UTC."""
+        action = PendingAction(
+            action_id="e4",
+            kind="brands_set",
+            payload={},
+            expires_at=dt.datetime(2026, 1, 1, 12, 0),  # intentionally naive
+        )
+        after = dt.datetime(2026, 1, 1, 12, 1, tzinfo=dt.UTC)
+        assert action.is_expired(now=after) is True
+
+    def test_deadline_passing_does_not_change_status(
+        self, store: PendingActionsStore
+    ) -> None:
+        """Test rows stay 'pending' until explicitly marked expired."""
+        past = dt.datetime.now(dt.UTC) - dt.timedelta(minutes=1)
+        store.insert_pending_action(
+            action_id="e5",
+            kind="brands_set",
+            payload={},
+            expires_at=past,
+        )
+        action = store.get_pending_action("e5")
+        assert action is not None
+        assert action.status is PendingActionStatus.PENDING
+        assert action.is_expired() is True
+
+
+# ------------------------------------------------------------------
+# PostgreSQL integration tests (require a running Postgres instance)
+# ------------------------------------------------------------------
+
+_TEST_DB_URL = os.environ.get("TEST_DATABASE_URL", "")
+_skip_no_pg = pytest.mark.skipif(
+    not _TEST_DB_URL,
+    reason="TEST_DATABASE_URL not set — no Postgres server available",
+)
+
+
+@_skip_no_pg
+class TestPendingActionsPostgres:
+    """Integration tests against PostgreSQL.
+
+    Requires a running PostgreSQL instance. Set TEST_DATABASE_URL
+    to run: ``TEST_DATABASE_URL=postgresql://user:pass@localhost/test``.
+    """
+
+    @pytest.fixture
+    def pg_store(self) -> PendingActionsStore:
+        migrate(_TEST_DB_URL)
+        conn = get_connection(_TEST_DB_URL)
+        try:
+            conn.execute(
+                "DELETE FROM pending_actions WHERE requester = ?", ("pg-test",)
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        return PendingActionsStore(_TEST_DB_URL)
+
+    def test_full_lifecycle(self, pg_store: PendingActionsStore) -> None:
+        """Test insert, read, and transition round-trip on PostgreSQL."""
+        action = pg_store.insert_pending_action(
+            action_id="pg-1",
+            kind="safeway_order_submit",
+            payload=_payload(),
+            expires_at=_in_five_minutes(),
+            requester="pg-test",
+        )
+        assert action.status is PendingActionStatus.PENDING
+        assert action.payload == _payload()
+        assert pg_store.mark_pending_approved("pg-1") is True
+        assert pg_store.mark_pending_approved("pg-1") is False
+        fetched = pg_store.get_pending_action("pg-1")
+        assert fetched is not None
+        assert fetched.status is PendingActionStatus.APPROVED


### PR DESCRIPTION
## Summary

Part of the RubotPaul migration (issue #44). Adds the server-side staging + audit-log layer for destructive actions (Safeway order submissions, brand/preference changes), per `api-patches.md` and `PIVOT.md`.

- **Migration 004** (SQLite `004_pending_actions.sql` + PostgreSQL `004_pending_actions_pg.sql`): `pending_actions` table — `action_id` PK, `kind`, `payload` (JSONB on PG, JSON text on SQLite), `status` defaulting to `pending`, `requester` defaulting to `rubotpaul`, `expires_at`, `created_at`, `resolved_at` — plus an index on `(status, expires_at)`. Applies via the existing `python -m grocery_butler.db.migrate` runner and dual-dialect discovery.
- **`PendingAction` / `PendingActionStatus` models** with an `is_expired()` helper (naive timestamps from SQLite are treated as UTC).
- **`PendingActionsStore`** (connection-per-operation, same pattern as `RecipeStore`, works on both backends through the adapter layer): `insert_pending_action`, `get_pending_action`, `mark_pending_approved`, `mark_pending_denied`, `mark_pending_expired`. Transitions are guarded on `status = 'pending'` so an action resolves exactly once.

## Tests

- 25 new tests: migration application/idempotency, insert defaults + payload round-trip + duplicate-id `IntegrityError`, every status transition including double-resolution and unknown ids, and expiry semantics (deadline passing does not mutate status — callers mark expiry explicitly).
- PG integration test class runs in CI via `TEST_DATABASE_URL` (skips locally without a server).
- Full suite: 1025 passed. Coverage gate (90%+), ruff lint/format, mypy, bandit, radon, interrogate all green locally.

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)