### PR TITLE
feat: /api/v1 low-stakes write endpoints — stock, restock/clear, recipes save/delete

### DIFF
--- a/grocery_butler/api.py
+++ b/grocery_butler/api.py
@@ -19,8 +19,16 @@ from grocery_butler.auth_middleware import require_bearer
 from grocery_butler.claude_utils import make_anthropic_client
 from grocery_butler.config import ConfigError, load_config
 from grocery_butler.consolidator import Consolidator
+from grocery_butler.db.adapter import IntegrityError
 from grocery_butler.meal_parser import MealParser
-from grocery_butler.models import ParsedMeal, ShoppingListItem
+from grocery_butler.models import (
+    Ingredient,
+    IngredientCategory,
+    InventoryItem,
+    InventoryStatus,
+    ParsedMeal,
+    ShoppingListItem,
+)
 from grocery_butler.pantry_manager import PantryManager
 from grocery_butler.recipe_store import RecipeStore
 from grocery_butler.safeway_pipeline import SafewayPipeline, SafewayPipelineError
@@ -29,7 +37,7 @@ if TYPE_CHECKING:
     from flask import Response
     from werkzeug.exceptions import HTTPException
 
-    from grocery_butler.models import BrandPreference, CartSummary, InventoryItem
+    from grocery_butler.models import BrandPreference, CartSummary
 
 api_v1 = Blueprint("api_v1", __name__, url_prefix="/api/v1")
 
@@ -262,3 +270,127 @@ def post_order_preview() -> Response | tuple[Response, int]:
     finally:
         pipeline.close()
     return jsonify(cart=cart.model_dump(mode="json"), total=str(_cart_total(cart)))
+
+
+# ---------------------------------------------------------------------------
+# Low-stakes write endpoints (immediate execution, no confirmation staging)
+# ---------------------------------------------------------------------------
+
+# RubotPaul speaks in/out/low/good; the store models on_hand/low/out.
+_STATUS_TOKENS: dict[str, InventoryStatus] = {
+    "in": InventoryStatus.ON_HAND,
+    "good": InventoryStatus.ON_HAND,
+    "low": InventoryStatus.LOW,
+    "out": InventoryStatus.OUT,
+}
+
+
+def _required_text(body: dict[str, Any], key: str, message: str) -> str:
+    """Return a non-empty stripped string field from the body, or abort 400."""
+    value = body.get(key)
+    if not isinstance(value, str) or not value.strip():
+        abort(400, description=message)
+    return value.strip()
+
+
+def _parse_ingredient_payloads(raw_ingredients: Any) -> list[Ingredient]:
+    """Validate raw ingredient payloads into Ingredient models, or abort 400."""
+    if not isinstance(raw_ingredients, list) or not raw_ingredients:
+        abort(400, description="name and ingredients required")
+    try:
+        return [Ingredient.model_validate(item) for item in raw_ingredients]
+    except ValidationError as exc:
+        abort(400, description=f"invalid ingredient: {exc.error_count()} error(s)")
+
+
+def _parse_servings(body: dict[str, Any]) -> int:
+    """Return the optional servings override (default 4), or abort 400."""
+    servings = body.get("servings", 4)
+    if isinstance(servings, bool) or not isinstance(servings, int) or servings < 1:
+        abort(400, description="servings must be a positive integer")
+    return servings
+
+
+@api_v1.post("/stock/update")
+def post_stock_update() -> Response:
+    """Set a tracked item's stock status; writes immediately."""
+    require_bearer()
+    body = _json_body()
+    status = body.get("status")
+    if not isinstance(status, str) or status not in _STATUS_TOKENS:
+        abort(400, description="status must be one of in/out/low/good")
+    item = _required_text(body, "item", "item required")
+    manager = _pantry_manager()
+    if manager.get_item(item) is None:
+        abort(404, description="item not tracked")
+    manager.update_status(item, _STATUS_TOKENS[status])
+    updated = manager.get_item(item)
+    if updated is None:  # pragma: no cover - item removed mid-request
+        abort(404, description="item not tracked")
+    return jsonify(_item(updated))
+
+
+@api_v1.post("/stock/add")
+def post_stock_add() -> tuple[Response, int]:
+    """Start tracking a new inventory item; writes immediately."""
+    require_bearer()
+    body = _json_body()
+    name = _required_text(body, "item", "item and category required")
+    raw_category = _required_text(body, "category", "item and category required")
+    try:
+        category = IngredientCategory(raw_category)
+    except ValueError:
+        abort(400, description="unknown category")
+    manager = _pantry_manager()
+    try:
+        manager.add_item(
+            InventoryItem(ingredient=name, display_name=name, category=category)
+        )
+    except IntegrityError:
+        abort(409, description="item already tracked")
+    created = manager.get_item(name)
+    if created is None:  # pragma: no cover - item removed mid-request
+        abort(404, description="item not tracked")
+    return jsonify(_item(created)), 201
+
+
+@api_v1.post("/restock/clear")
+def post_restock_clear() -> Response:
+    """Move every low/out item back to on_hand; writes immediately."""
+    require_bearer()
+    cleared = _pantry_manager().clear_restock_queue()
+    return jsonify(ok=True, cleared=cleared)
+
+
+@api_v1.post("/recipes/save")
+def post_recipes_save() -> tuple[Response, int]:
+    """Save a new recipe; 409 if the name is already taken."""
+    require_bearer()
+    body = _json_body()
+    name = _required_text(body, "name", "name and ingredients required")
+    ingredients = _parse_ingredient_payloads(body.get("ingredients"))
+    servings = _parse_servings(body)
+    store = _recipe_store()
+    if store.get_recipe(name) is not None:
+        abort(409, description="recipe with that name exists")
+    meal = ParsedMeal(
+        name=name,
+        servings=servings,
+        known_recipe=True,
+        needs_confirmation=False,
+        purchase_items=[i for i in ingredients if not i.is_pantry_item],
+        pantry_items=[i for i in ingredients if i.is_pantry_item],
+    )
+    recipe_id = store.save_recipe(meal)
+    return jsonify(id=recipe_id, **meal.model_dump(mode="json")), 201
+
+
+@api_v1.delete("/recipes/<int:recipe_id>")
+def delete_recipe(recipe_id: int) -> tuple[str, int]:
+    """Delete a recipe by id; 404 if unknown."""
+    require_bearer()
+    store = _recipe_store()
+    if store.get_recipe_by_id(recipe_id) is None:
+        abort(404, description="recipe not found")
+    store.delete_recipe(recipe_id)
+    return "", 204

--- a/tests/test_api_writes.py
+++ b/tests/test_api_writes.py
@@ -1,0 +1,507 @@
+"""Tests for the /api/v1 low-stakes write endpoints (grocery_butler.api)."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from flask import Flask
+    from flask.testing import FlaskClient
+
+from grocery_butler.app import create_app
+from grocery_butler.auth_middleware import SECRET_ENV_VAR, mint_token
+from grocery_butler.models import (
+    Ingredient,
+    IngredientCategory,
+    InventoryItem,
+    InventoryStatus,
+    ParsedMeal,
+)
+from grocery_butler.pantry_manager import PantryManager
+from grocery_butler.recipe_store import RecipeStore
+
+TEST_SECRET = "test-shared-secret"
+SECRET_ENV = {SECRET_ENV_VAR: TEST_SECRET}
+
+WRITE_ENDPOINTS = [
+    ("POST", "/api/v1/stock/update"),
+    ("POST", "/api/v1/stock/add"),
+    ("POST", "/api/v1/restock/clear"),
+    ("POST", "/api/v1/recipes/save"),
+    ("DELETE", "/api/v1/recipes/1"),
+]
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> str:
+    """Return a temporary database path for test isolation."""
+    return str(tmp_path / "test_api_writes.db")
+
+
+@pytest.fixture()
+def app(db_path: str) -> Flask:
+    """Create a Flask test app with a temporary database."""
+    application = create_app(db_path=db_path)
+    application.config["TESTING"] = True
+    return application
+
+
+@pytest.fixture()
+def client(app: Flask) -> FlaskClient:
+    """Return a Flask test client."""
+    return app.test_client()
+
+
+@pytest.fixture()
+def pantry_mgr(db_path: str) -> PantryManager:
+    """Return a PantryManager bound to the test database."""
+    return PantryManager(db_path)
+
+
+@pytest.fixture()
+def recipe_store(db_path: str) -> RecipeStore:
+    """Return a RecipeStore bound to the test database."""
+    return RecipeStore(db_path)
+
+
+@pytest.fixture()
+def auth_headers() -> dict[str, str]:
+    """Return a valid Authorization header minted with the test secret."""
+    with patch.dict(os.environ, SECRET_ENV):
+        token = mint_token("rubotpaul")
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture()
+def sample_item() -> InventoryItem:
+    """Return a sample InventoryItem for seeding."""
+    return InventoryItem(
+        ingredient="milk",
+        display_name="Milk",
+        category=IngredientCategory.DAIRY,
+        status=InventoryStatus.ON_HAND,
+    )
+
+
+@pytest.fixture()
+def sample_meal() -> ParsedMeal:
+    """Return a sample ParsedMeal for seeding."""
+    return ParsedMeal(
+        name="test pasta",
+        servings=4,
+        known_recipe=True,
+        needs_confirmation=False,
+        purchase_items=[
+            Ingredient(
+                ingredient="penne",
+                quantity=1.0,
+                unit="lb",
+                category=IngredientCategory.PANTRY_DRY,
+            )
+        ],
+        pantry_items=[],
+    )
+
+
+def _post(
+    client: FlaskClient,
+    path: str,
+    headers: dict[str, str],
+    body: dict[str, Any],
+) -> Any:
+    """POST a JSON body with auth headers."""
+    return client.post(path, json=body, headers=headers)
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("method", "path"), WRITE_ENDPOINTS)
+def test_write_endpoints_require_bearer(
+    client: FlaskClient, method: str, path: str
+) -> None:
+    """Every write endpoint returns 401 without a bearer token."""
+    with patch.dict(os.environ, SECRET_ENV):
+        response = client.open(path, method=method, json={})
+    assert response.status_code == 401
+    assert response.get_json() is not None
+
+
+# ---------------------------------------------------------------------------
+# POST /stock/update
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("token", "expected"),
+    [
+        ("in", InventoryStatus.ON_HAND),
+        ("good", InventoryStatus.ON_HAND),
+        ("low", InventoryStatus.LOW),
+        ("out", InventoryStatus.OUT),
+    ],
+)
+def test_stock_update_writes_status(
+    client: FlaskClient,
+    pantry_mgr: PantryManager,
+    auth_headers: dict[str, str],
+    sample_item: InventoryItem,
+    token: str,
+    expected: InventoryStatus,
+) -> None:
+    """Each accepted status token maps onto the stored InventoryStatus."""
+    pantry_mgr.add_item(sample_item)
+    with patch.dict(os.environ, SECRET_ENV):
+        response = _post(
+            client,
+            "/api/v1/stock/update",
+            auth_headers,
+            {"item": "Milk", "status": token},
+        )
+    assert response.status_code == 200
+    stored = pantry_mgr.get_item("milk")
+    assert stored is not None
+    assert stored.status is expected
+    assert response.get_json()["status"] == expected.value
+
+
+def test_stock_update_rejects_bad_status(
+    client: FlaskClient,
+    pantry_mgr: PantryManager,
+    auth_headers: dict[str, str],
+    sample_item: InventoryItem,
+) -> None:
+    """A status outside in/out/low/good is a 400 and writes nothing."""
+    pantry_mgr.add_item(sample_item)
+    with patch.dict(os.environ, SECRET_ENV):
+        response = _post(
+            client,
+            "/api/v1/stock/update",
+            auth_headers,
+            {"item": "milk", "status": "plentiful"},
+        )
+    assert response.status_code == 400
+    stored = pantry_mgr.get_item("milk")
+    assert stored is not None
+    assert stored.status is InventoryStatus.ON_HAND
+
+
+def test_stock_update_rejects_non_string_status(
+    client: FlaskClient, auth_headers: dict[str, str]
+) -> None:
+    """A non-string status is a 400, not a server error."""
+    with patch.dict(os.environ, SECRET_ENV):
+        response = _post(
+            client,
+            "/api/v1/stock/update",
+            auth_headers,
+            {"item": "milk", "status": ["out"]},
+        )
+    assert response.status_code == 400
+
+
+def test_stock_update_requires_item(
+    client: FlaskClient, auth_headers: dict[str, str]
+) -> None:
+    """A missing item is a 400."""
+    with patch.dict(os.environ, SECRET_ENV):
+        response = _post(
+            client, "/api/v1/stock/update", auth_headers, {"status": "out"}
+        )
+    assert response.status_code == 400
+
+
+def test_stock_update_unknown_item_404(
+    client: FlaskClient, auth_headers: dict[str, str]
+) -> None:
+    """Updating an untracked item is a JSON 404."""
+    with patch.dict(os.environ, SECRET_ENV):
+        response = _post(
+            client,
+            "/api/v1/stock/update",
+            auth_headers,
+            {"item": "caviar", "status": "out"},
+        )
+    assert response.status_code == 404
+    assert "error" in response.get_json()
+
+
+def test_stock_update_rejects_non_object_body(
+    client: FlaskClient, auth_headers: dict[str, str]
+) -> None:
+    """A non-object JSON body is a 400."""
+    with patch.dict(os.environ, SECRET_ENV):
+        response = client.post(
+            "/api/v1/stock/update", json=["milk"], headers=auth_headers
+        )
+    assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# POST /stock/add
+# ---------------------------------------------------------------------------
+
+
+def test_stock_add_creates_item(
+    client: FlaskClient, pantry_mgr: PantryManager, auth_headers: dict[str, str]
+) -> None:
+    """A valid add returns 201 and persists the item."""
+    with patch.dict(os.environ, SECRET_ENV):
+        response = _post(
+            client,
+            "/api/v1/stock/add",
+            auth_headers,
+            {"item": "Oat Milk", "category": "dairy"},
+        )
+    assert response.status_code == 201
+    stored = pantry_mgr.get_item("oat milk")
+    assert stored is not None
+    assert stored.category is IngredientCategory.DAIRY
+    payload = response.get_json()
+    assert payload["ingredient"] == "oat milk"
+    assert payload["display_name"] == "Oat Milk"
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {"category": "dairy"},
+        {"item": "oat milk"},
+        {"item": "", "category": "dairy"},
+        {"item": "oat milk", "category": ""},
+    ],
+)
+def test_stock_add_requires_item_and_category(
+    client: FlaskClient, auth_headers: dict[str, str], body: dict[str, Any]
+) -> None:
+    """Missing item or category is a 400."""
+    with patch.dict(os.environ, SECRET_ENV):
+        response = _post(client, "/api/v1/stock/add", auth_headers, body)
+    assert response.status_code == 400
+
+
+def test_stock_add_rejects_unknown_category(
+    client: FlaskClient, auth_headers: dict[str, str]
+) -> None:
+    """A category outside IngredientCategory is a 400."""
+    with patch.dict(os.environ, SECRET_ENV):
+        response = _post(
+            client,
+            "/api/v1/stock/add",
+            auth_headers,
+            {"item": "oat milk", "category": "cryptids"},
+        )
+    assert response.status_code == 400
+
+
+def test_stock_add_duplicate_conflict(
+    client: FlaskClient,
+    pantry_mgr: PantryManager,
+    auth_headers: dict[str, str],
+    sample_item: InventoryItem,
+) -> None:
+    """Adding an already-tracked ingredient is a 409."""
+    pantry_mgr.add_item(sample_item)
+    with patch.dict(os.environ, SECRET_ENV):
+        response = _post(
+            client,
+            "/api/v1/stock/add",
+            auth_headers,
+            {"item": "Milk", "category": "dairy"},
+        )
+    assert response.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# POST /restock/clear
+# ---------------------------------------------------------------------------
+
+
+def test_restock_clear_empties_queue(
+    client: FlaskClient,
+    pantry_mgr: PantryManager,
+    auth_headers: dict[str, str],
+    sample_item: InventoryItem,
+) -> None:
+    """Clearing the restock queue moves low/out items back to on_hand."""
+    pantry_mgr.add_item(sample_item)
+    pantry_mgr.update_status("milk", InventoryStatus.OUT)
+    assert pantry_mgr.get_restock_queue()
+    with patch.dict(os.environ, SECRET_ENV):
+        response = _post(client, "/api/v1/restock/clear", auth_headers, {})
+    assert response.status_code == 200
+    assert response.get_json()["ok"] is True
+    assert pantry_mgr.get_restock_queue() == []
+
+
+# ---------------------------------------------------------------------------
+# POST /recipes/save
+# ---------------------------------------------------------------------------
+
+
+def _recipe_body(**overrides: Any) -> dict[str, Any]:
+    """Return a valid recipes/save body, with optional overrides."""
+    body: dict[str, Any] = {
+        "name": "Veggie Chili",
+        "ingredients": [
+            {
+                "ingredient": "kidney beans",
+                "quantity": 2.0,
+                "unit": "can",
+                "category": "pantry_dry",
+            },
+            {
+                "ingredient": "salt",
+                "quantity": 1.0,
+                "unit": "tsp",
+                "category": "pantry_dry",
+                "is_pantry_item": True,
+            },
+        ],
+    }
+    body.update(overrides)
+    return body
+
+
+def test_recipes_save_persists_recipe(
+    client: FlaskClient, recipe_store: RecipeStore, auth_headers: dict[str, str]
+) -> None:
+    """A valid save returns 201 and persists purchase + pantry splits."""
+    with patch.dict(os.environ, SECRET_ENV):
+        response = _post(client, "/api/v1/recipes/save", auth_headers, _recipe_body())
+    assert response.status_code == 201
+    payload = response.get_json()
+    stored = recipe_store.get_recipe_by_id(payload["id"])
+    assert stored is not None
+    assert stored.name == "Veggie Chili"
+    assert [i.ingredient for i in stored.purchase_items] == ["kidney beans"]
+    assert [i.ingredient for i in stored.pantry_items] == ["salt"]
+
+
+def test_recipes_save_duplicate_conflict(
+    client: FlaskClient,
+    recipe_store: RecipeStore,
+    auth_headers: dict[str, str],
+    sample_meal: ParsedMeal,
+) -> None:
+    """Saving a recipe whose name already exists is a 409."""
+    recipe_store.save_recipe(sample_meal)
+    with patch.dict(os.environ, SECRET_ENV):
+        response = _post(
+            client,
+            "/api/v1/recipes/save",
+            auth_headers,
+            _recipe_body(name="Test Pasta"),
+        )
+    assert response.status_code == 409
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        {
+            "ingredients": [
+                {"ingredient": "x", "quantity": 1, "unit": "lb", "category": "other"}
+            ]
+        },
+        {"name": "Veggie Chili"},
+        {"name": "", "ingredients": []},
+        {"name": "Veggie Chili", "ingredients": []},
+    ],
+)
+def test_recipes_save_requires_name_and_ingredients(
+    client: FlaskClient, auth_headers: dict[str, str], body: dict[str, Any]
+) -> None:
+    """Missing name or ingredients is a 400."""
+    with patch.dict(os.environ, SECRET_ENV):
+        response = _post(client, "/api/v1/recipes/save", auth_headers, body)
+    assert response.status_code == 400
+
+
+@pytest.mark.parametrize(
+    "ingredients",
+    ["penne", [{"ingredient": "penne"}], [42]],
+)
+def test_recipes_save_rejects_invalid_ingredients(
+    client: FlaskClient, auth_headers: dict[str, str], ingredients: Any
+) -> None:
+    """Non-list or non-Ingredient payloads are a 400."""
+    with patch.dict(os.environ, SECRET_ENV):
+        response = _post(
+            client,
+            "/api/v1/recipes/save",
+            auth_headers,
+            _recipe_body(ingredients=ingredients),
+        )
+    assert response.status_code == 400
+
+
+@pytest.mark.parametrize("servings", ["four", 0, -2, True])
+def test_recipes_save_rejects_bad_servings(
+    client: FlaskClient, auth_headers: dict[str, str], servings: Any
+) -> None:
+    """A non-positive-int servings override is a 400."""
+    with patch.dict(os.environ, SECRET_ENV):
+        response = _post(
+            client,
+            "/api/v1/recipes/save",
+            auth_headers,
+            _recipe_body(servings=servings),
+        )
+    assert response.status_code == 400
+
+
+def test_recipes_save_honors_servings(
+    client: FlaskClient, recipe_store: RecipeStore, auth_headers: dict[str, str]
+) -> None:
+    """An explicit servings override is persisted."""
+    with patch.dict(os.environ, SECRET_ENV):
+        response = _post(
+            client, "/api/v1/recipes/save", auth_headers, _recipe_body(servings=6)
+        )
+    assert response.status_code == 201
+    stored = recipe_store.get_recipe_by_id(response.get_json()["id"])
+    assert stored is not None
+    assert stored.servings == 6
+
+
+# ---------------------------------------------------------------------------
+# DELETE /recipes/<id>
+# ---------------------------------------------------------------------------
+
+
+def test_recipes_delete_removes_recipe(
+    client: FlaskClient,
+    recipe_store: RecipeStore,
+    auth_headers: dict[str, str],
+    sample_meal: ParsedMeal,
+) -> None:
+    """Deleting an existing recipe returns 204 and removes it."""
+    recipe_id = recipe_store.save_recipe(sample_meal)
+    with patch.dict(os.environ, SECRET_ENV):
+        response = client.delete(f"/api/v1/recipes/{recipe_id}", headers=auth_headers)
+    assert response.status_code == 204
+    assert response.data == b""
+    assert recipe_store.get_recipe_by_id(recipe_id) is None
+
+
+def test_recipes_delete_unknown_404(
+    client: FlaskClient, auth_headers: dict[str, str]
+) -> None:
+    """Deleting an unknown recipe id is a JSON 404."""
+    with patch.dict(os.environ, SECRET_ENV):
+        response = client.delete("/api/v1/recipes/999", headers=auth_headers)
+    assert response.status_code == 404
+    assert "error" in response.get_json()


### PR DESCRIPTION
## Summary
- Five immediate-execution write endpoints on the `api_v1` blueprint (low-stakes per the kit's safety model — no confirmation staging; that's #48):
  - `POST /api/v1/stock/update` `{item, status}` — accepts RubotPaul's `in/out/low/good` tokens, mapped onto the store's `InventoryStatus` (`on_hand/low/out`); 400 on bad status or missing item, 404 on untracked item
  - `POST /api/v1/stock/add` `{item, category}` — 201; 400 on missing fields or unknown category; 409 on duplicate ingredient via the adapter's dual-backend `IntegrityError`
  - `POST /api/v1/restock/clear` — moves every low/out item back to on_hand; returns `{ok: true, cleared: n}`
  - `POST /api/v1/recipes/save` `{name, ingredients[, servings]}` — 201; ingredients validated as `Ingredient` models and split purchase/pantry on `is_pantry_item`; 409 on duplicate name
  - `DELETE /api/v1/recipes/<id>` — 204; 404 on unknown id
- All endpoints require the HMAC bearer; errors are JSON via the blueprint error handler from #53.

## Test plan
- [x] 38 new tests in `tests/test_api_writes.py`: DB-write verification on every happy path, all four status-token mappings (mutation target from the issue), bad status/missing field 400s, duplicate 409s, unknown 404s, non-object body 400, 401s without bearer on all five endpoints
- [x] `./scripts/check-all.sh` — 7/7 gates green locally, 1124 tests passed, coverage above the 90% gate

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)