### PR TITLE
feat: destructive endpoints with staged confirmation — order/submit, brands/set, preferences/set

### DIFF
--- a/grocery_butler/api.py
+++ b/grocery_butler/api.py
@@ -8,7 +8,10 @@ ships in the same Railway web process.
 
 from __future__ import annotations
 
+import dataclasses
+import datetime as dt
 import os
+import uuid
 from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
@@ -22,29 +25,40 @@ from grocery_butler.consolidator import Consolidator
 from grocery_butler.db.adapter import IntegrityError
 from grocery_butler.meal_parser import MealParser
 from grocery_butler.models import (
+    BrandPreference,
+    CartSummary,
     Ingredient,
     IngredientCategory,
     InventoryItem,
     InventoryStatus,
     ParsedMeal,
+    PendingActionStatus,
     ShoppingListItem,
 )
 from grocery_butler.pantry_manager import PantryManager
+from grocery_butler.pending_actions import PendingActionsStore
 from grocery_butler.recipe_store import RecipeStore
 from grocery_butler.safeway_pipeline import SafewayPipeline, SafewayPipelineError
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from flask import Response
     from werkzeug.exceptions import HTTPException
 
-    from grocery_butler.models import BrandPreference, CartSummary
+    from grocery_butler.models import PendingAction
 
 api_v1 = Blueprint("api_v1", __name__, url_prefix="/api/v1")
+
+#: How long a staged destructive action stays confirmable.
+CONFIRMATION_TTL = dt.timedelta(minutes=5)
 
 
 @api_v1.errorhandler(400)
 @api_v1.errorhandler(401)
 @api_v1.errorhandler(404)
+@api_v1.errorhandler(409)
+@api_v1.errorhandler(410)
 def _json_http_error(exc: HTTPException) -> tuple[Response, int]:
     """Render blueprint HTTP errors as JSON instead of Flask's HTML."""
     return jsonify(error=exc.description), exc.code or 500
@@ -394,3 +408,232 @@ def delete_recipe(recipe_id: int) -> tuple[str, int]:
         abort(404, description="recipe not found")
     store.delete_recipe(recipe_id)
     return "", 204
+
+
+# ---------------------------------------------------------------------------
+# Destructive endpoints (staged confirmation: draft -> confirm -> execute)
+#
+# The chat-reply confirmation pattern from PIVOT.md: these endpoints stage
+# a pending_actions row (the audit log) and return an action_id. RubotPaul
+# posts the draft to chat and calls /actions/confirm only after the user
+# replies "confirm". Nothing destructive happens at staging time.
+# ---------------------------------------------------------------------------
+
+
+def _pending_store() -> PendingActionsStore:
+    """Return a PendingActionsStore bound to the app's database."""
+    return PendingActionsStore(current_app.config["DATABASE_PATH"])
+
+
+def _stage_pending(kind: str, payload: dict[str, Any]) -> str:
+    """Stage a pending action with the standard TTL; return its action_id."""
+    action = _pending_store().insert_pending_action(
+        action_id=str(uuid.uuid4()),
+        kind=kind,
+        payload=payload,
+        expires_at=dt.datetime.now(dt.UTC) + CONFIRMATION_TTL,
+    )
+    return action.action_id
+
+
+def _parse_cart_payload(body: dict[str, Any]) -> CartSummary:
+    """Validate the request's cart into a CartSummary, or abort 400."""
+    raw_cart = body.get("cart")
+    if raw_cart is None:
+        abort(400, description="cart required")
+    try:
+        cart = CartSummary.model_validate(raw_cart)
+    except ValidationError as exc:
+        abort(400, description=f"invalid cart: {exc.error_count()} error(s)")
+    if not cart.items and not cart.restock_items:
+        abort(400, description="cart is empty — nothing to order")
+    return cart
+
+
+@api_v1.post("/order/submit")
+def post_order_submit() -> Response:
+    """Stage a Safeway order for confirmation. Never submits directly."""
+    require_bearer()
+    body = _json_body()
+    cart = _parse_cart_payload(body)
+    total = str(body.get("total") or _cart_total(cart))
+    action_id = _stage_pending(
+        "safeway_order_submit",
+        {"cart": cart.model_dump(mode="json"), "total": total},
+    )
+    item_count = len(cart.items) + len(cart.restock_items)
+    return jsonify(
+        status="pending_confirmation",
+        action_id=action_id,
+        message=(
+            f"Staged Safeway order ({item_count} items, ${total}). "
+            "Reply 'confirm' to submit."
+        ),
+    )
+
+
+@api_v1.post("/brands/set")
+def post_brands_set() -> Response:
+    """Stage a brand preference rule for confirmation."""
+    require_bearer()
+    body = _json_body()
+    try:
+        pref = BrandPreference.model_validate(body)
+    except ValidationError as exc:
+        abort(400, description=f"invalid brand rule: {exc.error_count()} error(s)")
+    action_id = _stage_pending("brands_set", pref.model_dump(mode="json"))
+    return jsonify(
+        status="pending_confirmation",
+        action_id=action_id,
+        message=(
+            f"Staged brand rule: {pref.preference_type.value} '{pref.brand}' "
+            f"for {pref.match_target}. Reply 'confirm' to apply."
+        ),
+    )
+
+
+def _parse_preferences_payload(body: dict[str, Any]) -> dict[str, str]:
+    """Validate a non-empty string-to-string preferences map, or abort 400."""
+    preferences = body.get("preferences")
+    if not isinstance(preferences, dict) or not preferences:
+        abort(400, description="preferences must be a non-empty object")
+    # JSON object keys are always strings; only values need checking.
+    if not all(isinstance(value, str) for value in preferences.values()):
+        abort(400, description="preference values must be strings")
+    return preferences
+
+
+@api_v1.post("/preferences/set")
+def post_preferences_set() -> Response:
+    """Stage app-level preference changes for confirmation."""
+    require_bearer()
+    preferences = _parse_preferences_payload(_json_body())
+    action_id = _stage_pending("preferences_set", {"preferences": preferences})
+    keys = ", ".join(sorted(preferences))
+    return jsonify(
+        status="pending_confirmation",
+        action_id=action_id,
+        message=f"Staged preference change ({keys}). Reply 'confirm' to apply.",
+    )
+
+
+def _load_pending_action(body: dict[str, Any]) -> PendingAction:
+    """Fetch the pending action named by the request body, or abort 400/404."""
+    action_id = body.get("action_id")
+    if not isinstance(action_id, str) or not action_id.strip():
+        abort(400, description="action_id required")
+    action = _pending_store().get_pending_action(action_id.strip())
+    if action is None:
+        abort(404, description="unknown action_id")
+    return action
+
+
+def _claim_pending(store: PendingActionsStore, action_id: str) -> None:
+    """Atomically claim a pending action as approved, or abort 409.
+
+    The guarded UPDATE in the store is the exactly-once gate: only one
+    caller can transition the row out of ``pending``, so a raced double
+    confirm cannot execute twice.
+    """
+    if not store.mark_pending_approved(action_id):
+        abort(409, description="action already resolved")
+
+
+def _approved(action: PendingAction, result: dict[str, Any]) -> Response:
+    """Serialize a successful confirmation response."""
+    return jsonify(
+        status="approved",
+        action_id=action.action_id,
+        kind=action.kind,
+        result=result,
+    )
+
+
+def _confirm_order_submit(
+    action: PendingAction, store: PendingActionsStore
+) -> Response | tuple[Response, int]:
+    """Submit the exact staged cart to Safeway (real money)."""
+    cart = CartSummary.model_validate(action.payload["cart"])
+    try:
+        pipeline = _safeway_pipeline()
+    except (ConfigError, SafewayPipelineError) as exc:
+        # Not claimed yet: the action stays pending so it can be retried
+        # (until it expires) once configuration is fixed.
+        return jsonify(error=f"safeway pipeline unavailable: {exc}"), 503
+    _claim_pending(store, action.action_id)
+    try:
+        result = pipeline.submit_cart(cart)
+    except SafewayPipelineError as exc:
+        return jsonify(error=f"order submission failed: {exc}"), 502
+    finally:
+        pipeline.close()
+    if not result.success:
+        return jsonify(error=result.error_message), 502
+    confirmation = (
+        dataclasses.asdict(result.confirmation) if result.confirmation else {}
+    )
+    return _approved(
+        action, {**confirmation, "items_restocked": result.items_restocked}
+    )
+
+
+def _confirm_brands_set(action: PendingAction, store: PendingActionsStore) -> Response:
+    """Apply the staged brand preference rule."""
+    pref = BrandPreference.model_validate(action.payload)
+    _claim_pending(store, action.action_id)
+    pref_id = _recipe_store().add_brand_preference(pref)
+    return _approved(action, {"id": pref_id, **pref.model_dump(mode="json")})
+
+
+def _confirm_preferences_set(
+    action: PendingAction, store: PendingActionsStore
+) -> Response:
+    """Apply the staged app-level preference changes."""
+    preferences: dict[str, str] = action.payload["preferences"]
+    _claim_pending(store, action.action_id)
+    store_ = _recipe_store()
+    for key, value in preferences.items():
+        store_.set_preference(key, value)
+    return _approved(action, {"updated": len(preferences)})
+
+
+_CONFIRM_EXECUTORS: dict[
+    str,
+    Callable[[PendingAction, PendingActionsStore], Response | tuple[Response, int]],
+] = {
+    "safeway_order_submit": _confirm_order_submit,
+    "brands_set": _confirm_brands_set,
+    "preferences_set": _confirm_preferences_set,
+}
+
+
+@api_v1.post("/actions/confirm")
+def post_actions_confirm() -> Response | tuple[Response, int]:
+    """Execute a staged action exactly once after chat confirmation."""
+    require_bearer()
+    action = _load_pending_action(_json_body())
+    store = _pending_store()
+    if action.status is not PendingActionStatus.PENDING:
+        abort(409, description="action already resolved")
+    if action.is_expired():
+        store.mark_pending_expired(action.action_id)
+        abort(410, description="action expired — stage it again")
+    executor = _CONFIRM_EXECUTORS.get(action.kind)
+    if executor is None:
+        abort(400, description=f"unknown action kind: {action.kind}")
+    return executor(action, store)
+
+
+@api_v1.post("/actions/deny")
+def post_actions_deny() -> Response:
+    """Mark a staged action as denied (audit trail; nothing executes).
+
+    Denial is safe regardless of expiry, so unlike confirm this does not
+    check the TTL — a denied-after-expiry action records the user's
+    explicit "no" rather than a timeout.
+    """
+    require_bearer()
+    action = _load_pending_action(_json_body())
+    if not _pending_store().mark_pending_denied(action.action_id):
+        abort(409, description="action already resolved")
+    return jsonify(status="denied", action_id=action.action_id, kind=action.kind)

--- a/tests/test_api_destructive.py
+++ b/tests/test_api_destructive.py
@@ -1,0 +1,727 @@
+"""Tests for the /api/v1 destructive endpoints with staged confirmation.
+
+Covers the highest-stakes flow in the stack: ``/order/submit``,
+``/brands/set``, and ``/preferences/set`` stage into ``pending_actions``
+and execute only through ``/actions/confirm`` (chat-based draft →
+confirm → execute per PIVOT.md). No test may ever reach a real Safeway
+client — the pipeline factory is mocked everywhere it could execute.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import os
+import uuid
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from flask import Flask
+    from flask.testing import FlaskClient
+
+from grocery_butler.app import create_app
+from grocery_butler.auth_middleware import SECRET_ENV_VAR, mint_token
+from grocery_butler.config import ConfigError
+from grocery_butler.models import (
+    BrandMatchType,
+    BrandPreference,
+    BrandPreferenceType,
+    CartItem,
+    CartSummary,
+    FulfillmentType,
+    IngredientCategory,
+    PendingActionStatus,
+    SafewayProduct,
+    ShoppingListItem,
+    Unit,
+)
+from grocery_butler.order_service import OrderConfirmation, OrderResult
+from grocery_butler.pending_actions import PendingActionsStore
+from grocery_butler.recipe_store import RecipeStore
+
+TEST_SECRET = "test-shared-secret"
+SECRET_ENV = {SECRET_ENV_VAR: TEST_SECRET}
+
+DESTRUCTIVE_ENDPOINTS = [
+    "/api/v1/order/submit",
+    "/api/v1/brands/set",
+    "/api/v1/preferences/set",
+    "/api/v1/actions/confirm",
+    "/api/v1/actions/deny",
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures and builders
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> str:
+    """Return a temporary database path for test isolation."""
+    return str(tmp_path / "test_api_destructive.db")
+
+
+@pytest.fixture()
+def app(db_path: str) -> Flask:
+    """Create a Flask test app with a temporary database."""
+    application = create_app(db_path=db_path)
+    application.config["TESTING"] = True
+    return application
+
+
+@pytest.fixture()
+def client(app: Flask) -> FlaskClient:
+    """Return a Flask test client."""
+    return app.test_client()
+
+
+@pytest.fixture()
+def pending_store(db_path: str) -> PendingActionsStore:
+    """Return a PendingActionsStore bound to the test database."""
+    return PendingActionsStore(db_path)
+
+
+@pytest.fixture()
+def recipe_store(db_path: str) -> RecipeStore:
+    """Return a RecipeStore bound to the test database."""
+    return RecipeStore(db_path)
+
+
+@pytest.fixture()
+def auth_headers() -> dict[str, str]:
+    """Return a valid Authorization header minted with the test secret."""
+    with patch.dict(os.environ, SECRET_ENV):
+        token = mint_token("rubotpaul")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _make_shopping_item(ingredient: str = "pasta") -> ShoppingListItem:
+    """Return a ShoppingListItem for cart payloads."""
+    return ShoppingListItem(
+        ingredient=ingredient,
+        quantity=1.0,
+        unit=Unit.LB,
+        category=IngredientCategory.PANTRY_DRY,
+        search_term=ingredient,
+        from_meals=["test pasta"],
+    )
+
+
+def _make_cart_item(ingredient: str, cost: float) -> CartItem:
+    """Return a CartItem with the given estimated cost."""
+    return CartItem(
+        shopping_list_item=_make_shopping_item(ingredient),
+        safeway_product=SafewayProduct(
+            product_id=f"prod-{ingredient}",
+            name=f"Brand {ingredient}",
+            price=cost,
+            size="1 lb",
+        ),
+        quantity_to_order=1,
+        estimated_cost=cost,
+    )
+
+
+def _make_cart(costs: dict[str, float]) -> CartSummary:
+    """Return a CartSummary with one item per (ingredient, cost) pair."""
+    items = [_make_cart_item(name, cost) for name, cost in costs.items()]
+    return CartSummary(
+        items=items,
+        failed_items=[],
+        substituted_items=[],
+        restock_items=[],
+        subtotal=sum(costs.values()),
+        fulfillment_options=[],
+        recommended_fulfillment=FulfillmentType.PICKUP,
+        estimated_total=sum(costs.values()),
+    )
+
+
+def _order_body(costs: dict[str, float] | None = None) -> dict[str, Any]:
+    """Return a valid /order/submit request body."""
+    cart = _make_cart(costs or {"pasta": 3.50, "sauce": 4.25})
+    return {"cart": cart.model_dump(mode="json"), "total": "7.75"}
+
+
+def _brand_body() -> dict[str, Any]:
+    """Return a valid /brands/set request body."""
+    return BrandPreference(
+        match_target="milk",
+        match_type=BrandMatchType.INGREDIENT,
+        brand="Clover",
+        preference_type=BrandPreferenceType.PREFERRED,
+        notes="organic when available",
+    ).model_dump(mode="json")
+
+
+def _successful_order_result() -> OrderResult:
+    """Return an OrderResult for a successfully submitted order."""
+    return OrderResult(
+        success=True,
+        confirmation=OrderConfirmation(
+            order_id="SW-12345",
+            status="confirmed",
+            estimated_time="Tomorrow 10am",
+            total=7.75,
+            fulfillment_type=FulfillmentType.PICKUP,
+            item_count=2,
+        ),
+        items_restocked=1,
+    )
+
+
+def _stage_via_api(
+    client: FlaskClient,
+    auth_headers: dict[str, str],
+    path: str,
+    body: dict[str, Any],
+) -> str:
+    """Stage an action through the API and return its action_id."""
+    response = client.post(path, json=body, headers=auth_headers)
+    assert response.status_code == 200
+    action_id = response.get_json()["action_id"]
+    assert isinstance(action_id, str)
+    return action_id
+
+
+# ---------------------------------------------------------------------------
+# Auth: every destructive endpoint rejects unauthenticated requests
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, SECRET_ENV)
+class TestAuthRequired:
+    """All destructive endpoints must reject requests without a valid bearer."""
+
+    @pytest.mark.parametrize("path", DESTRUCTIVE_ENDPOINTS)
+    def test_missing_bearer_returns_401(self, client: FlaskClient, path: str) -> None:
+        """Requests without an Authorization header get a JSON 401."""
+        response = client.post(path, json={})
+        assert response.status_code == 401
+        assert "error" in response.get_json()
+
+    @pytest.mark.parametrize("path", DESTRUCTIVE_ENDPOINTS)
+    def test_garbage_bearer_returns_401(self, client: FlaskClient, path: str) -> None:
+        """Requests with an invalid token get 401."""
+        response = client.post(
+            path, json={}, headers={"Authorization": "Bearer not.a.token"}
+        )
+        assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# POST /order/submit — stages, never submits
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, SECRET_ENV)
+class TestOrderSubmitStaging:
+    """/order/submit stages a pending action and must not touch Safeway."""
+
+    def test_missing_cart_returns_400(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """A body without a cart is rejected."""
+        response = client.post(
+            "/api/v1/order/submit", json={"total": "9.99"}, headers=auth_headers
+        )
+        assert response.status_code == 400
+        assert "cart" in response.get_json()["error"]
+
+    def test_invalid_cart_returns_400(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """A cart that fails CartSummary validation is rejected."""
+        response = client.post(
+            "/api/v1/order/submit",
+            json={"cart": {"items": "nope"}},
+            headers=auth_headers,
+        )
+        assert response.status_code == 400
+        assert "invalid cart" in response.get_json()["error"]
+
+    def test_empty_cart_returns_400(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """A structurally valid but empty cart is rejected."""
+        empty = _make_cart({})
+        response = client.post(
+            "/api/v1/order/submit",
+            json={"cart": empty.model_dump(mode="json")},
+            headers=auth_headers,
+        )
+        assert response.status_code == 400
+        assert "empty" in response.get_json()["error"]
+
+    def test_non_object_body_returns_400(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """A non-object JSON body is rejected."""
+        response = client.post(
+            "/api/v1/order/submit", json=["not", "a", "dict"], headers=auth_headers
+        )
+        assert response.status_code == 400
+
+    def test_stages_pending_action_and_returns_confirmation_prompt(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        pending_store: PendingActionsStore,
+    ) -> None:
+        """Submitting a cart stages a pending_actions row with the exact cart."""
+        body = _order_body()
+        response = client.post("/api/v1/order/submit", json=body, headers=auth_headers)
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["status"] == "pending_confirmation"
+        assert "2 items" in data["message"]
+        assert "$7.75" in data["message"]
+
+        action = pending_store.get_pending_action(data["action_id"])
+        assert action is not None
+        assert action.kind == "safeway_order_submit"
+        assert action.status is PendingActionStatus.PENDING
+        assert action.payload["cart"] == body["cart"]
+        assert action.payload["total"] == "7.75"
+        assert not action.is_expired()
+
+    def test_total_defaults_to_cart_total_when_omitted(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        pending_store: PendingActionsStore,
+    ) -> None:
+        """Without an explicit total, the staged total is computed from the cart."""
+        cart = _make_cart({"pasta": 3.50, "sauce": 4.25})
+        response = client.post(
+            "/api/v1/order/submit",
+            json={"cart": cart.model_dump(mode="json")},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        action = pending_store.get_pending_action(response.get_json()["action_id"])
+        assert action is not None
+        assert action.payload["total"] == "7.75"
+
+    def test_staging_never_touches_the_safeway_pipeline(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """Staging an order must not construct or call the Safeway pipeline."""
+        factory = MagicMock()
+        with patch("grocery_butler.api._safeway_pipeline", factory):
+            response = client.post(
+                "/api/v1/order/submit", json=_order_body(), headers=auth_headers
+            )
+        assert response.status_code == 200
+        factory.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# POST /brands/set and /preferences/set — same staging pattern
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, SECRET_ENV)
+class TestBrandsSetStaging:
+    """/brands/set stages a validated brand rule without applying it."""
+
+    def test_stages_pending_action(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        pending_store: PendingActionsStore,
+        recipe_store: RecipeStore,
+    ) -> None:
+        """A valid brand rule is staged, not written to brand preferences."""
+        response = client.post(
+            "/api/v1/brands/set", json=_brand_body(), headers=auth_headers
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["status"] == "pending_confirmation"
+
+        action = pending_store.get_pending_action(data["action_id"])
+        assert action is not None
+        assert action.kind == "brands_set"
+        assert action.status is PendingActionStatus.PENDING
+        assert action.payload["brand"] == "Clover"
+        assert recipe_store.get_brand_preferences() == []
+
+    def test_invalid_brand_payload_returns_400(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """A payload missing required brand fields is rejected."""
+        response = client.post(
+            "/api/v1/brands/set", json={"brand": "Clover"}, headers=auth_headers
+        )
+        assert response.status_code == 400
+        assert "invalid brand" in response.get_json()["error"]
+
+
+@patch.dict(os.environ, SECRET_ENV)
+class TestPreferencesSetStaging:
+    """/preferences/set stages key/value settings without applying them."""
+
+    def test_stages_pending_action(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        pending_store: PendingActionsStore,
+        recipe_store: RecipeStore,
+    ) -> None:
+        """Valid preferences are staged, not written to the store."""
+        body = {"preferences": {"fulfillment": "pickup", "store_id": "1234"}}
+        response = client.post(
+            "/api/v1/preferences/set", json=body, headers=auth_headers
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["status"] == "pending_confirmation"
+
+        action = pending_store.get_pending_action(data["action_id"])
+        assert action is not None
+        assert action.kind == "preferences_set"
+        assert action.payload == body
+        # Staging must not write: neither staged key reaches the store.
+        stored = recipe_store.get_all_preferences()
+        assert "fulfillment" not in stored
+        assert "store_id" not in stored
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            {},
+            {"preferences": {}},
+            {"preferences": "pickup"},
+            {"preferences": {"fulfillment": 7}},
+        ],
+    )
+    def test_invalid_preferences_return_400(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        body: dict[str, Any],
+    ) -> None:
+        """Missing, empty, or non-string preference payloads are rejected."""
+        response = client.post(
+            "/api/v1/preferences/set", json=body, headers=auth_headers
+        )
+        assert response.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# POST /actions/confirm — executes exactly once
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, SECRET_ENV)
+class TestActionsConfirm:
+    """/actions/confirm resolves staged actions with strict semantics."""
+
+    def test_missing_action_id_returns_400(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """A body without action_id is rejected."""
+        response = client.post("/api/v1/actions/confirm", json={}, headers=auth_headers)
+        assert response.status_code == 400
+
+    def test_unknown_action_id_returns_404(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """An unknown action_id gets a JSON 404."""
+        response = client.post(
+            "/api/v1/actions/confirm",
+            json={"action_id": str(uuid.uuid4())},
+            headers=auth_headers,
+        )
+        assert response.status_code == 404
+        assert "error" in response.get_json()
+
+    def test_expired_action_returns_410_and_marks_expired(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        pending_store: PendingActionsStore,
+    ) -> None:
+        """Confirming past the TTL returns 410 and resolves the row as expired."""
+        action_id = str(uuid.uuid4())
+        pending_store.insert_pending_action(
+            action_id=action_id,
+            kind="preferences_set",
+            payload={"preferences": {"fulfillment": "pickup"}},
+            expires_at=dt.datetime.now(dt.UTC) - dt.timedelta(seconds=1),
+        )
+        response = client.post(
+            "/api/v1/actions/confirm",
+            json={"action_id": action_id},
+            headers=auth_headers,
+        )
+        assert response.status_code == 410
+        action = pending_store.get_pending_action(action_id)
+        assert action is not None
+        assert action.status is PendingActionStatus.EXPIRED
+        assert action.resolved_at is not None
+
+    def test_confirm_order_calls_submit_with_exact_staged_cart(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        pending_store: PendingActionsStore,
+    ) -> None:
+        """Confirming an order submits the exact staged cart and approves the row."""
+        body = _order_body()
+        action_id = _stage_via_api(client, auth_headers, "/api/v1/order/submit", body)
+
+        pipeline = MagicMock()
+        pipeline.submit_cart.return_value = _successful_order_result()
+        with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
+            response = client.post(
+                "/api/v1/actions/confirm",
+                json={"action_id": action_id},
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["status"] == "approved"
+        assert data["result"]["order_id"] == "SW-12345"
+        assert data["result"]["items_restocked"] == 1
+
+        pipeline.submit_cart.assert_called_once()
+        submitted_cart = pipeline.submit_cart.call_args.args[0]
+        assert submitted_cart.model_dump(mode="json") == body["cart"]
+        pipeline.close.assert_called_once()
+
+        action = pending_store.get_pending_action(action_id)
+        assert action is not None
+        assert action.status is PendingActionStatus.APPROVED
+        assert action.resolved_at is not None
+
+    def test_failed_order_submission_returns_502(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        pending_store: PendingActionsStore,
+    ) -> None:
+        """A failed Safeway submission reports 502; the claim is consumed."""
+        action_id = _stage_via_api(
+            client, auth_headers, "/api/v1/order/submit", _order_body()
+        )
+        pipeline = MagicMock()
+        pipeline.submit_cart.return_value = OrderResult(
+            success=False, error_message="Safeway is down"
+        )
+        with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
+            response = client.post(
+                "/api/v1/actions/confirm",
+                json={"action_id": action_id},
+                headers=auth_headers,
+            )
+        assert response.status_code == 502
+        assert "Safeway is down" in response.get_json()["error"]
+        action = pending_store.get_pending_action(action_id)
+        assert action is not None
+        assert action.status is PendingActionStatus.APPROVED
+
+    def test_unavailable_pipeline_returns_503_and_keeps_action_pending(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        pending_store: PendingActionsStore,
+    ) -> None:
+        """If the pipeline can't start, the action stays pending for retry."""
+        action_id = _stage_via_api(
+            client, auth_headers, "/api/v1/order/submit", _order_body()
+        )
+        with patch(
+            "grocery_butler.api._safeway_pipeline",
+            side_effect=ConfigError("SAFEWAY_USERNAME missing"),
+        ):
+            response = client.post(
+                "/api/v1/actions/confirm",
+                json={"action_id": action_id},
+                headers=auth_headers,
+            )
+        assert response.status_code == 503
+        action = pending_store.get_pending_action(action_id)
+        assert action is not None
+        assert action.status is PendingActionStatus.PENDING
+
+    def test_double_confirm_returns_409(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """Confirming an already-approved action returns 409."""
+        action_id = _stage_via_api(
+            client, auth_headers, "/api/v1/brands/set", _brand_body()
+        )
+        first = client.post(
+            "/api/v1/actions/confirm",
+            json={"action_id": action_id},
+            headers=auth_headers,
+        )
+        assert first.status_code == 200
+        second = client.post(
+            "/api/v1/actions/confirm",
+            json={"action_id": action_id},
+            headers=auth_headers,
+        )
+        assert second.status_code == 409
+        assert "error" in second.get_json()
+
+    def test_confirm_after_deny_returns_409(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """Confirming a denied action returns 409."""
+        action_id = _stage_via_api(
+            client, auth_headers, "/api/v1/brands/set", _brand_body()
+        )
+        denied = client.post(
+            "/api/v1/actions/deny",
+            json={"action_id": action_id},
+            headers=auth_headers,
+        )
+        assert denied.status_code == 200
+        response = client.post(
+            "/api/v1/actions/confirm",
+            json={"action_id": action_id},
+            headers=auth_headers,
+        )
+        assert response.status_code == 409
+
+    def test_confirm_brands_applies_rule(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        recipe_store: RecipeStore,
+        pending_store: PendingActionsStore,
+    ) -> None:
+        """Confirming a brands_set action writes the brand rule."""
+        action_id = _stage_via_api(
+            client, auth_headers, "/api/v1/brands/set", _brand_body()
+        )
+        response = client.post(
+            "/api/v1/actions/confirm",
+            json={"action_id": action_id},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["status"] == "approved"
+        assert data["result"]["brand"] == "Clover"
+
+        prefs = recipe_store.get_brand_preferences()
+        assert len(prefs) == 1
+        assert prefs[0].brand == "Clover"
+        assert prefs[0].match_target == "milk"
+
+        action = pending_store.get_pending_action(action_id)
+        assert action is not None
+        assert action.status is PendingActionStatus.APPROVED
+
+    def test_confirm_preferences_applies_settings(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        recipe_store: RecipeStore,
+    ) -> None:
+        """Confirming a preferences_set action writes every key/value pair."""
+        body = {"preferences": {"fulfillment": "pickup", "store_id": "1234"}}
+        action_id = _stage_via_api(
+            client, auth_headers, "/api/v1/preferences/set", body
+        )
+        response = client.post(
+            "/api/v1/actions/confirm",
+            json={"action_id": action_id},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        assert response.get_json()["result"]["updated"] == 2
+        stored = recipe_store.get_all_preferences()
+        assert stored["fulfillment"] == "pickup"
+        assert stored["store_id"] == "1234"
+
+
+# ---------------------------------------------------------------------------
+# POST /actions/deny — audit-trail denial
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, SECRET_ENV)
+class TestActionsDeny:
+    """/actions/deny resolves staged actions as denied."""
+
+    def test_missing_action_id_returns_400(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """A body without action_id is rejected."""
+        response = client.post("/api/v1/actions/deny", json={}, headers=auth_headers)
+        assert response.status_code == 400
+
+    def test_unknown_action_id_returns_404(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """An unknown action_id gets 404."""
+        response = client.post(
+            "/api/v1/actions/deny",
+            json={"action_id": str(uuid.uuid4())},
+            headers=auth_headers,
+        )
+        assert response.status_code == 404
+
+    def test_denies_pending_action(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        pending_store: PendingActionsStore,
+        recipe_store: RecipeStore,
+    ) -> None:
+        """Denying marks the row denied and never applies the change."""
+        action_id = _stage_via_api(
+            client, auth_headers, "/api/v1/brands/set", _brand_body()
+        )
+        response = client.post(
+            "/api/v1/actions/deny",
+            json={"action_id": action_id},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["status"] == "denied"
+        assert data["action_id"] == action_id
+
+        action = pending_store.get_pending_action(action_id)
+        assert action is not None
+        assert action.status is PendingActionStatus.DENIED
+        assert action.resolved_at is not None
+        assert recipe_store.get_brand_preferences() == []
+
+    def test_double_deny_returns_409(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """Denying an already-denied action returns 409."""
+        action_id = _stage_via_api(
+            client, auth_headers, "/api/v1/brands/set", _brand_body()
+        )
+        first = client.post(
+            "/api/v1/actions/deny",
+            json={"action_id": action_id},
+            headers=auth_headers,
+        )
+        assert first.status_code == 200
+        second = client.post(
+            "/api/v1/actions/deny",
+            json={"action_id": action_id},
+            headers=auth_headers,
+        )
+        assert second.status_code == 409


### PR DESCRIPTION
## Summary

Implements the highest-stakes flow in the stack: destructive `/api/v1` endpoints that stage into the `pending_actions` audit log (#44) and execute only after chat confirmation, per PIVOT.md's draft → confirm → execute pattern. No Discord button — RubotPaul relays the user's "confirm" reply and calls `/actions/confirm`.

- **`POST /api/v1/order/submit`** `{cart, total}` — validates the cart as a `CartSummary` (400 missing/invalid/empty), stages `safeway_order_submit` with a 5-minute TTL, returns `{status: "pending_confirmation", action_id, message}`. Never constructs or calls the Safeway pipeline.
- **`POST /api/v1/brands/set`** — validates a `BrandPreference` rule and stages `brands_set`.
- **`POST /api/v1/preferences/set`** `{preferences: {key: value}}` — validates a non-empty string map and stages `preferences_set`.
- **`POST /api/v1/actions/confirm`** `{action_id}` — 404 unknown, 410 expired (row marked expired), 409 already-resolved. The store's guarded `mark_pending_approved` transition is the atomic exactly-once claim, so a raced double confirm cannot submit an order twice. Orders: pipeline-unavailable → 503 with the action left pending (retryable until TTL); failed submission after claim → 502 (consumed; re-stage to retry). Brands/preferences apply through the existing `RecipeStore` setters.
- **`POST /api/v1/actions/deny`** `{action_id}` — marks denied with `resolved_at` for the audit trail; 409 if already resolved.
- 409/410 added to the blueprint-scoped JSON error handler.

## Test plan

- 38 new tests in `tests/test_api_destructive.py`: 401s on all five endpoints; staging writes the exact cart payload and never touches the pipeline factory (asserted via mock); confirm submits the exact staged cart (`submit_cart` called once, cart round-trips byte-equal); expired → 410 + row expired; double-confirm and confirm-after-deny → 409; deny → denied + change never applied; 400 contract on carts/brands/preferences bodies; 502/503 order failure paths with claim semantics.
- Full suite: 1162 passed, coverage 93.45% (gate 90%). `./scripts/check-all.sh` 7/7 green.

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)