### PR TITLE
feat: /api/v1 compute endpoints — meals/parse, shopping-list/preview, order/preview

### DIFF
--- a/grocery_butler/api.py
+++ b/grocery_butler/api.py
@@ -8,20 +8,38 @@ ships in the same Railway web process.
 
 from __future__ import annotations
 
+import os
+from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
-from flask import Blueprint, current_app, jsonify
+from flask import Blueprint, abort, current_app, jsonify, request
+from pydantic import ValidationError
 
 from grocery_butler.auth_middleware import require_bearer
+from grocery_butler.claude_utils import make_anthropic_client
+from grocery_butler.config import ConfigError, load_config
+from grocery_butler.consolidator import Consolidator
+from grocery_butler.meal_parser import MealParser
+from grocery_butler.models import ParsedMeal, ShoppingListItem
 from grocery_butler.pantry_manager import PantryManager
 from grocery_butler.recipe_store import RecipeStore
+from grocery_butler.safeway_pipeline import SafewayPipeline, SafewayPipelineError
 
 if TYPE_CHECKING:
     from flask import Response
+    from werkzeug.exceptions import HTTPException
 
-    from grocery_butler.models import BrandPreference, InventoryItem
+    from grocery_butler.models import BrandPreference, CartSummary, InventoryItem
 
 api_v1 = Blueprint("api_v1", __name__, url_prefix="/api/v1")
+
+
+@api_v1.errorhandler(400)
+@api_v1.errorhandler(401)
+@api_v1.errorhandler(404)
+def _json_http_error(exc: HTTPException) -> tuple[Response, int]:
+    """Render blueprint HTTP errors as JSON instead of Flask's HTML."""
+    return jsonify(error=exc.description), exc.code or 500
 
 
 def _pantry_manager() -> PantryManager:
@@ -32,6 +50,49 @@ def _pantry_manager() -> PantryManager:
 def _recipe_store() -> RecipeStore:
     """Return a RecipeStore bound to the app's database."""
     return RecipeStore(current_app.config["DATABASE_PATH"])
+
+
+def _anthropic_client() -> Any | None:
+    """Return an Anthropic client from the environment, or None.
+
+    Without a key the Claude-backed pipelines fall back to their
+    pure-Python paths (stored recipes, simple consolidation).
+    """
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "")
+    if not api_key:
+        return None
+    return make_anthropic_client(api_key)
+
+
+def _meal_parser() -> MealParser:
+    """Return a MealParser wired to the app's database and Claude."""
+    return MealParser(_recipe_store(), _anthropic_client())
+
+
+def _consolidator() -> Consolidator:
+    """Return a Consolidator wired to Claude when available."""
+    return Consolidator(anthropic_client=_anthropic_client())
+
+
+def _safeway_pipeline() -> SafewayPipeline:
+    """Return a SafewayPipeline for the app's database.
+
+    Raises:
+        ConfigError: If required environment configuration is missing.
+        SafewayPipelineError: If Safeway credentials are missing.
+    """
+    config = load_config()
+    return SafewayPipeline(
+        config, current_app.config["DATABASE_PATH"], _anthropic_client()
+    )
+
+
+def _json_body() -> dict[str, Any]:
+    """Return the request's JSON object body, or abort 400."""
+    body = request.get_json(silent=True)
+    if not isinstance(body, dict):
+        abort(400, description="request body must be a JSON object")
+    return body
 
 
 # ---------------------------------------------------------------------------
@@ -107,3 +168,97 @@ def get_restock() -> Response:
     require_bearer()
     items = _pantry_manager().get_restock_queue()
     return jsonify(items=[_item(i) for i in items])
+
+
+# ---------------------------------------------------------------------------
+# Compute endpoints (read-only, no writes)
+# ---------------------------------------------------------------------------
+
+
+def _split_meal_names(text: str) -> list[str]:
+    """Split free text into meal names on newlines and commas."""
+    return [
+        name.strip()
+        for line in text.split("\n")
+        for name in line.split(",")
+        if name.strip()
+    ]
+
+
+def _parse_meal_payloads(raw_meals: Any) -> list[ParsedMeal]:
+    """Validate raw meal payloads into ParsedMeal models, or abort 400."""
+    if not isinstance(raw_meals, list):
+        abort(400, description="meals must be a list of meal objects")
+    try:
+        return [ParsedMeal.model_validate(meal) for meal in raw_meals]
+    except ValidationError as exc:
+        abort(400, description=f"invalid meal payload: {exc.error_count()} error(s)")
+
+
+def _parse_shopping_list_payloads(raw_items: Any) -> list[ShoppingListItem]:
+    """Validate raw shopping list payloads, or abort 400."""
+    if not isinstance(raw_items, list) or not raw_items:
+        abort(400, description="shopping_list required")
+    try:
+        return [ShoppingListItem.model_validate(item) for item in raw_items]
+    except ValidationError as exc:
+        abort(
+            400,
+            description=f"invalid shopping list item: {exc.error_count()} error(s)",
+        )
+
+
+def _cart_total(cart: CartSummary) -> Decimal:
+    """Sum item and restock costs without float artifacts."""
+    return sum(
+        (
+            Decimal(str(cart_item.estimated_cost))
+            for cart_item in [*cart.items, *cart.restock_items]
+        ),
+        Decimal("0"),
+    )
+
+
+@api_v1.post("/meals/parse")
+def post_meals_parse() -> Response:
+    """Parse free-text meal names into structured ingredient lists."""
+    require_bearer()
+    text = str(_json_body().get("text", "")).strip()
+    if not text:
+        abort(400, description="text required")
+    meals = _meal_parser().parse_meals(_split_meal_names(text))
+    return jsonify(meals=[meal.model_dump(mode="json") for meal in meals])
+
+
+@api_v1.post("/shopping-list/preview")
+def post_shopping_list_preview() -> Response:
+    """Consolidate meals into a shopping list without persisting anything."""
+    require_bearer()
+    body = _json_body()
+    meals = _parse_meal_payloads(body.get("meals", []))
+    include_restock = bool(body.get("include_restock", True))
+    restock_queue = _pantry_manager().get_restock_queue() if include_restock else []
+    items = _consolidator().consolidate(
+        meals=meals,
+        restock_queue=restock_queue,
+        pantry_staples=_recipe_store().get_pantry_staple_names(),
+    )
+    return jsonify(items=[item.model_dump(mode="json") for item in items])
+
+
+@api_v1.post("/order/preview")
+def post_order_preview() -> Response | tuple[Response, int]:
+    """Build a Safeway cart for review without submitting an order."""
+    require_bearer()
+    shopping_list = _parse_shopping_list_payloads(_json_body().get("shopping_list"))
+    try:
+        pipeline = _safeway_pipeline()
+    except (ConfigError, SafewayPipelineError) as exc:
+        return jsonify(error=f"safeway pipeline unavailable: {exc}"), 503
+    try:
+        cart = pipeline.build_cart_only(shopping_list)
+    except SafewayPipelineError as exc:
+        return jsonify(error=f"cart build failed: {exc}"), 503
+    finally:
+        pipeline.close()
+    return jsonify(cart=cart.model_dump(mode="json"), total=str(_cart_total(cart)))

--- a/tests/test_api_compute.py
+++ b/tests/test_api_compute.py
@@ -1,0 +1,479 @@
+"""Tests for the /api/v1 compute endpoints (grocery_butler.api blueprint).
+
+Covers POST /api/v1/meals/parse, /api/v1/shopping-list/preview, and
+/api/v1/order/preview. The Claude / Safeway pipelines are mocked — no
+live API calls happen here.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from flask import Flask
+    from flask.testing import FlaskClient
+
+from grocery_butler.app import create_app
+from grocery_butler.auth_middleware import SECRET_ENV_VAR, mint_token
+from grocery_butler.models import (
+    CartItem,
+    CartSummary,
+    FulfillmentType,
+    Ingredient,
+    IngredientCategory,
+    InventoryItem,
+    InventoryStatus,
+    ParsedMeal,
+    SafewayProduct,
+    ShoppingListItem,
+    Unit,
+)
+from grocery_butler.pantry_manager import PantryManager
+from grocery_butler.recipe_store import RecipeStore
+from grocery_butler.safeway_pipeline import SafewayPipelineError
+
+TEST_SECRET = "test-shared-secret"
+SECRET_ENV = {SECRET_ENV_VAR: TEST_SECRET}
+
+COMPUTE_ENDPOINTS = [
+    "/api/v1/meals/parse",
+    "/api/v1/shopping-list/preview",
+    "/api/v1/order/preview",
+]
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> str:
+    """Return a temporary database path for test isolation."""
+    return str(tmp_path / "test_api_compute.db")
+
+
+@pytest.fixture()
+def app(db_path: str) -> Flask:
+    """Create a Flask test app with a temporary database."""
+    application = create_app(db_path=db_path)
+    application.config["TESTING"] = True
+    return application
+
+
+@pytest.fixture()
+def client(app: Flask) -> FlaskClient:
+    """Return a Flask test client."""
+    return app.test_client()
+
+
+@pytest.fixture()
+def pantry_mgr(db_path: str) -> PantryManager:
+    """Return a PantryManager bound to the test database."""
+    return PantryManager(db_path)
+
+
+@pytest.fixture()
+def recipe_store(db_path: str) -> RecipeStore:
+    """Return a RecipeStore bound to the test database."""
+    return RecipeStore(db_path)
+
+
+@pytest.fixture()
+def auth_headers() -> dict[str, str]:
+    """Return a valid Authorization header minted with the test secret."""
+    with patch.dict(os.environ, SECRET_ENV):
+        token = mint_token("rubotpaul")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _make_meal(name: str = "test pasta") -> ParsedMeal:
+    """Return a ParsedMeal with one purchase item."""
+    return ParsedMeal(
+        name=name,
+        servings=4,
+        known_recipe=True,
+        needs_confirmation=False,
+        purchase_items=[
+            Ingredient(
+                ingredient="pasta",
+                quantity=1.0,
+                unit="lb",
+                category=IngredientCategory.PANTRY_DRY,
+            ),
+        ],
+        pantry_items=[],
+    )
+
+
+def _make_shopping_item(ingredient: str = "pasta") -> ShoppingListItem:
+    """Return a ShoppingListItem for order previews."""
+    return ShoppingListItem(
+        ingredient=ingredient,
+        quantity=1.0,
+        unit=Unit.LB,
+        category=IngredientCategory.PANTRY_DRY,
+        search_term=ingredient,
+        from_meals=["test pasta"],
+    )
+
+
+def _make_cart_item(ingredient: str, cost: float) -> CartItem:
+    """Return a CartItem with the given estimated cost."""
+    return CartItem(
+        shopping_list_item=_make_shopping_item(ingredient),
+        safeway_product=SafewayProduct(
+            product_id=f"prod-{ingredient}",
+            name=f"Brand {ingredient}",
+            price=cost,
+            size="1 lb",
+        ),
+        quantity_to_order=1,
+        estimated_cost=cost,
+    )
+
+
+def _make_cart(costs: dict[str, float]) -> CartSummary:
+    """Return a CartSummary with one item per (ingredient, cost) pair."""
+    items = [_make_cart_item(name, cost) for name, cost in costs.items()]
+    return CartSummary(
+        items=items,
+        failed_items=[],
+        substituted_items=[],
+        restock_items=[],
+        subtotal=sum(costs.values()),
+        fulfillment_options=[],
+        recommended_fulfillment=FulfillmentType.PICKUP,
+        estimated_total=sum(costs.values()),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Auth: every compute endpoint rejects unauthenticated requests, with JSON
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, SECRET_ENV)
+class TestAuthRequired:
+    """All compute endpoints must reject requests without a valid bearer."""
+
+    @pytest.mark.parametrize("path", COMPUTE_ENDPOINTS)
+    def test_missing_bearer_returns_401(self, client: FlaskClient, path: str) -> None:
+        """Requests without an Authorization header get 401."""
+        response = client.post(path, json={})
+        assert response.status_code == 401
+
+    @pytest.mark.parametrize("path", COMPUTE_ENDPOINTS)
+    def test_garbage_bearer_returns_401(self, client: FlaskClient, path: str) -> None:
+        """Requests with an invalid token get 401."""
+        response = client.post(
+            path, json={}, headers={"Authorization": "Bearer not-a-real-token"}
+        )
+        assert response.status_code == 401
+
+    @pytest.mark.parametrize("path", COMPUTE_ENDPOINTS)
+    def test_401_body_is_json(self, client: FlaskClient, path: str) -> None:
+        """API auth failures return a JSON error body, not HTML."""
+        response = client.post(path, json={})
+        assert response.content_type.startswith("application/json")
+        assert "error" in response.get_json()
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/meals/parse
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, SECRET_ENV)
+class TestMealsParse:
+    """POST /api/v1/meals/parse."""
+
+    @pytest.mark.parametrize("body", [{}, {"text": ""}, {"text": "   "}])
+    def test_empty_text_returns_400(
+        self, client: FlaskClient, auth_headers: dict[str, str], body: dict[str, str]
+    ) -> None:
+        """Missing or blank text is a 400 with a JSON error."""
+        response = client.post("/api/v1/meals/parse", json=body, headers=auth_headers)
+        assert response.status_code == 400
+        assert "error" in response.get_json()
+
+    def test_non_object_body_returns_400(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """A non-object JSON body is a 400."""
+        response = client.post(
+            "/api/v1/meals/parse", json=["tacos"], headers=auth_headers
+        )
+        assert response.status_code == 400
+
+    def test_parses_comma_and_newline_separated_meals(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """Meal names split on commas and newlines reach parse_meals."""
+        parser = MagicMock()
+        parser.parse_meals.return_value = [_make_meal("tacos"), _make_meal("pasta")]
+        with patch("grocery_butler.api._meal_parser", return_value=parser):
+            response = client.post(
+                "/api/v1/meals/parse",
+                json={"text": "tacos, pasta\nchili"},
+                headers=auth_headers,
+            )
+        assert response.status_code == 200
+        parser.parse_meals.assert_called_once_with(["tacos", "pasta", "chili"])
+
+    def test_serializes_parsed_meals(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """The parsed meals come back JSON-serialized."""
+        parser = MagicMock()
+        parser.parse_meals.return_value = [_make_meal("tacos")]
+        with patch("grocery_butler.api._meal_parser", return_value=parser):
+            response = client.post(
+                "/api/v1/meals/parse", json={"text": "tacos"}, headers=auth_headers
+            )
+        assert response.status_code == 200
+        meals = response.get_json()["meals"]
+        assert len(meals) == 1
+        assert meals[0]["name"] == "tacos"
+        assert meals[0]["purchase_items"][0]["ingredient"] == "pasta"
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/shopping-list/preview
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, SECRET_ENV)
+class TestShoppingListPreview:
+    """POST /api/v1/shopping-list/preview."""
+
+    def test_invalid_meals_returns_400(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """Meals that fail ParsedMeal validation are a 400."""
+        response = client.post(
+            "/api/v1/shopping-list/preview",
+            json={"meals": [{"name": "incomplete"}]},
+            headers=auth_headers,
+        )
+        assert response.status_code == 400
+        assert "error" in response.get_json()
+
+    def test_meals_must_be_a_list(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """A non-list meals field is a 400."""
+        response = client.post(
+            "/api/v1/shopping-list/preview",
+            json={"meals": "tacos"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 400
+
+    def test_consolidates_with_restock_and_staples(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        pantry_mgr: PantryManager,
+        recipe_store: RecipeStore,
+    ) -> None:
+        """The consolidator gets parsed meals, restock queue, and staples."""
+        pantry_mgr.add_item(
+            InventoryItem(
+                ingredient="milk",
+                display_name="Milk",
+                category=IngredientCategory.DAIRY,
+                status=InventoryStatus.ON_HAND,
+            )
+        )
+        pantry_mgr.update_status("milk", InventoryStatus.OUT)
+        recipe_store.add_pantry_staple("saffron", IngredientCategory.PANTRY_DRY.value)
+
+        consolidator = MagicMock()
+        consolidator.consolidate.return_value = [_make_shopping_item()]
+        meal = _make_meal("tacos")
+        with patch("grocery_butler.api._consolidator", return_value=consolidator):
+            response = client.post(
+                "/api/v1/shopping-list/preview",
+                json={"meals": [meal.model_dump(mode="json")]},
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 200
+        kwargs = consolidator.consolidate.call_args.kwargs
+        assert kwargs["meals"] == [meal]
+        assert [i.ingredient for i in kwargs["restock_queue"]] == ["milk"]
+        assert "saffron" in kwargs["pantry_staples"]
+        items = response.get_json()["items"]
+        assert len(items) == 1
+        assert items[0]["ingredient"] == "pasta"
+
+    def test_include_restock_false_skips_restock_queue(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        pantry_mgr: PantryManager,
+    ) -> None:
+        """include_restock=false keeps the restock queue out of the call."""
+        pantry_mgr.add_item(
+            InventoryItem(
+                ingredient="milk",
+                display_name="Milk",
+                category=IngredientCategory.DAIRY,
+                status=InventoryStatus.ON_HAND,
+            )
+        )
+        pantry_mgr.update_status("milk", InventoryStatus.OUT)
+
+        consolidator = MagicMock()
+        consolidator.consolidate.return_value = []
+        with patch("grocery_butler.api._consolidator", return_value=consolidator):
+            response = client.post(
+                "/api/v1/shopping-list/preview",
+                json={
+                    "meals": [_make_meal().model_dump(mode="json")],
+                    "include_restock": False,
+                },
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 200
+        assert consolidator.consolidate.call_args.kwargs["restock_queue"] == []
+
+
+# ---------------------------------------------------------------------------
+# POST /api/v1/order/preview
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, SECRET_ENV)
+class TestOrderPreview:
+    """POST /api/v1/order/preview."""
+
+    @pytest.mark.parametrize("body", [{}, {"shopping_list": []}])
+    def test_empty_shopping_list_returns_400(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        body: dict[str, object],
+    ) -> None:
+        """A missing or empty shopping_list is a 400."""
+        response = client.post("/api/v1/order/preview", json=body, headers=auth_headers)
+        assert response.status_code == 400
+        assert "error" in response.get_json()
+
+    def test_invalid_shopping_list_item_returns_400(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """Items that fail ShoppingListItem validation are a 400."""
+        response = client.post(
+            "/api/v1/order/preview",
+            json={"shopping_list": [{"ingredient": "pasta"}]},
+            headers=auth_headers,
+        )
+        assert response.status_code == 400
+
+    def test_builds_cart_and_returns_decimal_safe_total(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """0.1 + 0.2 comes back as exactly "0.3", not a float artifact."""
+        pipeline = MagicMock()
+        pipeline.build_cart_only.return_value = _make_cart({"pasta": 0.1, "beans": 0.2})
+        item = _make_shopping_item()
+        with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
+            response = client.post(
+                "/api/v1/order/preview",
+                json={"shopping_list": [item.model_dump(mode="json")]},
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 200
+        pipeline.build_cart_only.assert_called_once_with([item])
+        pipeline.close.assert_called_once_with()
+        body = response.get_json()
+        assert body["total"] == "0.3"
+        assert len(body["cart"]["items"]) == 2
+
+    def test_restock_items_count_toward_total(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """Restock cart items are part of the Decimal-safe total."""
+        cart = _make_cart({"pasta": 1.25})
+        cart = cart.model_copy(
+            update={"restock_items": [_make_cart_item("milk", 2.50)]}
+        )
+        pipeline = MagicMock()
+        pipeline.build_cart_only.return_value = cart
+        with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
+            response = client.post(
+                "/api/v1/order/preview",
+                json={"shopping_list": [_make_shopping_item().model_dump(mode="json")]},
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 200
+        assert response.get_json()["total"] == "3.75"
+
+    def test_pipeline_error_returns_503(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """Safeway pipeline failures surface as a JSON 503."""
+        with patch(
+            "grocery_butler.api._safeway_pipeline",
+            side_effect=SafewayPipelineError("no credentials"),
+        ):
+            response = client.post(
+                "/api/v1/order/preview",
+                json={"shopping_list": [_make_shopping_item().model_dump(mode="json")]},
+                headers=auth_headers,
+            )
+        assert response.status_code == 503
+        assert "error" in response.get_json()
+
+    def test_pipeline_closed_even_when_build_fails(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """The Safeway client is cleaned up when cart building raises."""
+        pipeline = MagicMock()
+        pipeline.build_cart_only.side_effect = SafewayPipelineError("auth failed")
+        with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
+            response = client.post(
+                "/api/v1/order/preview",
+                json={"shopping_list": [_make_shopping_item().model_dump(mode="json")]},
+                headers=auth_headers,
+            )
+        assert response.status_code == 503
+        pipeline.close.assert_called_once_with()
+
+
+# ---------------------------------------------------------------------------
+# Anthropic client helper
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicClientHelper:
+    """grocery_butler.api._anthropic_client."""
+
+    def test_returns_none_without_api_key(self) -> None:
+        """No ANTHROPIC_API_KEY means no client (pure-Python fallbacks)."""
+        from grocery_butler.api import _anthropic_client
+
+        with patch.dict(os.environ, {"ANTHROPIC_API_KEY": ""}):
+            assert _anthropic_client() is None
+
+    def test_builds_client_from_env_key(self) -> None:
+        """A configured key is passed through to make_anthropic_client."""
+        from grocery_butler import api
+
+        with (
+            patch.dict(os.environ, {"ANTHROPIC_API_KEY": "sk-test"}),
+            patch.object(api, "make_anthropic_client") as factory,
+        ):
+            factory.return_value = object()
+            assert api._anthropic_client() is factory.return_value
+        factory.assert_called_once_with("sk-test")


### PR DESCRIPTION
## Summary

Part of the RubotPaul migration. Adds the three read-only compute endpoints to the `api_v1` blueprint so RubotPaul makes one HTTP call per pipeline instead of orchestrating them token-by-token:

- **`POST /api/v1/meals/parse`** `{text}` — splits meal names on commas/newlines, runs the existing `MealParser`, returns serialized `ParsedMeal`s. 400 on empty/missing text.
- **`POST /api/v1/shopping-list/preview`** `{meals, include_restock=true}` — validates `ParsedMeal` payloads, runs the existing `Consolidator` against the restock queue (when `include_restock`) and pantry staples. 400 on invalid meals.
- **`POST /api/v1/order/preview`** `{shopping_list}` — builds a cart via `SafewayPipeline.build_cart_only` (never submits), returns the serialized `CartSummary` plus a **Decimal-safe string total** (no float artifacts: 0.1 + 0.2 → `"0.3"`). 400 on empty/invalid list, 503 when Safeway/config is unavailable; the Safeway client is closed even on failure.

Also fixes the quirk flagged in #45: a blueprint-scoped JSON error handler so 400/401/404 inside `/api/v1` return JSON, not Flask's HTML error page.

## Test plan

- 28 new tests in `tests/test_api_compute.py`, pipelines fully mocked — no live Claude/Safeway calls: call-arg verification for all three pipelines, Decimal edge case (0.1+0.2), restock-items-in-total, 400s, 401s (now JSON), 503s, cleanup-on-failure, and the `_anthropic_client` env helper.
- Full suite: 1086 passed, coverage 93.25% (gate 90%).
- `./scripts/check-all.sh`: 7/7 green (format, lint, mypy, complexity, security, tests, coverage).

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)