### PR TITLE
fix(deploy): run migrations at container start via docker-entrypoint.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY --from=builder /install /usr/local
 # Copy application code
 WORKDIR /app
 COPY grocery_butler/ grocery_butler/
+COPY --chmod=0755 docker-entrypoint.sh /app/docker-entrypoint.sh
 
 # Own the workdir
 RUN chown -R butler:butler /app
@@ -30,4 +31,8 @@ EXPOSE $PORT
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:${PORT}/health')"
 
+# The entrypoint runs pending DB migrations, then execs the CMD below
+# (issue #58) -- Railway has no Heroku-style `release` phase, so the
+# migration step must happen inside the container's own boot sequence.
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
 CMD gunicorn 'grocery_butler.app:create_app()' --bind "0.0.0.0:${PORT}" --workers ${WEB_CONCURRENCY:-2} --timeout 120

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,0 @@
-release: python -m grocery_butler.db.migrate
-web: gunicorn 'grocery_butler.app:create_app()' --bind 0.0.0.0:$PORT --workers ${WEB_CONCURRENCY:-2} --timeout 120

--- a/README.md
+++ b/README.md
@@ -137,20 +137,26 @@ on Railway Postgres. Schema is defined declaratively in `db/schema.sql` and
 
 ### Process Topology
 
-In production (Railway), the system runs as **one long-lived web process** plus
-a one-shot release step:
+In production (Railway), the system builds and runs from the `Dockerfile` —
+there's no separate build/release configuration to keep in sync. The image
+boots into `docker-entrypoint.sh`, which applies any pending schema
+migrations (`python -m grocery_butler.db.migrate`, reading `DATABASE_URL`)
+before anything else starts. If a migration fails, `set -eu` aborts the boot
+immediately, so gunicorn never starts and no request is ever served against
+an unmigrated schema. Once migrations succeed, the entrypoint `exec`s
+straight into gunicorn (`grocery_butler.app:create_app()`), which becomes
+the container's only long-lived process, serving both the kitchen-phone HTML
+UI and the HMAC-authenticated `/api/v1` blueprint.
 
-| Process | Command | Role |
-|---------|---------|------|
-| `release` | `python -m grocery_butler.db.migrate` | Run schema migrations on every deploy. |
-| `web` | `gunicorn 'grocery_butler.app:create_app()'` | Flask dashboard + the `/api/v1` JSON API for RubotPaul. |
+There is no separate worker process in production. The Discord bot
+(`python -m grocery_butler.bot`) is retired from deployment — RubotPaul is
+the household's Discord interface now, and it drives grocery-butler through
+`/api/v1` instead. The bot module stays in the codebase and can still be run
+locally (see [Discord bot (local only)](#discord-bot-local-only--retired-from-production)).
+The CLI is invoked ad-hoc as a single-shot process (no daemon).
 
-The single web process serves both the kitchen-phone HTML UI and the
-HMAC-authenticated `/api/v1` blueprint. The former `worker` process
-(`python -m grocery_butler.bot`) is retired from deployment: RubotPaul is the
-household's Discord interface and drives grocery-butler through `/api/v1`. The
-bot module stays in the codebase and can still be run locally. The CLI is
-invoked ad-hoc as a single-shot process (no daemon).
+See [Deploying to Railway](#deploying-to-railway) for the environment
+variables and setup steps that go with this topology.
 
 ### Key Design Rules
 
@@ -180,13 +186,15 @@ and easy to operate alone.**
 
 ### Web
 
-- **Flask 3** — small, explicit, and fits on a single Railway dyno without
-  ceremony. The app is constructed by an `create_app(db_path)` factory so
-  tests can spin up isolated instances against a tmpfile database.
+- **Flask 3** — small, explicit, and fits in a single Railway container
+  without ceremony. The app is constructed by an `create_app(db_path)`
+  factory so tests can spin up isolated instances against a tmpfile
+  database.
 - **Jinja2 templates + Pico CSS** — server-rendered HTML, no SPA, no build
   step. The dashboard is meant to be operated from a phone in the kitchen,
   not from a workstation.
-- **Gunicorn** — production WSGI server, configured in the `Procfile`.
+- **Gunicorn** — production WSGI server, launched by the `Dockerfile`'s
+  `CMD` (after `docker-entrypoint.sh` runs migrations).
 
 ### Chat
 
@@ -686,7 +694,8 @@ grocery-butler/
 ├── .github/workflows/          # CI/CD pipelines
 ├── .claude/                    # AI subagents and skills
 ├── pyproject.toml              # Tool configuration
-├── Procfile                    # Railway process definitions
+├── Dockerfile                  # Railway build + runtime image
+├── docker-entrypoint.sh        # Runs migrations, then execs gunicorn
 ├── requirements.txt            # Runtime dependencies
 └── requirements-dev.txt        # Development dependencies
 ```
@@ -706,17 +715,15 @@ See `CLAUDE.md` for the full engineering culture document.
 
 ## Deploying to Railway
 
-The project includes a `Procfile` for [Railway](https://railway.app/) deployment
-with two processes:
+Railway builds and runs the project's `Dockerfile` directly. See
+[Process Topology](#process-topology) for how the container boots — in
+short, `docker-entrypoint.sh` migrates the database before gunicorn ever
+starts, and a migration failure aborts the deploy rather than serving
+requests against a stale schema.
 
-| Process | Command | Description |
-|---------|---------|-------------|
-| `release` | `python -m grocery_butler.db.migrate` | Schema migrations on every deploy. |
-| `web` | `gunicorn 'grocery_butler.app:create_app()'` | Flask web app + `/api/v1` RubotPaul API. |
-
-The former `worker` process (Discord bot) is retired; RubotPaul reaches the
-`/api/v1` blueprint over Tailscale at
-`https://grocery-butler.tailnet.ts.net/api/v1`.
+RubotPaul reaches the `/api/v1` blueprint over Tailscale at
+`https://grocery-butler.tailnet.ts.net/api/v1`; there's no standalone worker
+process to deploy alongside the web service.
 
 ### Required environment variables
 
@@ -735,11 +742,12 @@ Set these in your Railway project settings:
 
 ### Quick start
 
-1. Connect your Railway project to this GitHub repo.
+1. Connect your Railway project to this GitHub repo (Railway detects and
+   builds the `Dockerfile` automatically).
 2. Add a PostgreSQL plugin (provides `DATABASE_URL` automatically).
 3. Set the required environment variables above.
-4. Railway auto-deploys on push to `main`; the `release` step runs migrations
-   before `web` starts.
+4. Railway auto-deploys on push to `main`; each deploy migrates the
+   schema before serving traffic (see above).
 5. Attach the Railway service to your Tailscale tailnet so RubotPaul can reach
    `/api/v1` privately.
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Container entrypoint: run database migrations before starting the server.
+#
+# Railway (and any other Docker-based host) has no Heroku-style `release`
+# phase, so migrations must run inside the container's own boot sequence
+# instead (issue #58). `set -eu` aborts the container immediately if the
+# migration step fails, rather than booting gunicorn against a stale schema.
+set -eu
+
+python -m grocery_butler.db.migrate
+
+exec "$@"

--- a/tests/test_deployment_wiring.py
+++ b/tests/test_deployment_wiring.py
@@ -1,13 +1,18 @@
-"""Tests for the production process wiring (issue #49).
+"""Tests for the production process wiring (issues #49 and #58).
 
 One gunicorn web process serves both the HTML dashboard and the /api/v1
 blueprint; the Discord worker process is retired from the Procfile (RubotPaul
-is the Discord interface after cutover).
+is the Discord interface after cutover). The Dockerfile is the single
+canonical deploy path (issue #58): a `docker-entrypoint.sh` wrapper runs
+database migrations before `exec`-ing into the gunicorn server, and the
+Heroku-only Procfile is deleted entirely.
 """
 
 from __future__ import annotations
 
+import os
 import re
+import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -24,6 +29,8 @@ TEST_SECRET = "test-shared-secret"
 
 PROCFILE = Path(__file__).resolve().parent.parent / "Procfile"
 DOCKERFILE = Path(__file__).resolve().parent.parent / "Dockerfile"
+ENTRYPOINT_SCRIPT = Path(__file__).resolve().parent.parent / "docker-entrypoint.sh"
+MIGRATE_COMMAND = "python -m grocery_butler.db.migrate"
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -90,35 +97,16 @@ class TestSingleProcessServesBothSurfaces:
 
 
 # ---------------------------------------------------------------------------
-# Procfile topology
+# Single canonical deploy path (issue #58)
 # ---------------------------------------------------------------------------
 
 
-class TestProcfileTopology:
-    """The Procfile deploys release + web only; the Discord worker retired."""
+class TestSingleCanonicalDeployPath:
+    """The Dockerfile is the only deploy path; the Heroku Procfile is gone."""
 
-    def test_procfile_has_no_worker_process(self) -> None:
-        """RubotPaul owns Discord after cutover; no bot process deploys."""
-        processes = _procfile_processes()
-        assert "worker" not in processes
-
-    def test_procfile_keeps_release_and_web(self) -> None:
-        """Migrations still run on deploy and gunicorn serves the app."""
-        processes = _procfile_processes()
-        assert processes["release"] == "python -m grocery_butler.db.migrate"
-        assert "gunicorn 'grocery_butler.app:create_app()'" in processes["web"]
-
-
-def _procfile_processes() -> dict[str, str]:
-    """Parse the Procfile into a {process_name: command} mapping."""
-    processes: dict[str, str] = {}
-    for line in PROCFILE.read_text().splitlines():
-        stripped = line.strip()
-        if not stripped or stripped.startswith("#"):
-            continue
-        name, _, command = stripped.partition(":")
-        processes[name.strip()] = command.strip()
-    return processes
+    def test_procfile_absent(self) -> None:
+        """Procfile is deleted; Railway never reads it, so it must not exist."""
+        assert not PROCFILE.exists()
 
 
 # ---------------------------------------------------------------------------
@@ -168,3 +156,172 @@ def _dockerfile_cmd() -> str:
         if stripped.startswith("CMD "):
             command = stripped.removeprefix("CMD ")
     return command
+
+
+# ---------------------------------------------------------------------------
+# Dockerfile wires in docker-entrypoint.sh (issue #58)
+# ---------------------------------------------------------------------------
+
+
+class TestDockerfileEntrypointWiring:
+    """The image COPYs docker-entrypoint.sh in and declares it ENTRYPOINT."""
+
+    def test_dockerfile_declares_entrypoint(self) -> None:
+        """An ENTRYPOINT instruction must invoke docker-entrypoint.sh."""
+        entrypoint_line = _dockerfile_entrypoint_line()
+        assert "docker-entrypoint.sh" in entrypoint_line
+
+    def test_dockerfile_copies_entrypoint_executable(self) -> None:
+        """docker-entrypoint.sh is COPYed in and made executable."""
+        text = DOCKERFILE.read_text()
+        copies_script = any(
+            line.strip().startswith("COPY") and "docker-entrypoint.sh" in line
+            for line in text.splitlines()
+        )
+        assert copies_script, "Dockerfile must COPY docker-entrypoint.sh"
+        assert _dockerfile_makes_entrypoint_executable(text)
+
+
+def _dockerfile_entrypoint_line() -> str:
+    """Return the Dockerfile's `ENTRYPOINT` instruction line, if present.
+
+    Returns:
+        The stripped text of the line starting with `ENTRYPOINT `, or an
+        empty string if the Dockerfile declares no ENTRYPOINT.
+    """
+    for line in DOCKERFILE.read_text().splitlines():
+        stripped = line.strip()
+        if stripped.startswith("ENTRYPOINT "):
+            return stripped
+    return ""
+
+
+def _dockerfile_makes_entrypoint_executable(text: str) -> bool:
+    """Return whether the Dockerfile marks docker-entrypoint.sh executable.
+
+    Args:
+        text: Full contents of the Dockerfile.
+
+    Returns:
+        True if a `COPY --chmod=0755` clause targets the entrypoint script,
+        or a separate `RUN` instruction `chmod +x`s it; False otherwise.
+    """
+    for line in text.splitlines():
+        stripped = line.strip()
+        if "docker-entrypoint.sh" not in stripped:
+            continue
+        if stripped.startswith("COPY") and "--chmod=0755" in stripped:
+            return True
+        if stripped.startswith("RUN") and "chmod" in stripped and "+x" in stripped:
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# docker-entrypoint.sh contents (issue #58)
+# ---------------------------------------------------------------------------
+
+
+class TestEntrypointScriptContents:
+    """Static checks on the text of docker-entrypoint.sh."""
+
+    def test_entrypoint_invokes_migration_runner(self) -> None:
+        """The script must run the migration module before serving."""
+        text = ENTRYPOINT_SCRIPT.read_text()
+        assert MIGRATE_COMMAND in text
+
+    def test_entrypoint_execs_cmd_last(self) -> None:
+        """`exec "$@"` must appear, and only after the migration command."""
+        text = ENTRYPOINT_SCRIPT.read_text()
+        exec_snippet = 'exec "$@"'
+        assert exec_snippet in text
+        assert text.index(MIGRATE_COMMAND) < text.index(exec_snippet)
+
+    def test_entrypoint_fails_fast(self) -> None:
+        """`set -e` (or `-eu`) must appear near the top so failures abort."""
+        non_comment_lines = [
+            line.strip()
+            for line in ENTRYPOINT_SCRIPT.read_text().splitlines()
+            if line.strip() and not line.strip().startswith("#")
+        ][:5]
+        assert any(line.startswith("set -e") for line in non_comment_lines)
+
+
+# ---------------------------------------------------------------------------
+# docker-entrypoint.sh behavior (issue #58)
+# ---------------------------------------------------------------------------
+
+
+class TestEntrypointBehavior:
+    """Runs docker-entrypoint.sh against fake `python`/server shims."""
+
+    def test_entrypoint_runs_migrations_before_server(self, tmp_path: Path) -> None:
+        """Migrations run, then the wrapped server command execs, in order."""
+        log_path = tmp_path / "log.txt"
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        _write_shim(bin_dir / "python", log_path, "migrate", exit_code=0)
+        server_shim = bin_dir / "server"
+        _write_shim(server_shim, log_path, "server", exit_code=0)
+
+        result = _run_entrypoint(bin_dir, [str(server_shim)])
+
+        assert result.returncode == 0
+        assert log_path.read_text().splitlines() == ["migrate", "server"]
+
+    def test_entrypoint_aborts_server_when_migration_fails(
+        self, tmp_path: Path
+    ) -> None:
+        """A failing migration must abort before the server ever runs."""
+        log_path = tmp_path / "log.txt"
+        bin_dir = tmp_path / "bin"
+        bin_dir.mkdir()
+        _write_shim(bin_dir / "python", log_path, "migrate", exit_code=1)
+        server_shim = bin_dir / "server"
+        _write_shim(server_shim, log_path, "server", exit_code=0)
+
+        result = _run_entrypoint(bin_dir, [str(server_shim)])
+
+        assert result.returncode != 0
+        log_contents = log_path.read_text() if log_path.exists() else ""
+        assert "migrate" in log_contents.splitlines()
+        assert "server" not in log_contents.splitlines()
+
+
+def _write_shim(path: Path, log_path: Path, label: str, *, exit_code: int) -> None:
+    """Write an executable POSIX shell shim that logs one line and exits.
+
+    Args:
+        path: Filesystem path at which to create the shim script.
+        log_path: File the shim appends `label` to when invoked.
+        label: Line appended to `log_path` on invocation.
+        exit_code: Process exit status the shim returns.
+    """
+    path.write_text(f'#!/bin/sh\necho "{label}" >> "{log_path}"\nexit {exit_code}\n')
+    path.chmod(0o755)
+
+
+def _run_entrypoint(
+    bin_dir: Path, server_argv: list[str]
+) -> subprocess.CompletedProcess[str]:
+    """Run docker-entrypoint.sh with a fake `python` shim ahead on PATH.
+
+    Args:
+        bin_dir: Directory containing the fake `python` shim, prepended to
+            `PATH` so the script's migration step invokes the shim.
+        server_argv: Argv passed to the script, standing in for the real
+            gunicorn `CMD` that `exec "$@"` should hand off to.
+
+    Returns:
+        The completed subprocess, including its captured exit code.
+    """
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env.get('PATH', '')}"
+    return subprocess.run(
+        ["sh", str(ENTRYPOINT_SCRIPT), *server_argv],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )


### PR DESCRIPTION
## Summary

- Fixes the launch-blocker where migrations never ran on Railway: the root Dockerfile CMD launched only gunicorn, and the Procfile `release:` phase is a Heroku convention Railway never executes.
- Adds a repo-root `docker-entrypoint.sh` (`set -eu`) that applies pending migrations via `python -m grocery_butler.db.migrate` (reads `DATABASE_URL`) and then `exec "$@"` into the unchanged gunicorn CMD — a migration failure aborts container boot, so no request is ever served against an unmigrated schema.
- Deletes the non-functional Procfile so the Dockerfile is the single canonical deploy path (locked by `test_procfile_absent`), and rewrites the README Process Topology / Deploying to Railway sections around it.

## Test plan

- New behavioral subprocess tests run the real entrypoint with shimmed `python`/server commands and assert (1) migrate runs strictly before the server starts and (2) a failing migration aborts with non-zero exit and the server never launches.
- New parse tests lock the Dockerfile wiring (`ENTRYPOINT` present, `COPY --chmod=0755 docker-entrypoint.sh`), the script contract (`set -e*`, migrate invocation, trailing `exec "$@"`), and Procfile absence; the four pre-existing Dockerfile CMD tests are retained unchanged and still pass.
- `./scripts/check-all.sh` exits 0: 7/7 checks, 1213 passed / 8 pre-existing Postgres-env skips, 95.54% branch coverage, mypy strict, ruff, bandit + pip-audit, complexity all clean.

Scope note: `create_app()`/`DATABASE_URL` wiring is sibling issue #57 and the migration-hook refactor is #37 — this PR deliberately touches neither `app.py` nor `migrate.py`.

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)
