### PR TITLE
chore: Dockerfile CMD uses ${WEB_CONCURRENCY:-2} for gunicorn workers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,6 @@ COPY --from=builder /install /usr/local
 # Copy application code
 WORKDIR /app
 COPY grocery_butler/ grocery_butler/
-COPY Procfile .
 
 # Own the workdir
 RUN chown -R butler:butler /app
@@ -31,4 +30,4 @@ EXPOSE $PORT
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:${PORT}/health')"
 
-CMD gunicorn 'grocery_butler.app:create_app()' --bind "0.0.0.0:${PORT}" --workers 2 --timeout 120
+CMD gunicorn 'grocery_butler.app:create_app()' --bind "0.0.0.0:${PORT}" --workers ${WEB_CONCURRENCY:-2} --timeout 120

--- a/grocery_butler/api.py
+++ b/grocery_butler/api.py
@@ -322,7 +322,7 @@ def _parse_servings(body: dict[str, Any]) -> int:
     servings = body.get("servings", 4)
     if isinstance(servings, bool) or not isinstance(servings, int) or servings < 1:
         abort(400, description="servings must be a positive integer")
-    return servings
+    return int(servings)
 
 
 @api_v1.post("/stock/update")

--- a/tests/test_deployment_wiring.py
+++ b/tests/test_deployment_wiring.py
@@ -7,6 +7,7 @@ is the Discord interface after cutover).
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -22,6 +23,7 @@ from grocery_butler.auth_middleware import SECRET_ENV_VAR, mint_token
 TEST_SECRET = "test-shared-secret"
 
 PROCFILE = Path(__file__).resolve().parent.parent / "Procfile"
+DOCKERFILE = Path(__file__).resolve().parent.parent / "Dockerfile"
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -117,3 +119,52 @@ def _procfile_processes() -> dict[str, str]:
         name, _, command = stripped.partition(":")
         processes[name.strip()] = command.strip()
     return processes
+
+
+# ---------------------------------------------------------------------------
+# Dockerfile topology
+# ---------------------------------------------------------------------------
+
+
+class TestDockerfileTopology:
+    """The container image runs gunicorn directly; it never reads Procfile."""
+
+    def test_dockerfile_cmd_uses_web_concurrency_env(self) -> None:
+        """Worker count is configurable via WEB_CONCURRENCY at runtime."""
+        cmd = _dockerfile_cmd()
+        assert "--workers ${WEB_CONCURRENCY:-2}" in cmd
+
+    def test_dockerfile_cmd_has_no_hardcoded_worker_count(self) -> None:
+        """The CMD must not pin a literal worker count like `--workers 2`."""
+        cmd = _dockerfile_cmd()
+        assert re.search(r"--workers\s+\d+", cmd) is None
+
+    def test_dockerfile_does_not_copy_procfile(self) -> None:
+        """The image is Heroku-agnostic; it must not COPY the Procfile in."""
+        lines = DOCKERFILE.read_text().splitlines()
+        assert not any("COPY Procfile" in line for line in lines)
+
+    def test_dockerfile_still_runs_gunicorn_app_factory(self) -> None:
+        """The container still boots the Flask app via the gunicorn factory."""
+        cmd = _dockerfile_cmd()
+        assert "gunicorn 'grocery_butler.app:create_app()'" in cmd
+
+
+def _dockerfile_cmd() -> str:
+    """Return the command string of the Dockerfile's container-entrypoint CMD.
+
+    The HEALTHCHECK instruction's continuation line also starts with
+    `CMD ` (it is itself a `CMD <command>` clause), so this returns the
+    *last* matching line in the file, which is the real `CMD` instruction
+    that becomes the container's entrypoint.
+
+    Returns:
+        The command text following the `CMD ` prefix on the last line of
+        the Dockerfile that starts with `CMD `.
+    """
+    command = ""
+    for line in DOCKERFILE.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("CMD "):
+            command = stripped.removeprefix("CMD ")
+    return command


### PR DESCRIPTION
## Summary

- Dockerfile CMD now uses `--workers ${WEB_CONCURRENCY:-2}` (shell-form, expanded at runtime) so Railway's `WEB_CONCURRENCY` env var is respected in Docker deployments, matching the Procfile.
- Removed `COPY Procfile .` from the Dockerfile — the Procfile is a Railway manifest, not needed inside the image.
- Added `TestDockerfileTopology` (4 text-parsing tests in `tests/test_deployment_wiring.py`, mirroring the existing Procfile-test idiom) pinning the CMD worker parametrization, the absence of a hardcoded worker count, the absence of `COPY Procfile`, and the gunicorn app-factory invocation.

### Gate-unblocking fix (one line, no suppression)

`grocery_butler/api.py` `_parse_servings`: `return servings` → `return int(servings)`. mypy 1.19.1 (installed via the unpinned `mypy>=1.5.0` dev requirement) reports `no-any-return` on the old line, which makes `./scripts/check-all.sh` fail on a pristine `main` checkout. The isinstance guard above already rejects bools and non-ints, so `int()` is an identity conversion — a real fix, not a suppression. Included here because Gate 2 cannot exit 0 without it. (Attempted to file this as its own issue; issue creation was not permitted in this run, so it is documented here instead.)

## Test plan

- `./scripts/check-all.sh` → exit 0 (ruff lint + format, mypy strict, bandit, pip-audit, radon complexity, interrogate, full test suite, coverage).
- Test suite: 1170 passed, 8 skipped (pre-existing `TEST_DATABASE_URL` Postgres skips), coverage 93.45% (≥90% required).
- TDD: the 3 new Dockerfile assertions were confirmed RED against the old Dockerfile (hardcoded `--workers 2`, `COPY Procfile .` present) before the implementation turned them GREEN; the gunicorn-factory regression guard passed throughout.

Closes #36
