### PR TITLE
test: E2E suite for /api/v1 chain, HMAC auth, and core workflows (real wiring, boundary-only mocks)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,10 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+markers = [
+    "e2e: end-to-end tests exercising real wiring with mocks only at external boundaries",
+    "integration: integration tests",
+]
 
 [tool.coverage.run]
 source = ["grocery_butler"]

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""End-to-end tests for grocery-butler."""

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,504 @@
+"""Shared fixtures for the grocery-butler end-to-end test suite.
+
+Every fixture wires REAL application components together: the Flask app
+via ``create_app``, a real temporary SQLite database, and real
+stores/services/pipeline objects. Mocking is restricted to external
+network boundaries only:
+
+* the Anthropic SDK client object (``make_anthropic_client``), and
+* the httpx transport inside :class:`~grocery_butler.safeway_client.SafewayClient`.
+
+All state comes from ``monkeypatch``/``tmp_path`` -- nothing ambient.
+``load_dotenv(override=False)`` (see ``grocery_butler.config.load_config``)
+means ``monkeypatch.setenv`` always wins over a developer's local
+``.env`` file, so these tests are deterministic in CI (which has no
+secrets) and locally.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+from grocery_butler.app import create_app
+from grocery_butler.auth_middleware import SECRET_ENV_VAR, mint_token
+from grocery_butler.models import Ingredient, IngredientCategory, ParsedMeal
+from grocery_butler.recipe_store import RecipeStore
+from grocery_butler.safeway_client import OKTA_CLIENT_ID
+from grocery_butler.safeway_client import SafewayClient as _RealSafewayClient
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from flask import Flask
+    from flask.testing import FlaskClient
+
+#: Shared HMAC secret every minted token in this suite is signed with.
+E2E_SHARED_SECRET = "e2e-test-secret"
+
+#: Deterministic seeded recipe name, resolvable via RecipeStore without Claude.
+SEEDED_RECIPE_NAME = "spaghetti bolognese"
+
+
+# ---------------------------------------------------------------------------
+# Database and environment
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> str:
+    """Return a fresh temporary SQLite database path.
+
+    A single seam for the storage backend: every fixture and service in
+    this suite reads and writes through this path, so a future
+    PostgreSQL variant only needs to change this fixture.
+
+    Args:
+        tmp_path: Pytest's per-test temporary directory.
+
+    Returns:
+        Absolute path string for a database file that does not yet exist.
+    """
+    return str(tmp_path / "e2e.db")
+
+
+@pytest.fixture(autouse=True)
+def e2e_env(monkeypatch: pytest.MonkeyPatch, db_path: str) -> None:
+    """Set every environment variable the app needs, isolated per test.
+
+    ``load_config`` calls ``load_dotenv`` with the default
+    ``override=False``, so these ``monkeypatch.setenv`` calls always win
+    over any local ``.env`` file -- CI has no secrets and none are
+    needed here.
+
+    Args:
+        monkeypatch: Pytest's monkeypatch fixture.
+        db_path: The temporary database path for this test.
+    """
+    monkeypatch.setenv(SECRET_ENV_VAR, E2E_SHARED_SECRET)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-e2e-not-real")
+    monkeypatch.setenv("SAFEWAY_USERNAME", "e2e-safeway-user")
+    monkeypatch.setenv("SAFEWAY_PASSWORD", "e2e-safeway-pass")
+    monkeypatch.setenv("SAFEWAY_STORE_ID", "e2e-store-1")
+    monkeypatch.setenv("DATABASE_PATH", db_path)
+
+
+@pytest.fixture()
+def seed_recipe(db_path: str) -> ParsedMeal:
+    """Seed a deterministic recipe so ``MealParser.find_recipe`` resolves it.
+
+    Saving through a real :class:`RecipeStore` means the seeded recipe
+    round-trips through the exact same lookup path production code
+    uses, so no Claude call is ever needed to resolve it by name.
+
+    Args:
+        db_path: The temporary database path for this test.
+
+    Returns:
+        The ParsedMeal as saved (name, servings, ingredients).
+    """
+    meal = ParsedMeal(
+        name=SEEDED_RECIPE_NAME,
+        servings=4,
+        known_recipe=True,
+        needs_confirmation=False,
+        purchase_items=[
+            Ingredient(
+                ingredient="ground beef",
+                quantity=1.0,
+                unit="lb",
+                category=IngredientCategory.MEAT,
+            ),
+            Ingredient(
+                ingredient="spaghetti",
+                quantity=1.0,
+                unit="box",
+                category=IngredientCategory.PANTRY_DRY,
+            ),
+            Ingredient(
+                ingredient="tomato sauce",
+                quantity=2.0,
+                unit="can",
+                category=IngredientCategory.PANTRY_DRY,
+            ),
+        ],
+        pantry_items=[
+            Ingredient(
+                ingredient="salt",
+                quantity=1.0,
+                unit="tsp",
+                category=IngredientCategory.PANTRY_DRY,
+                is_pantry_item=True,
+            ),
+        ],
+    )
+    RecipeStore(db_path).save_recipe(meal)
+    return meal
+
+
+# ---------------------------------------------------------------------------
+# Flask app / client
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def app(db_path: str, e2e_env: None) -> Flask:
+    """Create the real Flask app wired to the temporary database.
+
+    Uses an explicit ``db_path`` rather than relying on ``DATABASE_URL``
+    pickup: issue #57 tracks an open bug in that alternate path, and
+    this suite deliberately sidesteps it instead of asserting around it.
+
+    Args:
+        db_path: The temporary database path for this test.
+        e2e_env: Ensures environment variables are set before app creation.
+
+    Returns:
+        A configured Flask application in ``TESTING`` mode.
+    """
+    application = create_app(db_path=db_path)
+    application.config["TESTING"] = True
+    return application
+
+
+@pytest.fixture()
+def client(app: Flask) -> FlaskClient:
+    """Return a Flask test client bound to the real app.
+
+    Args:
+        app: The configured Flask application.
+
+    Returns:
+        A Flask test client.
+    """
+    return app.test_client()
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def signed_headers() -> Callable[..., dict[str, str]]:
+    """Return a factory for minting ``Authorization`` headers.
+
+    Supports building expired, future-dated, and foreign-secret tokens
+    for exercising the auth module's rejection paths, in addition to
+    plain valid tokens.
+
+    Returns:
+        A callable ``(caller_id="rubotpaul", *, now_offset=0.0,
+        secret=None) -> {"Authorization": "Bearer <token>"}``. Positive
+        ``now_offset`` mints a future-dated token; a very negative one
+        mints an expired token. ``secret`` signs with a different
+        shared secret than the one the server validates against.
+    """
+
+    def _make(
+        caller_id: str = "rubotpaul",
+        *,
+        now_offset: float = 0.0,
+        secret: str | None = None,
+    ) -> dict[str, str]:
+        now = time.time() + now_offset
+        if secret is None:
+            token = mint_token(caller_id, now=now)
+        else:
+            real_secret = os.environ[SECRET_ENV_VAR]
+            os.environ[SECRET_ENV_VAR] = secret
+            try:
+                token = mint_token(caller_id, now=now)
+            finally:
+                os.environ[SECRET_ENV_VAR] = real_secret
+        return {"Authorization": f"Bearer {token}"}
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# Claude seam
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def no_claude(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force API-layer Claude-backed services onto their deterministic fallback.
+
+    Patches the ``make_anthropic_client`` name as imported into
+    ``grocery_butler.api`` so ``_anthropic_client()`` returns ``None``
+    even though ``ANTHROPIC_API_KEY`` is set. This is the seam that
+    keeps API-layer e2e tests offline and deterministic (MealParser,
+    Consolidator, ProductSelector, and SubstitutionService all fall
+    back to pure-Python heuristics when their client is ``None``).
+
+    Args:
+        monkeypatch: Pytest's monkeypatch fixture.
+    """
+    monkeypatch.setattr(
+        "grocery_butler.api.make_anthropic_client",
+        lambda api_key: None,
+    )
+
+
+@pytest.fixture()
+def no_claude_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force CLI-driven Claude calls onto their deterministic fallback.
+
+    ``grocery_butler.cli`` imports ``make_anthropic_client`` locally
+    inside ``_make_anthropic_client`` on every call, so patching the
+    source function in ``grocery_butler.claude_utils`` is what actually
+    takes effect: the local ``from ... import`` re-resolves the name
+    from the module namespace each time it runs.
+
+    Args:
+        monkeypatch: Pytest's monkeypatch fixture.
+    """
+    monkeypatch.setattr(
+        "grocery_butler.claude_utils.make_anthropic_client",
+        lambda api_key: None,
+    )
+
+
+@pytest.fixture()
+def fake_claude(monkeypatch: pytest.MonkeyPatch) -> Callable[[str], None]:
+    """Patch the Claude seam to return a scripted mock client.
+
+    Use only when a scenario genuinely needs a Claude "decision"
+    instead of a deterministic fallback -- check whether the no-client
+    fallback already produces the desired behavior first.
+
+    Args:
+        monkeypatch: Pytest's monkeypatch fixture.
+
+    Returns:
+        A callable that scripts the mock client's ``messages.create``
+        response text for subsequent calls.
+    """
+    mock_client = MagicMock()
+
+    def _script(response_text: str) -> None:
+        """Set the text the mock client's next Claude call will return."""
+        response = MagicMock()
+        response.content = [MagicMock(text=response_text)]
+        mock_client.messages.create.return_value = response
+
+    monkeypatch.setattr(
+        "grocery_butler.api.make_anthropic_client",
+        lambda api_key: mock_client,
+    )
+    return _script
+
+
+# ---------------------------------------------------------------------------
+# Safeway mock transport
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SafewayMockState:
+    """Mutable configuration and call recorder for the mocked Safeway API.
+
+    Attributes:
+        available_products: Steady-state search results keyed by search
+            term; each value is a list of raw Nimbus ``productsInfo``
+            entries (dicts with ``upc``/``name``/``price``/``size``/
+            ``inStock`` keys).
+        oos_once: Search terms whose FIRST search call returns a single
+            out-of-stock product (forcing the substitution flow);
+            subsequent calls for the same term fall back to
+            ``available_products``.
+        force_search_empty: If True, every product search returns no
+            results, exercising the ``failed_items`` path.
+        force_auth_fail: If True, the Okta authn step returns a 500,
+            exercising the pipeline's authentication-failure path.
+        order_response: The JSON body returned by the order-submit
+            endpoint.
+        requested_paths: Every request path seen by the mock transport,
+            in call order.
+    """
+
+    available_products: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    oos_once: set[str] = field(default_factory=set)
+    force_search_empty: bool = False
+    force_auth_fail: bool = False
+    order_response: dict[str, Any] = field(
+        default_factory=lambda: {
+            "orderId": "e2e-order-1",
+            "status": "confirmed",
+            "estimatedTime": "Tomorrow 9am-11am",
+            "total": "0",
+        }
+    )
+    requested_paths: list[str] = field(default_factory=list)
+    search_call_counts: dict[str, int] = field(default_factory=dict)
+
+
+def _default_product(
+    term: str,
+    *,
+    in_stock: bool = True,
+    price: float = 3.99,
+) -> dict[str, Any]:
+    """Build a generic Nimbus ``productsInfo`` entry for a search term.
+
+    Args:
+        term: The search term the product should match.
+        in_stock: Stock flag for the returned product.
+        price: Price for the returned product.
+
+    Returns:
+        A dict shaped like a Nimbus search result entry.
+    """
+    slug = term.strip().lower().replace(" ", "-") or "item"
+    return {
+        "upc": f"upc-{slug}",
+        "name": f"Generic {term.title()}",
+        "price": price,
+        "size": "1 lb",
+        "inStock": in_stock,
+    }
+
+
+def _handle_authn(state: SafewayMockState) -> httpx.Response:
+    """Return the Okta authn response: a session token, or a failure.
+
+    Args:
+        state: The mutable mock state for this test.
+
+    Returns:
+        A 200 response with a session token, or a 500 if
+        ``state.force_auth_fail`` is set.
+    """
+    if state.force_auth_fail:
+        return httpx.Response(500, json={"error": "internal error"})
+    return httpx.Response(
+        200,
+        json={"status": "SUCCESS", "sessionToken": "e2e-session-token"},
+    )
+
+
+def _handle_authorize() -> httpx.Response:
+    """Return the Okta authorize redirect with a bearer token fragment.
+
+    Returns:
+        A 302 response whose ``Location`` header fragment carries a
+        fake access token.
+    """
+    location = "https://www.safeway.com#access_token=e2e-access-token&expires_in=3600"
+    return httpx.Response(302, headers={"location": location})
+
+
+def _handle_search(request: httpx.Request, state: SafewayMockState) -> httpx.Response:
+    """Return search results for a query, honoring the state's knobs.
+
+    Args:
+        request: The incoming search request.
+        state: The mutable mock state for this test.
+
+    Returns:
+        A 200 response with a ``productsInfo`` list.
+    """
+    query = request.url.params.get("q", "")
+    if state.force_search_empty:
+        return httpx.Response(200, json={"productsInfo": []})
+
+    call_index = state.search_call_counts.get(query, 0)
+    state.search_call_counts[query] = call_index + 1
+
+    if query in state.oos_once and call_index == 0:
+        products = [_default_product(query, in_stock=False, price=1.99)]
+    else:
+        products = state.available_products.get(query, [_default_product(query)])
+    return httpx.Response(200, json={"productsInfo": products})
+
+
+def _handle_fulfillment() -> httpx.Response:
+    """Return a single available pickup fulfillment option.
+
+    Returns:
+        A 200 response with one available, fee-free pickup option.
+    """
+    return httpx.Response(
+        200,
+        json={
+            "fulfillmentOptions": [
+                {"type": "pickup", "available": True, "fee": 0.0, "windows": []},
+            ]
+        },
+    )
+
+
+def _build_safeway_handler(
+    state: SafewayMockState,
+) -> Callable[[httpx.Request], httpx.Response]:
+    """Build the routing handler for the mocked Safeway ``MockTransport``.
+
+    Routes on the request path to the Okta authn/authorize steps and
+    the Nimbus search/fulfillment/order endpoints that
+    ``grocery_butler.safeway_client`` and ``grocery_butler.cart_builder``
+    call.
+
+    Args:
+        state: The mutable state driving responses for this test.
+
+    Returns:
+        A handler suitable for ``httpx.MockTransport``.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        """Dispatch a mocked Safeway/Okta request to the right response."""
+        path = request.url.path
+        state.requested_paths.append(path)
+
+        if path == "/api/v1/authn":
+            return _handle_authn(state)
+        if path == f"/oauth2/{OKTA_CLIENT_ID}/v1/authorize":
+            return _handle_authorize()
+        if path == "/api/v2/grocerystore/search":
+            return _handle_search(request, state)
+        if path.startswith("/abs/pub/web/stores/") and path.endswith("/fulfillment"):
+            return _handle_fulfillment()
+        if path == "/abs/pub/web/orders":
+            return httpx.Response(200, json=state.order_response)
+        return httpx.Response(404, json={"error": f"unhandled path {path}"})
+
+    return handler
+
+
+@pytest.fixture()
+def safeway_mock(monkeypatch: pytest.MonkeyPatch) -> SafewayMockState:
+    """Route ``SafewayPipeline``'s HTTP client through a ``MockTransport``.
+
+    Kills the real rate limiter (no ``time.sleep`` in tests) and wraps
+    the real :class:`SafewayClient` class so ``SafewayPipeline`` gets a
+    client whose ``http_client`` is backed by an in-process
+    ``httpx.MockTransport`` -- no real network traffic, and no
+    ``grocery_butler`` service classes are mocked.
+
+    Args:
+        monkeypatch: Pytest's monkeypatch fixture.
+
+    Returns:
+        The mutable :class:`SafewayMockState` scenarios drive and assert on.
+    """
+    state = SafewayMockState()
+    handler = _build_safeway_handler(state)
+    monkeypatch.setattr("grocery_butler.safeway_client._MIN_REQUEST_INTERVAL", 0.0)
+
+    def factory(**kwargs: Any) -> _RealSafewayClient:
+        """Build a real SafewayClient wired to the mock transport."""
+        return _RealSafewayClient(
+            **kwargs,
+            http_client=httpx.Client(transport=httpx.MockTransport(handler)),
+        )
+
+    monkeypatch.setattr("grocery_butler.safeway_pipeline.SafewayClient", factory)
+    return state

--- a/tests/e2e/test_api_chain.py
+++ b/tests/e2e/test_api_chain.py
@@ -1,0 +1,169 @@
+"""E2E: the full happy-path chain from meal text to a confirmed order.
+
+Exercises every layer with real wiring -- ``MealParser`` + a seeded
+recipe, ``Consolidator``, ``SafewayPipeline`` (``CartBuilder`` +
+``OrderService``) over a ``MockTransport``, and the pending-actions
+staging/confirmation flow. Uses only items that resolve cleanly (no
+substitutions): bug #70 blocks driving a substituted cart through
+submit -> confirm, so that path is covered (and excluded past preview)
+separately in ``test_ordering.py``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from grocery_butler.models import ParsedMeal, PendingActionStatus
+from grocery_butler.pending_actions import PendingActionsStore
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from flask.testing import FlaskClient
+
+    from tests.e2e.conftest import SafewayMockState
+
+pytestmark = pytest.mark.e2e
+
+
+def _stage_order(
+    client: FlaskClient,
+    headers: dict[str, str],
+    meal_name: str,
+) -> str:
+    """Run meals/parse -> shopping-list/preview -> order/preview -> submit.
+
+    Args:
+        client: The Flask test client.
+        headers: Bearer auth headers.
+        meal_name: Name of a recipe already resolvable via the recipe store.
+
+    Returns:
+        The ``action_id`` of the staged ``safeway_order_submit`` action.
+    """
+    parsed = client.post(
+        "/api/v1/meals/parse",
+        json={"text": meal_name},
+        headers=headers,
+    )
+    meals = parsed.get_json()["meals"]
+    preview = client.post(
+        "/api/v1/shopping-list/preview",
+        json={"meals": meals, "include_restock": False},
+        headers=headers,
+    )
+    shopping_list = preview.get_json()["items"]
+    order_preview = client.post(
+        "/api/v1/order/preview",
+        json={"shopping_list": shopping_list},
+        headers=headers,
+    )
+    order_body = order_preview.get_json()
+    submitted = client.post(
+        "/api/v1/order/submit",
+        json={"cart": order_body["cart"], "total": order_body["total"]},
+        headers=headers,
+    )
+    action_id: str = submitted.get_json()["action_id"]
+    return action_id
+
+
+def test_full_chain_meal_to_confirmed_order(
+    client: FlaskClient,
+    signed_headers: Callable[..., dict[str, str]],
+    seed_recipe: ParsedMeal,
+    no_claude: None,
+    safeway_mock: SafewayMockState,
+    db_path: str,
+) -> None:
+    """meals/parse -> shopping-list/preview -> order/preview -> submit -> confirm."""
+    headers = signed_headers()
+
+    parsed = client.post(
+        "/api/v1/meals/parse",
+        json={"text": seed_recipe.name},
+        headers=headers,
+    )
+    assert parsed.status_code == 200
+    meals = parsed.get_json()["meals"]
+    assert len(meals) == 1
+    assert meals[0]["known_recipe"] is True
+
+    preview = client.post(
+        "/api/v1/shopping-list/preview",
+        json={"meals": meals, "include_restock": False},
+        headers=headers,
+    )
+    assert preview.status_code == 200
+    shopping_list = preview.get_json()["items"]
+    assert {item["ingredient"] for item in shopping_list} == {
+        "ground beef",
+        "spaghetti",
+        "tomato sauce",
+    }
+
+    order_preview = client.post(
+        "/api/v1/order/preview",
+        json={"shopping_list": shopping_list},
+        headers=headers,
+    )
+    assert order_preview.status_code == 200
+    order_body = order_preview.get_json()
+    cart = order_body["cart"]
+    assert cart["failed_items"] == []
+    assert cart["substituted_items"] == []
+    assert len(cart["items"]) == 3
+
+    submitted = client.post(
+        "/api/v1/order/submit",
+        json={"cart": cart, "total": order_body["total"]},
+        headers=headers,
+    )
+    assert submitted.status_code == 200
+    submit_body = submitted.get_json()
+    assert submit_body["status"] == "pending_confirmation"
+    action_id = submit_body["action_id"]
+
+    confirmed = client.post(
+        "/api/v1/actions/confirm",
+        json={"action_id": action_id},
+        headers=headers,
+    )
+    assert confirmed.status_code == 200
+    confirm_body = confirmed.get_json()
+    assert confirm_body["status"] == "approved"
+    assert confirm_body["result"]["order_id"] == "e2e-order-1"
+
+    pending = PendingActionsStore(db_path).get_pending_action(action_id)
+    assert pending is not None
+    assert pending.status is PendingActionStatus.APPROVED
+
+    assert "/abs/pub/web/orders" in safeway_mock.requested_paths
+
+
+def test_confirming_same_action_twice_returns_409(
+    client: FlaskClient,
+    signed_headers: Callable[..., dict[str, str]],
+    seed_recipe: ParsedMeal,
+    no_claude: None,
+    safeway_mock: SafewayMockState,
+) -> None:
+    """A second confirm call for an already-resolved action is rejected."""
+    headers = signed_headers()
+    action_id = _stage_order(client, headers, seed_recipe.name)
+
+    first = client.post(
+        "/api/v1/actions/confirm",
+        json={"action_id": action_id},
+        headers=headers,
+    )
+    assert first.status_code == 200
+
+    second = client.post(
+        "/api/v1/actions/confirm",
+        json={"action_id": action_id},
+        headers=headers,
+    )
+    assert second.status_code == 409

--- a/tests/e2e/test_auth.py
+++ b/tests/e2e/test_auth.py
@@ -1,0 +1,76 @@
+"""E2E: bearer-token authentication rejects invalid requests, accepts valid ones.
+
+Exercises the real ``grocery_butler.auth_middleware`` module end to end
+through a live Flask route -- only the request's ``Authorization``
+header changes between scenarios; nothing in the auth module is mocked.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from flask.testing import FlaskClient
+
+pytestmark = pytest.mark.e2e
+
+INVENTORY_PATH = "/api/v1/inventory"
+
+
+def test_missing_authorization_returns_401(client: FlaskClient) -> None:
+    """A request with no Authorization header is rejected."""
+    response = client.get(INVENTORY_PATH)
+    assert response.status_code == 401
+
+
+def test_malformed_token_returns_401(client: FlaskClient) -> None:
+    """A syntactically invalid bearer token is rejected."""
+    response = client.get(
+        INVENTORY_PATH,
+        headers={"Authorization": "Bearer not-a-real-token"},
+    )
+    assert response.status_code == 401
+
+
+def test_foreign_secret_signature_returns_401(
+    client: FlaskClient,
+    signed_headers: Callable[..., dict[str, str]],
+) -> None:
+    """A token signed with a different shared secret is rejected."""
+    headers = signed_headers(secret="a-different-shared-secret")
+    response = client.get(INVENTORY_PATH, headers=headers)
+    assert response.status_code == 401
+
+
+def test_expired_token_returns_401(
+    client: FlaskClient,
+    signed_headers: Callable[..., dict[str, str]],
+) -> None:
+    """A token older than the backward TTL window is rejected."""
+    headers = signed_headers(now_offset=-400.0)
+    response = client.get(INVENTORY_PATH, headers=headers)
+    assert response.status_code == 401
+
+
+def test_future_dated_token_returns_401(
+    client: FlaskClient,
+    signed_headers: Callable[..., dict[str, str]],
+) -> None:
+    """A token minted too far in the future is rejected (clock-skew guard)."""
+    headers = signed_headers(now_offset=120.0)
+    response = client.get(INVENTORY_PATH, headers=headers)
+    assert response.status_code == 401
+
+
+def test_valid_token_on_protected_route_returns_200(
+    client: FlaskClient,
+    signed_headers: Callable[..., dict[str, str]],
+) -> None:
+    """A validly signed, fresh token is accepted."""
+    response = client.get(INVENTORY_PATH, headers=signed_headers())
+    assert response.status_code == 200
+    assert response.get_json() == {"items": []}

--- a/tests/e2e/test_brands.py
+++ b/tests/e2e/test_brands.py
@@ -1,0 +1,88 @@
+"""E2E: brand preference staging via ``/brands/set`` -> confirm/deny.
+
+The web ``/brands/<id>/remove`` form flow is excluded here: it is an
+open bug (#63) where ``templates/brands.html`` links using
+``loop.index`` instead of the preference's real database id (the
+``BrandPreference`` model returned by ``get_brand_preferences`` has no
+``id`` field at all, so the template can only be coincidentally
+correct). That is a templating defect in a different layer than the
+``/api/v1`` blueprint this suite covers, and is reported back rather
+than fixed here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from flask.testing import FlaskClient
+
+pytestmark = pytest.mark.e2e
+
+
+def _brand_body() -> dict[str, str]:
+    """Return a valid ``/brands/set`` request body.
+
+    Returns:
+        A JSON-serializable request body dict.
+    """
+    return {
+        "match_target": "milk",
+        "match_type": "ingredient",
+        "brand": "Organic Valley",
+        "preference_type": "preferred",
+        "notes": "e2e",
+    }
+
+
+def test_brands_set_then_confirm_is_applied(
+    client: FlaskClient,
+    signed_headers: Callable[..., dict[str, str]],
+    no_claude: None,
+) -> None:
+    """Confirming a staged brand rule persists it to the real RecipeStore."""
+    headers = signed_headers()
+    staged = client.post("/api/v1/brands/set", json=_brand_body(), headers=headers)
+    assert staged.status_code == 200
+    body = staged.get_json()
+    assert body["status"] == "pending_confirmation"
+    action_id = body["action_id"]
+
+    confirmed = client.post(
+        "/api/v1/actions/confirm",
+        json={"action_id": action_id},
+        headers=headers,
+    )
+    assert confirmed.status_code == 200
+    assert confirmed.get_json()["status"] == "approved"
+
+    listed = client.get("/api/v1/brands", headers=headers)
+    brands = [b["brand"] for b in listed.get_json()["brands"]]
+    assert "Organic Valley" in brands
+
+
+def test_brands_set_then_deny_is_not_applied(
+    client: FlaskClient,
+    signed_headers: Callable[..., dict[str, str]],
+    no_claude: None,
+) -> None:
+    """Denying a staged brand rule leaves the RecipeStore untouched."""
+    headers = signed_headers()
+    staged = client.post("/api/v1/brands/set", json=_brand_body(), headers=headers)
+    action_id = staged.get_json()["action_id"]
+
+    denied = client.post(
+        "/api/v1/actions/deny",
+        json={"action_id": action_id},
+        headers=headers,
+    )
+    assert denied.status_code == 200
+    assert denied.get_json()["status"] == "denied"
+
+    listed = client.get("/api/v1/brands", headers=headers)
+    brands = [b["brand"] for b in listed.get_json()["brands"]]
+    assert "Organic Valley" not in brands

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -1,0 +1,118 @@
+"""E2E: CLI subcommands against a real SQLite database.
+
+The CLI's ``order`` subcommand builds its own ``SafewayPipeline``
+directly from ``Config`` with no transport-injection hook, so it is not
+exercised here -- the API/pipeline tests in ``test_ordering.py`` and
+``test_api_chain.py`` cover that pipeline through the injectable
+``safeway_mock`` seam instead.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from grocery_butler import cli
+from grocery_butler.models import Ingredient, IngredientCategory, ParsedMeal
+from grocery_butler.pantry_manager import PantryManager
+from grocery_butler.recipe_store import RecipeStore
+
+pytestmark = pytest.mark.e2e
+
+
+def _run(argv: list[str]) -> int:
+    """Run the CLI and return its exit code.
+
+    Args:
+        argv: Argument list to pass to ``cli.main`` (without the program name).
+
+    Returns:
+        The process exit code raised via ``SystemExit``.
+    """
+    with pytest.raises(SystemExit) as exc_info:
+        cli.main(argv)
+    return int(exc_info.value.code or 0)
+
+
+def _sample_meal() -> ParsedMeal:
+    """Return a minimal ParsedMeal for seeding the recipe store directly.
+
+    Returns:
+        A simple two-ingredient meal named "e2e cli meal".
+    """
+    return ParsedMeal(
+        name="e2e cli meal",
+        servings=2,
+        known_recipe=True,
+        needs_confirmation=False,
+        purchase_items=[
+            Ingredient(
+                ingredient="rice",
+                quantity=1.0,
+                unit="cup",
+                category=IngredientCategory.PANTRY_DRY,
+            ),
+        ],
+        pantry_items=[],
+    )
+
+
+def test_stock_lifecycle_and_restock_round_trip(
+    db_path: str,
+    no_claude_cli: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``stock add/low`` + ``restock`` show/clear round-trip via the real DB."""
+    assert _run(["stock", "add", "cumin", "pantry_dry"]) == 0
+    assert _run(["stock", "low", "cumin"]) == 0
+
+    capsys.readouterr()
+    assert _run(["restock"]) == 0
+    restock_output = capsys.readouterr().out
+    assert "Cumin" in restock_output
+
+    assert _run(["restock", "clear"]) == 0
+    clear_output = capsys.readouterr().out
+    assert "Cleared 1 item" in clear_output
+
+    manager = PantryManager(db_path)
+    item = manager.get_item("cumin")
+    assert item is not None
+    assert item.status.value == "on_hand"
+
+
+def test_recipes_and_pantry_round_trip(
+    db_path: str,
+    no_claude_cli: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``recipes`` list and ``pantry`` add/list/remove round-trip via the real DB."""
+    RecipeStore(db_path).save_recipe(_sample_meal())
+
+    capsys.readouterr()
+    assert _run(["recipes"]) == 0
+    recipes_output = capsys.readouterr().out
+    assert "e2e cli meal" in recipes_output
+
+    assert _run(["pantry", "add", "cumin", "pantry_dry"]) == 0
+    assert _run(["pantry"]) == 0
+    pantry_output = capsys.readouterr().out
+    assert "Cumin" in pantry_output
+
+    assert _run(["pantry", "remove", "cumin"]) == 0
+    assert _run(["pantry"]) == 0
+    after_output = capsys.readouterr().out
+    assert "Cumin" not in after_output
+
+
+def test_plan_seeded_recipe_prints_deterministic_shopping_list(
+    seed_recipe: ParsedMeal,
+    no_claude_cli: None,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``plan <seeded recipe>`` prints a deterministic shopping list."""
+    capsys.readouterr()
+    assert _run(["plan", seed_recipe.name]) == 0
+    output = capsys.readouterr().out
+    assert "ground beef" in output
+    assert "spaghetti" in output
+    assert "tomato sauce" in output

--- a/tests/e2e/test_inventory.py
+++ b/tests/e2e/test_inventory.py
@@ -1,0 +1,83 @@
+"""E2E: inventory and restock queue endpoints against a real SQLite DB.
+
+No Claude/Safeway seams needed here -- pure Flask + PantryManager + a
+real temporary SQLite database.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from flask.testing import FlaskClient
+
+pytestmark = pytest.mark.e2e
+
+
+def test_stock_add_then_inventory_then_duplicate_conflicts(
+    client: FlaskClient,
+    signed_headers: Callable[..., dict[str, str]],
+) -> None:
+    """Adding a new item succeeds once; a duplicate add returns 409."""
+    headers = signed_headers()
+    body = {"item": "oat milk", "category": "dairy"}
+
+    created = client.post("/api/v1/stock/add", json=body, headers=headers)
+    assert created.status_code == 201
+    assert created.get_json()["ingredient"] == "oat milk"
+
+    listed = client.get("/api/v1/inventory", headers=headers)
+    assert listed.status_code == 200
+    ingredients = [item["ingredient"] for item in listed.get_json()["items"]]
+    assert "oat milk" in ingredients
+
+    duplicate = client.post("/api/v1/stock/add", json=body, headers=headers)
+    assert duplicate.status_code == 409
+
+
+def test_restock_queue_lifecycle_and_untracked_update_404(
+    client: FlaskClient,
+    signed_headers: Callable[..., dict[str, str]],
+) -> None:
+    """Restock queue reflects low/out status and clears; unknown items 404."""
+    headers = signed_headers()
+    client.post(
+        "/api/v1/stock/add",
+        json={"item": "eggs", "category": "dairy"},
+        headers=headers,
+    )
+
+    low = client.post(
+        "/api/v1/stock/update",
+        json={"item": "eggs", "status": "low"},
+        headers=headers,
+    )
+    assert low.status_code == 200
+    restock_low = client.get("/api/v1/restock", headers=headers)
+    assert "eggs" in [i["ingredient"] for i in restock_low.get_json()["items"]]
+
+    out = client.post(
+        "/api/v1/stock/update",
+        json={"item": "eggs", "status": "out"},
+        headers=headers,
+    )
+    assert out.status_code == 200
+    restock_out = client.get("/api/v1/restock", headers=headers)
+    assert "eggs" in [i["ingredient"] for i in restock_out.get_json()["items"]]
+
+    cleared = client.post("/api/v1/restock/clear", headers=headers)
+    assert cleared.status_code == 200
+    assert cleared.get_json()["cleared"] >= 1
+    restock_after = client.get("/api/v1/restock", headers=headers)
+    assert restock_after.get_json()["items"] == []
+
+    missing = client.post(
+        "/api/v1/stock/update",
+        json={"item": "unobtainium", "status": "low"},
+        headers=headers,
+    )
+    assert missing.status_code == 404

--- a/tests/e2e/test_ordering.py
+++ b/tests/e2e/test_ordering.py
@@ -1,0 +1,192 @@
+"""E2E: Safeway order preview/submit/confirm over a real pipeline + MockTransport.
+
+Every layer (``SafewayPipeline``, ``CartBuilder``, ``ProductSearchService``,
+``ProductSelector``, ``SubstitutionService``, ``OrderService``) runs for
+real; only the httpx transport inside ``SafewayClient`` is mocked.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from grocery_butler.safeway_client import OKTA_CLIENT_ID
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from flask.testing import FlaskClient
+
+    from tests.e2e.conftest import SafewayMockState
+
+pytestmark = pytest.mark.e2e
+
+
+def _shopping_list_body(ingredients: list[str]) -> dict[str, object]:
+    """Return an ``/order/preview`` request body for the given ingredients.
+
+    Args:
+        ingredients: Ingredient names to include, each treated as its
+            own search term with a simple default quantity/unit/category.
+
+    Returns:
+        A JSON-serializable request body dict.
+    """
+    return {
+        "shopping_list": [
+            {
+                "ingredient": name,
+                "quantity": 1.0,
+                "unit": "each",
+                "category": "other",
+                "search_term": name,
+                "from_meals": ["manual"],
+            }
+            for name in ingredients
+        ]
+    }
+
+
+def test_order_preview_happy_path_traverses_full_pipeline(
+    client: FlaskClient,
+    signed_headers: Callable[..., dict[str, str]],
+    no_claude: None,
+    safeway_mock: SafewayMockState,
+) -> None:
+    """A clean shopping list builds a cart and hits every pipeline stage."""
+    headers = signed_headers()
+    response = client.post(
+        "/api/v1/order/preview",
+        json=_shopping_list_body(["milk", "bread"]),
+        headers=headers,
+    )
+    assert response.status_code == 200
+    body = response.get_json()
+    cart = body["cart"]
+    assert len(cart["items"]) == 2
+    assert cart["failed_items"] == []
+    assert cart["substituted_items"] == []
+    assert cart["subtotal"] == pytest.approx(2 * 3.99)
+    assert body["total"] == "7.98"
+
+    assert "/api/v1/authn" in safeway_mock.requested_paths
+    assert f"/oauth2/{OKTA_CLIENT_ID}/v1/authorize" in safeway_mock.requested_paths
+    assert "/api/v2/grocerystore/search" in safeway_mock.requested_paths
+    assert any(p.endswith("/fulfillment") for p in safeway_mock.requested_paths)
+
+
+def test_order_preview_substitution_reflected_in_response(
+    client: FlaskClient,
+    signed_headers: Callable[..., dict[str, str]],
+    no_claude: None,
+    safeway_mock: SafewayMockState,
+) -> None:
+    """An out-of-stock primary product surfaces a substitute in the preview.
+
+    Bug #70 (open) blocks driving a substituted cart through
+    submit -> confirm, so this test stops at preview and does not
+    exercise ``/order/submit`` with a substituted item.
+    """
+    headers = signed_headers()
+    safeway_mock.oos_once.add("bell pepper")
+    safeway_mock.available_products["bell pepper"] = [
+        {
+            "upc": "upc-bell-pepper-alt",
+            "name": "Generic Bell Pepper (Alt)",
+            "price": 1.49,
+            "size": "1 each",
+            "inStock": True,
+        },
+    ]
+
+    response = client.post(
+        "/api/v1/order/preview",
+        json=_shopping_list_body(["bell pepper"]),
+        headers=headers,
+    )
+    assert response.status_code == 200
+    cart = response.get_json()["cart"]
+    assert cart["items"] == []
+    assert len(cart["substituted_items"]) == 1
+    substitution = cart["substituted_items"][0]
+    assert substitution["status"] == "alternatives_found"
+    assert substitution["original_item"]["ingredient"] == "bell pepper"
+    assert substitution["selected"] is not None
+    assert substitution["selected"]["product"]["name"] == "Generic Bell Pepper (Alt)"
+
+
+def test_order_preview_empty_search_yields_failed_item(
+    client: FlaskClient,
+    signed_headers: Callable[..., dict[str, str]],
+    no_claude: None,
+    safeway_mock: SafewayMockState,
+) -> None:
+    """An ingredient with no search results ends up in failed_items."""
+    headers = signed_headers()
+    safeway_mock.force_search_empty = True
+
+    response = client.post(
+        "/api/v1/order/preview",
+        json=_shopping_list_body(["unobtainium"]),
+        headers=headers,
+    )
+    assert response.status_code == 200
+    cart = response.get_json()["cart"]
+    assert cart["items"] == []
+    assert [item["ingredient"] for item in cart["failed_items"]] == ["unobtainium"]
+
+
+def test_order_preview_auth_failure_returns_503(
+    client: FlaskClient,
+    signed_headers: Callable[..., dict[str, str]],
+    no_claude: None,
+    safeway_mock: SafewayMockState,
+) -> None:
+    """A failing Okta authn step surfaces as a 503, not a 500."""
+    headers = signed_headers()
+    safeway_mock.force_auth_fail = True
+
+    response = client.post(
+        "/api/v1/order/preview",
+        json=_shopping_list_body(["milk"]),
+        headers=headers,
+    )
+    assert response.status_code == 503
+    assert "safeway" in response.get_json()["error"].lower()
+
+
+def test_order_submit_confirm_hits_orders_endpoint_with_confirmation(
+    client: FlaskClient,
+    signed_headers: Callable[..., dict[str, str]],
+    no_claude: None,
+    safeway_mock: SafewayMockState,
+) -> None:
+    """Confirming a staged, non-substituted cart really submits the order."""
+    headers = signed_headers()
+    preview = client.post(
+        "/api/v1/order/preview",
+        json=_shopping_list_body(["milk", "eggs"]),
+        headers=headers,
+    )
+    body = preview.get_json()
+    assert body["cart"]["substituted_items"] == []
+
+    submitted = client.post(
+        "/api/v1/order/submit",
+        json={"cart": body["cart"], "total": body["total"]},
+        headers=headers,
+    )
+    action_id = submitted.get_json()["action_id"]
+
+    confirmed = client.post(
+        "/api/v1/actions/confirm",
+        json={"action_id": action_id},
+        headers=headers,
+    )
+    assert confirmed.status_code == 200
+    result = confirmed.get_json()["result"]
+    assert result["order_id"] == "e2e-order-1"
+    assert result["status"] == "confirmed"
+    assert isinstance(result["items_restocked"], int)
+    assert safeway_mock.requested_paths.count("/abs/pub/web/orders") == 1

--- a/tests/e2e/test_pantry.py
+++ b/tests/e2e/test_pantry.py
@@ -1,0 +1,73 @@
+"""E2E: pantry staple web-form add/remove, verified through the JSON API.
+
+The web routes (``/pantry/add``, ``/pantry/<id>/remove``) don't require
+a bearer token; the read-back goes through the real bearer-protected
+``/api/v1/pantry`` endpoint.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from flask.testing import FlaskClient
+
+pytestmark = pytest.mark.e2e
+
+
+def _staple_names(client: FlaskClient, headers: dict[str, str]) -> list[str]:
+    """Return the ingredient names of all tracked pantry staples.
+
+    Args:
+        client: The Flask test client.
+        headers: Bearer auth headers for the API request.
+
+    Returns:
+        List of ingredient name strings currently tracked as staples.
+    """
+    response = client.get("/api/v1/pantry", headers=headers)
+    return [s["ingredient"] for s in response.get_json()["staples"]]
+
+
+def test_pantry_add_form_reflected_in_api_and_duplicate_is_safe(
+    client: FlaskClient,
+    signed_headers: Callable[..., dict[str, str]],
+) -> None:
+    """Adding a staple via the web form shows up through the API; dup is safe."""
+    headers = signed_headers()
+
+    added = client.post(
+        "/pantry/add",
+        data={"ingredient": "cumin", "category": "pantry_dry"},
+    )
+    assert added.status_code in (302, 303)
+    assert "cumin" in _staple_names(client, headers)
+
+    duplicate = client.post(
+        "/pantry/add",
+        data={"ingredient": "cumin", "category": "pantry_dry"},
+    )
+    assert duplicate.status_code in (302, 303)
+    assert _staple_names(client, headers).count("cumin") == 1
+
+
+def test_pantry_remove_form_no_longer_listed(
+    client: FlaskClient,
+    signed_headers: Callable[..., dict[str, str]],
+) -> None:
+    """Removing a staple via its web form drops it from the API listing."""
+    headers = signed_headers()
+    client.post("/pantry/add", data={"ingredient": "cumin", "category": "pantry_dry"})
+
+    response = client.get("/api/v1/pantry", headers=headers)
+    staple = next(
+        s for s in response.get_json()["staples"] if s["ingredient"] == "cumin"
+    )
+
+    removed = client.post(f"/pantry/{staple['id']}/remove")
+    assert removed.status_code in (302, 303)
+    assert "cumin" not in _staple_names(client, headers)

--- a/tests/e2e/test_recipes.py
+++ b/tests/e2e/test_recipes.py
@@ -1,0 +1,121 @@
+"""E2E: recipe save/list/detail/delete and meals/parse recipe reuse.
+
+``no_claude`` keeps the suite fully offline. ``/recipes/save`` never
+touches Claude at all, and scenario 17 saves the recipe before parsing
+it, so ``MealParser.find_recipe`` resolves it on the direct
+``RecipeStore`` lookup -- before any Claude call would even be
+attempted.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from flask.testing import FlaskClient
+
+pytestmark = pytest.mark.e2e
+
+
+def _save_body(name: str = "e2e taco night") -> dict[str, object]:
+    """Return a valid ``/recipes/save`` request body.
+
+    Args:
+        name: Recipe name to save.
+
+    Returns:
+        A JSON-serializable request body dict.
+    """
+    return {
+        "name": name,
+        "servings": 4,
+        "ingredients": [
+            {
+                "ingredient": "corn tortillas",
+                "quantity": 8,
+                "unit": "each",
+                "category": "bakery",
+                "is_pantry_item": False,
+            },
+            {
+                "ingredient": "salt",
+                "quantity": 1,
+                "unit": "tsp",
+                "category": "pantry_dry",
+                "is_pantry_item": True,
+            },
+        ],
+    }
+
+
+def test_save_list_detail_then_duplicate_conflicts(
+    client: FlaskClient,
+    signed_headers: Callable[..., dict[str, str]],
+    no_claude: None,
+) -> None:
+    """Saving a recipe makes it listable and fetchable; duplicates 409."""
+    headers = signed_headers()
+    body = _save_body()
+
+    created = client.post("/api/v1/recipes/save", json=body, headers=headers)
+    assert created.status_code == 201
+    recipe_id = created.get_json()["id"]
+
+    listed = client.get("/api/v1/recipes", headers=headers)
+    names = [r["display_name"] for r in listed.get_json()["recipes"]]
+    assert "e2e taco night" in names
+
+    detail = client.get(f"/api/v1/recipes/{recipe_id}", headers=headers)
+    assert detail.status_code == 200
+    assert detail.get_json()["name"] == "e2e taco night"
+
+    duplicate = client.post("/api/v1/recipes/save", json=body, headers=headers)
+    assert duplicate.status_code == 409
+
+
+def test_meals_parse_reuses_saved_recipe_without_claude(
+    client: FlaskClient,
+    signed_headers: Callable[..., dict[str, str]],
+    no_claude: None,
+) -> None:
+    """Parsing a saved recipe's name returns its stored ingredients."""
+    headers = signed_headers()
+    client.post("/api/v1/recipes/save", json=_save_body(), headers=headers)
+
+    response = client.post(
+        "/api/v1/meals/parse",
+        json={"text": "e2e taco night"},
+        headers=headers,
+    )
+    assert response.status_code == 200
+    meals = response.get_json()["meals"]
+    assert len(meals) == 1
+    meal = meals[0]
+    assert meal["known_recipe"] is True
+    ingredients = [i["ingredient"] for i in meal["purchase_items"]]
+    assert "corn tortillas" in ingredients
+
+
+def test_delete_recipe_then_detail_404(
+    client: FlaskClient,
+    signed_headers: Callable[..., dict[str, str]],
+    no_claude: None,
+) -> None:
+    """Deleting a recipe removes it; its detail page then 404s."""
+    headers = signed_headers()
+    created = client.post(
+        "/api/v1/recipes/save",
+        json=_save_body("e2e one-off"),
+        headers=headers,
+    )
+    recipe_id = created.get_json()["id"]
+
+    deleted = client.delete(f"/api/v1/recipes/{recipe_id}", headers=headers)
+    assert deleted.status_code == 204
+
+    detail = client.get(f"/api/v1/recipes/{recipe_id}", headers=headers)
+    assert detail.status_code == 404


### PR DESCRIPTION
## Summary

- Adds a true end-to-end suite (`tests/e2e/`, 25 scenarios) that exercises **real wiring** — real `create_app`, real SQLite temp DB, real stores/services/`SafewayPipeline` — mocking **only at the external boundaries**: the Anthropic SDK client object and the httpx transport inside `SafewayClient` (`httpx.MockTransport`). No internal grocery-butler class is MagicMocked.
- Covers the post-pivot `/api/v1` headline chain per the 2026-07-10 re-scoping comment: `meals/parse -> shopping-list/preview -> order/preview -> order/submit -> actions/confirm` (staged confirmation via the real `PendingActionsStore`), plus the full HMAC bearer-token boundary (missing / malformed / foreign-secret / expired / future tokens -> exact 401s; valid token -> 200).
- Also covered end-to-end: ordering happy path (asserts authn + authorize + search + fulfillment all traverse the real `SafewayClient`), substitution surfaced at `order/preview`, empty-search -> `failed_items`, Safeway auth outage -> 503, double-confirm -> 409, inventory + restock lifecycle, recipe CRUD + reuse-without-Claude, pantry staples via web form + API, brand preferences staged confirm/deny, and CLI round-trips (`stock`/`restock`/`recipes`/`pantry`/`plan`) against the real database.
- Registers the `e2e` and `integration` pytest markers in `pyproject.toml` (required by `--strict-markers`); `./scripts/test.sh --unit` continues to exclude e2e while the coverage gate and CI run them.

## Scope decisions

- **Open bugs deliberately excluded** so the suite is green today; each exclusion is documented in the module docstrings, and the infrastructure makes a one-scenario regression test trivial when each bug's own PR lands: #57 (fixture always passes explicit `db_path`), #63 (web brand-remove form not exercised), #66 (only seeded recipes drive parsing), #70 (substitution asserted at preview only; submit/confirm scenarios use no-substitution carts).
- **Out of scope**: Postgres-backed variant (dialect drift, e.g. #67) — recommend a follow-up issue; CLI `order` subcommand (constructs its own pipeline with no transport-injection hook; the API ordering tests cover the pipeline).
- Filed while working this issue: #97 (API order path never passes `restock_items` to `CartBuilder` — `items_restocked` is always 0; the affected test asserts actual behavior without endorsing it), #91 (dev-toolchain reproducibility), #92 (radon MI check is a no-op).
- The `fake_claude` conftest fixture is currently unused by design — it provisions the sanctioned Anthropic seam for future scenarios that need a scripted Claude decision (all current scenarios use the deterministic no-client fallbacks).

## Test plan

- `./scripts/check-all.sh` -> exit 0 (ruff lint + format, mypy strict, bandit + pip-audit clean, complexity, 1166 unit tests + 25 e2e under the coverage gate: 1191 passed, 8 skipped, **93.93% branch coverage** vs 90% floor).
- e2e suite alone: 25 passed in well under 1s wall time (rate-limiter sleep neutralized via the sanctioned `_MIN_REQUEST_INTERVAL` seam; no network, no wall-clock races).
- Every scenario verified non-vacuous: assertions were sabotaged (flipped availability, dropped seed, corrupted token, etc.), confirmed to fail for the predicted reason, then restored to green.
- Gate 2.5 self-review (code-review-orchestrator): CLEAN. Security review of secret hygiene / auth coverage: CLEAN (all fixture secrets are obvious literal fakes; auth negatives go through the real verifier).

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)
