### PR TITLE
chore: wire /api/v1 into the web process + retire the Discord worker (Procfile, docs)

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,2 @@
 release: python -m grocery_butler.db.migrate
 web: gunicorn 'grocery_butler.app:create_app()' --bind 0.0.0.0:$PORT --workers ${WEB_CONCURRENCY:-2} --timeout 120
-worker: python -m grocery_butler.bot

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This is a small system with a serious intention: give back the hours that
 - [Running the System](#running-the-system)
 - [API Documentation](#api-documentation)
   - [HTTP / Web API](#http--web-api)
+  - [RubotPaul Integration (/api/v1)](#rubotpaul-integration-apiv1)
   - [Discord Bot Commands](#discord-bot-commands)
   - [Command-Line Interface](#command-line-interface)
   - [Python Module API](#python-module-api)
@@ -136,17 +137,20 @@ on Railway Postgres. Schema is defined declaratively in `db/schema.sql` and
 
 ### Process Topology
 
-In production (Railway), the system runs as **two long-lived processes** plus
+In production (Railway), the system runs as **one long-lived web process** plus
 a one-shot release step:
 
 | Process | Command | Role |
 |---------|---------|------|
 | `release` | `python -m grocery_butler.db.migrate` | Run schema migrations on every deploy. |
-| `web` | `gunicorn 'grocery_butler.app:create_app()'` | Flask dashboard + JSON endpoints. |
-| `worker` | `python -m grocery_butler.bot` | Discord bot, listens to slash commands and DMs. |
+| `web` | `gunicorn 'grocery_butler.app:create_app()'` | Flask dashboard + the `/api/v1` JSON API for RubotPaul. |
 
-Both processes share the same database. The CLI is invoked ad-hoc as a
-single-shot process (no daemon).
+The single web process serves both the kitchen-phone HTML UI and the
+HMAC-authenticated `/api/v1` blueprint. The former `worker` process
+(`python -m grocery_butler.bot`) is retired from deployment: RubotPaul is the
+household's Discord interface and drives grocery-butler through `/api/v1`. The
+bot module stays in the codebase and can still be run locally. The CLI is
+invoked ad-hoc as a single-shot process (no daemon).
 
 ### Key Design Rules
 
@@ -265,7 +269,8 @@ $EDITOR .env
 | Variable | When required | Purpose |
 |----------|---------------|---------|
 | `ANTHROPIC_API_KEY` | Always | Claude API access for parsing and consolidation. |
-| `DISCORD_BOT_TOKEN` | Discord worker only | Authenticates the bot. |
+| `RUBOTPAUL_SHARED_SECRET` | RubotPaul API | HMAC secret for `/api/v1` bearer tokens (shared with RubotPaul). |
+| `DISCORD_BOT_TOKEN` | Local bot runs only | Authenticates the (retired-from-production) Discord bot. |
 | `FLASK_SECRET_KEY` | Web (production) | Stable session signing key. |
 | `DATABASE_PATH` | SQLite (dev) | Path to the local SQLite file. Defaults to `mealbot.db`. |
 | `DATABASE_URL` | Postgres (prod) | Connection URL injected by Railway Postgres. |
@@ -287,14 +292,16 @@ FLASK_APP='grocery_butler.app:create_app()' flask run --debug
 
 Open <http://localhost:5000>.
 
-### Discord bot
+### Discord bot (local only — retired from production)
 
 ```bash
 python -m grocery_butler.bot
 ```
 
 The bot connects with `DISCORD_BOT_TOKEN` and registers slash commands on
-startup.
+startup. In production this process no longer runs: RubotPaul owns the
+Discord side and talks to grocery-butler through the
+[RubotPaul integration API](#rubotpaul-integration-apiv1).
 
 ### CLI
 
@@ -374,7 +381,37 @@ server-rendered HTML except where noted.
 | `GET` | `/preferences` | Render the preferences form. |
 | `POST` | `/preferences` | Form: `default_servings`, `default_units`, `dietary_restrictions`. |
 
+### RubotPaul Integration (/api/v1)
+
+RubotPaul (the household's OpenClaw assistant) drives grocery-butler through a
+JSON API served by the same web process as the HTML UI — the web UI is
+unchanged. The blueprint lives in `grocery_butler/api.py` and is registered by
+`create_app()`.
+
+- **Base URL:** `https://grocery-butler.tailnet.ts.net/api/v1` — reached over
+  the Tailscale tailnet; the API is not meant to be exposed on the public
+  Railway domain.
+- **Auth:** every `/api/v1` route requires a bearer token in the
+  `<caller_id>.<timestamp>.<hmac_hex>` format, signed with
+  `RUBOTPAUL_SHARED_SECRET` (HMAC-SHA256, 5-minute TTL). Mint with
+  `grocery_butler.auth_middleware.mint_token`. An unauthenticated
+  `GET /healthz` liveness probe is exempt.
+- **Surface:** read endpoints (`/inventory`, `/pantry`, `/recipes`, `/brands`,
+  `/preferences`, `/restock`), compute previews (`/meals/parse`,
+  `/shopping-list/preview`, `/order/preview`), low-stakes writes
+  (`/stock/update`, `/stock/add`, `/restock/clear`, `/recipes/save`,
+  `DELETE /recipes/<id>`), and staged destructive actions (`/order/submit`,
+  `/brands/set`, `/preferences/set` → `/actions/confirm` / `/actions/deny`
+  against the `pending_actions` audit table).
+- **Safety:** destructive actions follow draft → confirm → execute. Staging
+  returns a `pending_confirmation` action id with a 5-minute expiry; nothing
+  executes until RubotPaul confirms after Geoff replies "confirm" in chat.
+
 ### Discord Bot Commands
+
+> **Retired from production.** RubotPaul replaces the standalone bot as the
+> Discord interface; these commands remain available when running the bot
+> locally.
 
 All commands are slash commands. Permission defaults to `manage_guild` and can
 be re-mapped per role via Server Settings -> Integrations.
@@ -670,13 +707,16 @@ See `CLAUDE.md` for the full engineering culture document.
 ## Deploying to Railway
 
 The project includes a `Procfile` for [Railway](https://railway.app/) deployment
-with three processes:
+with two processes:
 
 | Process | Command | Description |
 |---------|---------|-------------|
 | `release` | `python -m grocery_butler.db.migrate` | Schema migrations on every deploy. |
-| `web` | `gunicorn 'grocery_butler.app:create_app()'` | Flask web app. |
-| `worker` | `python -m grocery_butler.bot` | Discord bot. |
+| `web` | `gunicorn 'grocery_butler.app:create_app()'` | Flask web app + `/api/v1` RubotPaul API. |
+
+The former `worker` process (Discord bot) is retired; RubotPaul reaches the
+`/api/v1` blueprint over Tailscale at
+`https://grocery-butler.tailnet.ts.net/api/v1`.
 
 ### Required environment variables
 
@@ -686,7 +726,7 @@ Set these in your Railway project settings:
 |----------|----------|-------------|
 | `DATABASE_URL` | Yes | PostgreSQL connection URL (auto-injected by Railway Postgres plugin). |
 | `ANTHROPIC_API_KEY` | Yes | Anthropic API key for Claude-powered features. |
-| `DISCORD_BOT_TOKEN` | Yes (worker) | Discord bot token for the worker process. |
+| `RUBOTPAUL_SHARED_SECRET` | Yes (RubotPaul API) | HMAC secret for `/api/v1` bearer tokens; must match RubotPaul's copy. |
 | `FLASK_SECRET_KEY` | Yes (web) | Stable secret key for Flask sessions (generate once, reuse). |
 | `SAFEWAY_USERNAME` | Yes (ordering) | Safeway account username. |
 | `SAFEWAY_PASSWORD` | Yes (ordering) | Safeway account password. |
@@ -699,7 +739,9 @@ Set these in your Railway project settings:
 2. Add a PostgreSQL plugin (provides `DATABASE_URL` automatically).
 3. Set the required environment variables above.
 4. Railway auto-deploys on push to `main`; the `release` step runs migrations
-   before `web` and `worker` start.
+   before `web` starts.
+5. Attach the Railway service to your Tailscale tailnet so RubotPaul can reach
+   `/api/v1` privately.
 
 ## License
 

--- a/tests/test_deployment_wiring.py
+++ b/tests/test_deployment_wiring.py
@@ -1,0 +1,119 @@
+"""Tests for the production process wiring (issue #49).
+
+One gunicorn web process serves both the HTML dashboard and the /api/v1
+blueprint; the Discord worker process is retired from the Procfile (RubotPaul
+is the Discord interface after cutover).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from flask import Flask
+    from flask.testing import FlaskClient
+
+from grocery_butler.app import create_app
+from grocery_butler.auth_middleware import SECRET_ENV_VAR, mint_token
+
+TEST_SECRET = "test-shared-secret"
+
+PROCFILE = Path(__file__).resolve().parent.parent / "Procfile"
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> str:
+    """Return a temporary database path for test isolation."""
+    return str(tmp_path / "test_wiring.db")
+
+
+@pytest.fixture()
+def app(db_path: str) -> Flask:
+    """Create a Flask test app with a temporary database."""
+    application = create_app(db_path=db_path)
+    application.config["TESTING"] = True
+    return application
+
+
+@pytest.fixture()
+def client(app: Flask) -> FlaskClient:
+    """Return a Flask test client."""
+    return app.test_client()
+
+
+# ---------------------------------------------------------------------------
+# One web process serves both surfaces
+# ---------------------------------------------------------------------------
+
+
+class TestSingleProcessServesBothSurfaces:
+    """The web app instance serves the HTML UI and the authed JSON API."""
+
+    def test_html_dashboard_and_authed_api_in_one_app(
+        self, client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """One app instance answers an HTML route and an authed API route."""
+        monkeypatch.setenv(SECRET_ENV_VAR, TEST_SECRET)
+
+        html_response = client.get("/")
+        assert html_response.status_code == 200
+        assert "text/html" in html_response.content_type
+
+        token = mint_token("rubotpaul")
+        api_response = client.get(
+            "/api/v1/inventory",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert api_response.status_code == 200
+        assert api_response.is_json
+        assert api_response.get_json() == {"items": []}
+
+    def test_api_still_rejects_unauthenticated_while_html_is_open(
+        self, client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The API keeps HMAC auth while the kitchen-phone UI stays open."""
+        monkeypatch.setenv(SECRET_ENV_VAR, TEST_SECRET)
+
+        assert client.get("/").status_code == 200
+        api_response = client.get("/api/v1/inventory")
+        assert api_response.status_code == 401
+        assert api_response.is_json
+
+
+# ---------------------------------------------------------------------------
+# Procfile topology
+# ---------------------------------------------------------------------------
+
+
+class TestProcfileTopology:
+    """The Procfile deploys release + web only; the Discord worker retired."""
+
+    def test_procfile_has_no_worker_process(self) -> None:
+        """RubotPaul owns Discord after cutover; no bot process deploys."""
+        processes = _procfile_processes()
+        assert "worker" not in processes
+
+    def test_procfile_keeps_release_and_web(self) -> None:
+        """Migrations still run on deploy and gunicorn serves the app."""
+        processes = _procfile_processes()
+        assert processes["release"] == "python -m grocery_butler.db.migrate"
+        assert "gunicorn 'grocery_butler.app:create_app()'" in processes["web"]
+
+
+def _procfile_processes() -> dict[str, str]:
+    """Parse the Procfile into a {process_name: command} mapping."""
+    processes: dict[str, str] = {}
+    for line in PROCFILE.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        name, _, command = stripped.partition(":")
+        processes[name.strip()] = command.strip()
+    return processes


### PR DESCRIPTION
## Summary
- One gunicorn `web` process serves both the kitchen-phone HTML UI and the HMAC-authed `/api/v1` blueprint (registered by `create_app` since #45); no `__bridge__()` gymnastics needed since the staged-confirm endpoints (#48) removed the bot-side notifier.
- Procfile: the `worker: python -m grocery_butler.bot` process is retired — RubotPaul is the Discord interface after cutover and drives grocery-butler through `/api/v1` over Tailscale. Bot code stays in the tree (conservative: `cli.py` still imports it) for local runs.
- README: new **RubotPaul Integration (/api/v1)** section (base URL `https://grocery-butler.tailnet.ts.net/api/v1`, HMAC auth, endpoint surface, draft→confirm→execute), process topology and Railway docs updated, Discord sections marked retired-from-production, `RUBOTPAUL_SHARED_SECRET` documented (already present in `.env.example`).

## Acceptance criteria
- ✅ Integration test hits an HTML route and an authed API route in one app instance (`tests/test_deployment_wiring.py`), plus a 401 guard and Procfile topology tests.
- ✅ `./scripts/check-all.sh` 7/7 green locally; 1166 passed, coverage 93.45% (≥90%).

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)