### PR TITLE
fix: create_app() resolves DATABASE_URL/DATABASE_PATH so production uses Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ and easy to operate alone.**
 ### Web
 
 - **Flask 3** — small, explicit, and fits on a single Railway dyno without
-  ceremony. The app is constructed by an `create_app(db_path)` factory so
+  ceremony. The app is constructed by a `create_app(db_path=None)` factory so
   tests can spin up isolated instances against a tmpfile database.
 - **Jinja2 templates + Pico CSS** — server-rendered HTML, no SPA, no build
   step. The dashboard is meant to be operated from a phone in the kitchen,
@@ -318,8 +318,10 @@ Grocery Butler exposes the same domain through three distinct surface areas.
 
 ### HTTP / Web API
 
-Constructed by `grocery_butler.app.create_app(db_path: str)`. All routes are
-server-rendered HTML except where noted.
+Constructed by `grocery_butler.app.create_app(db_path: str | None = None)`.
+With no argument, it resolves `DATABASE_URL`, then `DATABASE_PATH`, then
+defaults to `mealbot.db` — this is how production gunicorn invokes it. All
+routes are server-rendered HTML except where noted.
 
 #### Health
 

--- a/grocery_butler/app.py
+++ b/grocery_butler/app.py
@@ -37,11 +37,42 @@ from grocery_butler.recipe_store import RecipeStore
 logger = logging.getLogger(__name__)
 
 
-def create_app(db_path: str = "mealbot.db") -> Flask:
+def _resolve_database_target(db_path: str | None) -> str:
+    """Resolve the database path or connection URL to use for the app.
+
+    Resolution order: an explicit ``db_path`` argument always wins. When
+    ``db_path`` is ``None`` (as it is for the production gunicorn
+    invocation ``gunicorn 'grocery_butler.app:create_app()'``, which calls
+    the factory with no arguments), the ``DATABASE_URL`` environment
+    variable is used if set, then ``DATABASE_PATH``, then finally the
+    ``"mealbot.db"`` local SQLite default. An empty-string ``DATABASE_URL``
+    is treated as unset (hence the ``or`` fallback) so a blank env var
+    doesn't silently mask ``DATABASE_PATH`` or the default.
+
+    Args:
+        db_path: Explicit database path or connection URL, or ``None`` to
+            resolve from the environment.
+
+    Returns:
+        The resolved database path or connection URL string.
+    """
+    if db_path is not None:
+        return db_path
+    return os.environ.get("DATABASE_URL") or os.environ.get(
+        "DATABASE_PATH", "mealbot.db"
+    )
+
+
+def create_app(db_path: str | None = None) -> Flask:
     """Create and configure the Flask application.
 
     Args:
-        db_path: Path to the SQLite database file.
+        db_path: Explicit database path or connection URL. When ``None``
+            (the default), the target is resolved from the ``DATABASE_URL``
+            environment variable, then ``DATABASE_PATH``, then finally the
+            ``"mealbot.db"`` local SQLite default. This lets the production
+            gunicorn invocation, which calls ``create_app()`` with no
+            arguments, pick up the Railway-provisioned Postgres URL.
 
     Returns:
         Configured Flask application instance.
@@ -51,10 +82,11 @@ def create_app(db_path: str = "mealbot.db") -> Flask:
         template_folder="templates",
         static_folder="static",
     )
-    app.config["DATABASE_PATH"] = db_path
+    resolved = _resolve_database_target(db_path)
+    app.config["DATABASE_PATH"] = resolved
     app.config["SECRET_KEY"] = os.environ.get("FLASK_SECRET_KEY", os.urandom(32).hex())
 
-    init_db(db_path)
+    init_db(resolved)
 
     _register_teardown(app)
     _register_error_handlers(app)

--- a/tests/test_deployment_wiring.py
+++ b/tests/test_deployment_wiring.py
@@ -168,3 +168,123 @@ def _dockerfile_cmd() -> str:
         if stripped.startswith("CMD "):
             command = stripped.removeprefix("CMD ")
     return command
+
+
+# ---------------------------------------------------------------------------
+# App factory database wiring (issue #57)
+# ---------------------------------------------------------------------------
+
+FAKE_POSTGRES_DSN = "postgresql://user:pass@db.example/testdb"
+
+
+def _noop_init_db(db_path: str) -> None:
+    """Stand in for ``grocery_butler.app.init_db`` without a live connection.
+
+    A ``postgresql://`` DSN passed to the real ``init_db`` would attempt to
+    open an actual network connection via psycopg2, which these tests must
+    not do since ``FAKE_POSTGRES_DSN`` points at a non-existent host.
+
+    Args:
+        db_path: Path or URL that would normally be initialized. Unused.
+    """
+
+
+class TestAppFactoryDatabaseWiring:
+    """create_app() must resolve DATABASE_URL/DATABASE_PATH env vars.
+
+    The production gunicorn invocation (``gunicorn
+    'grocery_butler.app:create_app()'``) calls ``create_app()`` with no
+    arguments, so the factory itself must read the Railway-provided
+    ``DATABASE_URL`` (or ``DATABASE_PATH``) environment variable. Without
+    this, every deploy silently falls back to the ``"mealbot.db"`` default,
+    writing to ephemeral SQLite instead of the persistent Postgres database
+    (issue #57).
+    """
+
+    def test_create_app_no_args_uses_database_url_when_set(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """create_app() with no args stores DATABASE_URL as the db target.
+
+        Args:
+            monkeypatch: Pytest fixture for patching env vars and attributes.
+        """
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        monkeypatch.delenv("DATABASE_PATH", raising=False)
+        monkeypatch.setenv("DATABASE_URL", FAKE_POSTGRES_DSN)
+        monkeypatch.setattr("grocery_butler.app.init_db", _noop_init_db)
+
+        application = create_app()
+
+        assert application.config["DATABASE_PATH"] == FAKE_POSTGRES_DSN
+
+    def test_create_app_no_args_uses_database_path_when_only_path_set(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """create_app() with no args falls back to DATABASE_PATH when set.
+
+        Args:
+            monkeypatch: Pytest fixture for patching env vars.
+            tmp_path: Pytest fixture providing an isolated temp directory.
+        """
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        monkeypatch.delenv("DATABASE_PATH", raising=False)
+        env_db_path = str(tmp_path / "env_configured.db")
+        monkeypatch.setenv("DATABASE_PATH", env_db_path)
+
+        application = create_app()
+
+        assert application.config["DATABASE_PATH"] == env_db_path
+
+    def test_create_app_prefers_database_url_over_database_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """DATABASE_URL takes precedence when both env vars are set.
+
+        Args:
+            monkeypatch: Pytest fixture for patching env vars and attributes.
+            tmp_path: Pytest fixture providing an isolated temp directory.
+        """
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        monkeypatch.delenv("DATABASE_PATH", raising=False)
+        monkeypatch.setenv("DATABASE_URL", FAKE_POSTGRES_DSN)
+        monkeypatch.setenv("DATABASE_PATH", str(tmp_path / "should_be_ignored.db"))
+        monkeypatch.setattr("grocery_butler.app.init_db", _noop_init_db)
+
+        application = create_app()
+
+        assert application.config["DATABASE_PATH"] == FAKE_POSTGRES_DSN
+
+    def test_create_app_defaults_to_mealbot_db_when_env_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """create_app() falls back to "mealbot.db" when no env var is set.
+
+        Args:
+            monkeypatch: Pytest fixture for patching env vars and attributes.
+        """
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        monkeypatch.delenv("DATABASE_PATH", raising=False)
+        monkeypatch.setattr("grocery_butler.app.init_db", _noop_init_db)
+
+        application = create_app()
+
+        assert application.config["DATABASE_PATH"] == "mealbot.db"
+
+    def test_create_app_explicit_db_path_overrides_env(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """An explicit db_path argument wins over any env var.
+
+        Args:
+            monkeypatch: Pytest fixture for patching env vars.
+            tmp_path: Pytest fixture providing an isolated temp directory.
+        """
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+        monkeypatch.delenv("DATABASE_PATH", raising=False)
+        monkeypatch.setenv("DATABASE_URL", FAKE_POSTGRES_DSN)
+        explicit_path = str(tmp_path / "explicit.db")
+
+        application = create_app(db_path=explicit_path)
+
+        assert application.config["DATABASE_PATH"] == explicit_path


### PR DESCRIPTION
## Summary

- `create_app()` now resolves its database target from the environment when called with no argument (the production gunicorn invocation): explicit `db_path` arg > `DATABASE_URL` > `DATABASE_PATH` > `"mealbot.db"`. Previously the factory hardcoded `db_path: str = "mealbot.db"`, so the deployed web process silently wrote to ephemeral container-local SQLite while the release step migrated Railway Postgres.
- Adds a `_resolve_database_target()` helper in `grocery_butler/app.py`; an empty-string `DATABASE_URL` is treated as unset so a blank env var can't mask `DATABASE_PATH`. The resolved target (which may embed Postgres credentials) is never logged.
- Pins the behavior with a new `TestAppFactoryDatabaseWiring` class in `tests/test_deployment_wiring.py` (5 tests: URL wins with no args, PATH-only fallback, URL beats PATH, default when env unset, explicit arg beats env) and updates the two README references to the factory signature.

Scope note: `Procfile`, `Dockerfile`, `grocery_butler/db/migrate.py`, and `grocery_butler/config.py` are intentionally untouched (owned by sibling PRs for #37/#58). All existing `create_app` call sites pass `db_path` explicitly and are unaffected.

## Test plan

- TDD: the three env-resolution tests were written first and failed against `main` with `AssertionError: assert 'mealbot.db' == '<env value>'`, proving the factory ignored `DATABASE_URL`/`DATABASE_PATH`; they pass after the fix. Postgres-URL cases monkeypatch `grocery_butler.app.init_db` with a fake DSN so no live connection is attempted.
- `./scripts/check-all.sh` → exit 0: 1212 passed / 8 skipped, coverage 95.55% (floor 90%), mypy strict clean, ruff lint+format clean, bandit clean, pip-audit clean, complexity pass.
- Gate 2.5 self-review (code-review-orchestrator) returned CLEAN.

Closes #57
