### PR TITLE
fix(cart): unit-aware quantity math, review gate, and per-item cap

### DIFF
--- a/grocery_butler/api.py
+++ b/grocery_butler/api.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING, Any
 from flask import Blueprint, abort, current_app, jsonify, request
 from pydantic import ValidationError
 
+from grocery_butler import order_service
 from grocery_butler.auth_middleware import require_bearer
 from grocery_butler.claude_utils import make_anthropic_client
 from grocery_butler.config import ConfigError, load_config
@@ -450,6 +451,33 @@ def _parse_cart_payload(body: dict[str, Any]) -> CartSummary:
     return cart
 
 
+def _render_review_section(cart: CartSummary) -> str:
+    """Render a staged-message clause naming flagged items and reasons.
+
+    Delegates flagged-item collection to
+    :func:`grocery_butler.order_service._collect_review_items` (single
+    source of truth for what counts as flagged) so the human sees every
+    item and its review reason before ever replying "confirm" — per the
+    chief-architect's ruling, that visibility is what makes a later
+    confirm count as an explicit override of the review gate.
+
+    Args:
+        cart: The cart being staged for confirmation.
+
+    Returns:
+        Empty string for a cart with no flagged items, otherwise a
+        sentence naming each flagged ingredient and its reason code.
+    """
+    flagged = order_service._collect_review_items(cart)
+    if not flagged:
+        return ""
+    named = ", ".join(
+        f"{item.shopping_list_item.ingredient} ({item.review_reason})"
+        for item in flagged
+    )
+    return f" Needs review: {named}."
+
+
 @api_v1.post("/order/submit")
 def post_order_submit() -> Response:
     """Stage a Safeway order for confirmation. Never submits directly."""
@@ -462,12 +490,13 @@ def post_order_submit() -> Response:
         {"cart": cart.model_dump(mode="json"), "total": total},
     )
     item_count = len(cart.items) + len(cart.restock_items)
+    review_section = _render_review_section(cart)
     return jsonify(
         status="pending_confirmation",
         action_id=action_id,
         message=(
-            f"Staged Safeway order ({item_count} items, ${total}). "
-            "Reply 'confirm' to submit."
+            f"Staged Safeway order ({item_count} items, ${total})."
+            f"{review_section} Reply 'confirm' to submit."
         ),
     )
 
@@ -562,7 +591,11 @@ def _confirm_order_submit(
         return jsonify(error=f"safeway pipeline unavailable: {exc}"), 503
     _claim_pending(store, action.action_id)
     try:
-        result = pipeline.submit_cart(cart)
+        # The staged message (post_order_submit) already named every
+        # flagged item and its reason code, so replying "confirm" IS the
+        # human's explicit override of the review gate (chief-architect
+        # ruling, issue #59 round 3).
+        result = pipeline.submit_cart(cart, allow_review_items=True)
     except SafewayPipelineError as exc:
         return jsonify(error=f"order submission failed: {exc}"), 502
     finally:

--- a/grocery_butler/bot.py
+++ b/grocery_butler/bot.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from grocery_butler.config import Config
     from grocery_butler.models import (
         BrandPreference,
+        CartItem,
         CartSummary,
         InventoryItem,
         ParsedMeal,
@@ -290,8 +291,12 @@ class _OrderConfirmView(discord.ui.View):
         """
         await interaction.response.defer()
         try:
+            # The rendered preview (_format_cart_summary) already showed
+            # the user every flagged item and its reason code, so this
+            # button press IS the explicit human override of the review
+            # gate (chief-architect ruling, issue #59 round 3).
             order_result = await asyncio.to_thread(
-                self._pipeline.submit_cart, self._cart
+                self._pipeline.submit_cart, self._cart, allow_review_items=True
             )
             msg = _format_order_result(order_result)
             await interaction.followup.send(msg)
@@ -339,6 +344,28 @@ def _make_bot_anthropic_client(config: Config) -> object | None:
     return make_anthropic_client(config.anthropic_api_key)
 
 
+def _format_cart_item_line(ci: CartItem) -> str:
+    """Format a single cart item line for display.
+
+    Appends a ``" (review: <reason>)"`` marker when the item's quantity
+    calculation was flagged for human review (issue #59). The reason
+    code is included so the user has actually seen what needs checking
+    before confirming the order (chief-architect ruling, round 3): a
+    bare ``"(review)"`` marker would not satisfy that.
+
+    Args:
+        ci: The cart item to format.
+
+    Returns:
+        A single formatted display line for the item.
+    """
+    marker = f" (review: {ci.review_reason})" if ci.needs_review else ""
+    return (
+        f"  {ci.quantity_to_order}x {ci.safeway_product.name}"
+        f"  ${ci.estimated_cost:.2f}{marker}"
+    )
+
+
 def _format_cart_summary(cart: CartSummary) -> str:
     """Format a CartSummary for Discord display.
 
@@ -352,19 +379,11 @@ def _format_cart_summary(cart: CartSummary) -> str:
 
     if cart.items:
         lines.append(f"Items ({len(cart.items)}):")
-        for ci in cart.items:
-            lines.append(
-                f"  {ci.quantity_to_order}x {ci.safeway_product.name}"
-                f"  ${ci.estimated_cost:.2f}"
-            )
+        lines.extend(_format_cart_item_line(ci) for ci in cart.items)
 
     if cart.restock_items:
         lines.append(f"\nRestock ({len(cart.restock_items)}):")
-        for ci in cart.restock_items:
-            lines.append(
-                f"  {ci.quantity_to_order}x {ci.safeway_product.name}"
-                f"  ${ci.estimated_cost:.2f}"
-            )
+        lines.extend(_format_cart_item_line(ci) for ci in cart.restock_items)
 
     if cart.substituted_items:
         lines.append(f"\nSubstituted ({len(cart.substituted_items)}):")

--- a/grocery_butler/cart_builder.py
+++ b/grocery_butler/cart_builder.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import logging
 import math
-import re
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from grocery_butler.models import (
@@ -21,6 +21,7 @@ from grocery_butler.models import (
     ShoppingListItem,
     SubstitutionResult,
 )
+from grocery_butler.units import convert, parse_size
 
 if TYPE_CHECKING:
     from grocery_butler.product_search import ProductSearchService
@@ -29,9 +30,32 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+#: Default maximum number of product units ordered for a single shopping
+#: list item, absent an explicit override. Guards against runaway orders
+#: caused by unit-mismatch quantity calculations (issue #59).
+MAX_QUANTITY_PER_ITEM = 10
+
 
 class CartBuildError(Exception):
     """Raised when cart building encounters an unrecoverable error."""
+
+
+@dataclass(frozen=True)
+class QuantityDecision:
+    """The outcome of a per-item quantity calculation.
+
+    Attributes:
+        quantity: Number of product units to order.
+        needs_review: Whether the decision should be flagged for human
+            review.
+        review_reason: Machine-readable reason code for ``needs_review``
+            (``"unparseable_size"``, ``"incomparable_units"``, or
+            ``"quantity_capped"``), or ``""`` when no review is needed.
+    """
+
+    quantity: int
+    needs_review: bool
+    review_reason: str
 
 
 class CartBuilder:
@@ -45,6 +69,8 @@ class CartBuilder:
         product_selector: Claude-assisted product selector.
         substitution_service: Handles out-of-stock substitutions.
         safeway_client: Authenticated Safeway API client.
+        max_quantity_per_item: Maximum product units ordered for any single
+            shopping list item.
     """
 
     def __init__(
@@ -53,6 +79,7 @@ class CartBuilder:
         product_selector: ProductSelector,
         substitution_service: SubstitutionService,
         safeway_client: Any,
+        max_quantity_per_item: int = MAX_QUANTITY_PER_ITEM,
     ) -> None:
         """Initialize the cart builder.
 
@@ -61,11 +88,14 @@ class CartBuilder:
             product_selector: Product selector.
             substitution_service: Substitution service.
             safeway_client: Safeway API client.
+            max_quantity_per_item: Maximum product units ordered for any
+                single shopping list item.
         """
         self._search = search_service
         self._selector = product_selector
         self._substitution = substitution_service
         self._client = safeway_client
+        self._max_quantity_per_item = max_quantity_per_item
 
     def build_cart(
         self,
@@ -155,13 +185,15 @@ class CartBuilder:
         if not product.in_stock:
             return self._handle_out_of_stock(item, product)
 
-        qty = _calculate_quantity(item, product)
-        cost = round(product.price * qty, 2)
+        decision = _calculate_quantity(item, product, cap=self._max_quantity_per_item)
+        cost = round(product.price * decision.quantity, 2)
         return CartItem(
             shopping_list_item=item,
             safeway_product=product,
-            quantity_to_order=qty,
+            quantity_to_order=decision.quantity,
             estimated_cost=cost,
+            needs_review=decision.needs_review,
+            review_reason=decision.review_reason,
         )
 
     def _handle_out_of_stock(
@@ -205,47 +237,54 @@ class CartBuilder:
 # ------------------------------------------------------------------
 
 
+#: Epsilon subtracted before ``math.ceil`` so that quantities landing on
+#: (or fractionally above, due to floating-point noise) an exact multiple
+#: of the product size don't round up to one unit too many.
+_QUANTITY_EPSILON = 1e-9
+
+
 def _calculate_quantity(
     item: ShoppingListItem,
     product: SafewayProduct,
-) -> int:
+    cap: int = MAX_QUANTITY_PER_ITEM,
+) -> QuantityDecision:
     """Calculate how many units to order based on item needs.
 
-    Parses the product size to determine unit quantity, then
-    calculates how many products are needed to fulfill the
-    shopping list quantity.
+    Parses the product size, converts the shopping list item's quantity
+    into the product's unit, and determines how many products are needed
+    to fulfill the requested amount. Flags the decision for human review
+    when the product size can't be parsed, the units can't be compared
+    (different physical dimensions), or the computed quantity exceeds
+    ``cap``.
 
     Args:
-        item: Shopping list item with desired quantity.
+        item: Shopping list item with desired quantity and unit.
         product: The product with size information.
+        cap: Maximum quantity to order without flagging for review.
 
     Returns:
-        Number of units to order (minimum 1).
+        A ``QuantityDecision`` with the quantity to order and any review
+        flag/reason.
     """
-    product_qty = _parse_product_size(product.size)
+    parsed_size = parse_size(product.size)
+    if parsed_size is None:
+        return QuantityDecision(1, True, "unparseable_size")
+
+    product_qty, product_unit = parsed_size
     if product_qty <= 0:
-        return 1
+        return QuantityDecision(1, True, "unparseable_size")
 
-    needed = item.quantity / product_qty
-    return max(1, math.ceil(needed))
+    converted_qty = convert(item.quantity, item.unit, product_unit)
+    if converted_qty is None:
+        return QuantityDecision(1, True, "incomparable_units")
 
+    needed = converted_qty / product_qty
+    quantity = max(1, math.ceil(needed - _QUANTITY_EPSILON))
 
-def _parse_product_size(size: str) -> float:
-    """Extract numeric quantity from a product size string.
+    if quantity > cap:
+        return QuantityDecision(cap, True, "quantity_capped")
 
-    Args:
-        size: Product size string like '2 lb', '16 oz', '1 gal'.
-
-    Returns:
-        Numeric quantity or 0.0 if unparseable.
-    """
-    match = re.match(r"([\d.]+)", size.strip())
-    if match:
-        try:
-            return float(match.group(1))
-        except ValueError:
-            return 0.0
-    return 0.0
+    return QuantityDecision(quantity, False, "")
 
 
 def _calculate_subtotal(

--- a/grocery_butler/cli.py
+++ b/grocery_butler/cli.py
@@ -556,9 +556,10 @@ def _format_cart_items(
         return []
     lines = [header]
     for ci in items:
+        marker = " (review)" if ci.needs_review else ""
         lines.append(
             f"  {ci.quantity_to_order}x {ci.safeway_product.name}"
-            f"  ${ci.estimated_cost:.2f}"
+            f"  ${ci.estimated_cost:.2f}{marker}"
         )
     lines.append("")
     return lines

--- a/grocery_butler/models.py
+++ b/grocery_butler/models.py
@@ -371,12 +371,27 @@ class SubstitutionResult(BaseModel):
 
 
 class CartItem(BaseModel):
-    """A shopping list item mapped to a Safeway product."""
+    """A shopping list item mapped to a Safeway product.
+
+    Attributes:
+        shopping_list_item: The originating shopping list item.
+        safeway_product: The matched Safeway product.
+        quantity_to_order: Number of product units to order.
+        estimated_cost: Estimated cost for ``quantity_to_order`` units.
+        needs_review: Whether the quantity calculation needs human review
+            (e.g. an unparseable product size, incomparable units, or a
+            quantity capped by the per-item maximum).
+        review_reason: Machine-readable reason code for ``needs_review``
+            (``"unparseable_size"``, ``"incomparable_units"``, or
+            ``"quantity_capped"``), or ``""`` when no review is needed.
+    """
 
     shopping_list_item: ShoppingListItem
     safeway_product: SafewayProduct
     quantity_to_order: int
     estimated_cost: float
+    needs_review: bool = False
+    review_reason: str = ""
 
 
 class FulfillmentOption(BaseModel):

--- a/grocery_butler/order_service.py
+++ b/grocery_butler/order_service.py
@@ -81,15 +81,33 @@ class OrderService:
     def submit_order(
         self,
         cart: CartSummary,
+        *,
+        allow_review_items: bool = False,
     ) -> OrderResult:
         """Submit a cart to Safeway and update inventory.
 
+        Before any money is spent, the cart is checked for items flagged
+        by unit-aware quantity math (see :attr:`CartItem.needs_review`).
+        Flagged items block submission unless ``allow_review_items`` is
+        set, which represents an explicit human override after review.
+
         Args:
             cart: The built cart summary to submit.
+            allow_review_items: If True, bypass the review gate and
+                submit even if items are flagged as ``needs_review``.
+                Defaults to False (safe/blocking).
 
         Returns:
             OrderResult with confirmation or error details.
         """
+        if not allow_review_items:
+            flagged = _collect_review_items(cart)
+            if flagged:
+                return OrderResult(
+                    success=False,
+                    error_message=_format_review_block_message(flagged),
+                )
+
         if not cart.items and not cart.restock_items:
             return OrderResult(
                 success=False,
@@ -236,6 +254,40 @@ def _safe_float(value: Any, fallback: float) -> float:
         return float(value)
     except (TypeError, ValueError):
         return fallback
+
+
+def _collect_review_items(cart: CartSummary) -> list[CartItem]:
+    """Collect cart items flagged as needing human review.
+
+    Args:
+        cart: Cart summary with regular and restock items.
+
+    Returns:
+        List of items (from ``items`` and ``restock_items``) whose
+        ``needs_review`` flag is True, in cart order.
+    """
+    return [item for item in cart.items + cart.restock_items if item.needs_review]
+
+
+def _format_review_block_message(flagged: list[CartItem]) -> str:
+    """Build the error message for an order blocked pending review.
+
+    Args:
+        flagged: Cart items flagged as ``needs_review``.
+
+    Returns:
+        Human-readable message naming each flagged ingredient and its
+        review reason, stating the order was blocked pending review.
+    """
+    named = ", ".join(
+        f"{item.shopping_list_item.ingredient} ({item.review_reason})"
+        for item in flagged
+    )
+    return (
+        "Order blocked pending review: the following items need "
+        f"manual review before ordering: {named}. Re-submit with "
+        "allow_review_items=True after confirming quantities."
+    )
 
 
 def _collect_restock_ingredients(cart: CartSummary) -> list[str]:

--- a/grocery_butler/safeway_pipeline.py
+++ b/grocery_butler/safeway_pipeline.py
@@ -128,7 +128,12 @@ class SafewayPipeline:
         self._authenticate()
         return self._cart_builder.build_cart(items, restock_items)
 
-    def submit_cart(self, cart: CartSummary) -> OrderResult:
+    def submit_cart(
+        self,
+        cart: CartSummary,
+        *,
+        allow_review_items: bool = False,
+    ) -> OrderResult:
         """Submit a pre-built cart to Safeway.
 
         Use this when the cart has already been built via
@@ -136,6 +141,9 @@ class SafewayPipeline:
 
         Args:
             cart: Pre-built cart summary to submit.
+            allow_review_items: If True, bypass the review gate for
+                items flagged as ``needs_review`` (explicit human
+                override). Defaults to False (safe/blocking).
 
         Returns:
             OrderResult with confirmation or error details.
@@ -144,7 +152,9 @@ class SafewayPipeline:
             SafewayPipelineError: If authentication fails.
         """
         self._authenticate()
-        return self._order_service.submit_order(cart)
+        return self._order_service.submit_order(
+            cart, allow_review_items=allow_review_items
+        )
 
     def close(self) -> None:
         """Clean up SafewayClient HTTP resources."""

--- a/grocery_butler/units.py
+++ b/grocery_butler/units.py
@@ -1,0 +1,218 @@
+"""Unit dimension classification, conversion, and product-size parsing.
+
+Introduced to fix issue #59: :func:`grocery_butler.cart_builder._calculate_quantity`
+used to divide a shopping-list quantity by the leading number of a product's
+size string with no regard for units, causing gross over-orders (500 g vs.
+"5 lb" ordering 100 units) and silent under-orders. This module provides the
+unit-aware primitives that make quantity calculations dimensionally sound:
+
+* :func:`dimension_of` classifies a :class:`~grocery_butler.models.Unit` into
+  a physical :class:`Dimension` (mass, volume, or count), or ``None`` for
+  packaging/other units that have no fixed physical size.
+* :func:`convert` converts a quantity between two units of the same
+  dimension, returning ``None`` when the units are incomparable.
+* :func:`parse_size` strictly parses a product size string (e.g. ``"2 lb"``)
+  into a ``(quantity, Unit)`` pair, returning ``None`` for anything it can't
+  confidently resolve -- unlike
+  :func:`grocery_butler.models.parse_unit`, it never falls back to
+  :attr:`~grocery_butler.models.Unit.EACH` for unrecognized unit tokens.
+"""
+
+from __future__ import annotations
+
+import re
+from enum import StrEnum
+
+from grocery_butler.models import _UNIT_ALIASES, Unit
+
+# ---------------------------------------------------------------------------
+# Dimension classification
+# ---------------------------------------------------------------------------
+
+
+class Dimension(StrEnum):
+    """Physical dimension used to validate cross-unit conversions."""
+
+    MASS = "mass"
+    VOLUME = "volume"
+    COUNT = "count"
+
+
+# Mass units, expressed as grams-per-unit.
+_MASS_FACTORS_G: dict[Unit, float] = {
+    Unit.G: 1.0,
+    Unit.KG: 1000.0,
+    Unit.OZ: 28.349523125,
+    Unit.LB: 453.59237,
+}
+
+# Volume units, expressed as milliliters-per-unit.
+_VOLUME_FACTORS_ML: dict[Unit, float] = {
+    Unit.ML: 1.0,
+    Unit.L: 1000.0,
+    Unit.TSP: 4.92892159,
+    Unit.TBSP: 14.7867648,
+    Unit.FL_OZ: 29.5735296,
+    Unit.CUP: 236.588237,
+    Unit.GAL: 3785.411784,
+}
+
+# Count units, expressed as each-per-unit.
+_COUNT_FACTORS_EACH: dict[Unit, float] = {
+    Unit.EACH: 1.0,
+    Unit.DOZEN: 12.0,
+}
+
+# Packaging/"other" units (bag, can, box, jar, bottle, package, block, pinch,
+# dash, to_taste, bunch, head, clove, slice) are deliberately absent: they
+# carry no fixed physical size, so they are non-convertible and classify as
+# dimensionless (``dimension_of`` returns ``None``).
+
+_DIMENSION_TABLE: dict[Unit, tuple[Dimension, float]] = {
+    **{unit: (Dimension.MASS, factor) for unit, factor in _MASS_FACTORS_G.items()},
+    **{unit: (Dimension.VOLUME, factor) for unit, factor in _VOLUME_FACTORS_ML.items()},
+    **{unit: (Dimension.COUNT, factor) for unit, factor in _COUNT_FACTORS_EACH.items()},
+}
+
+
+def dimension_of(unit: Unit) -> Dimension | None:
+    """Classify a unit's physical dimension.
+
+    Args:
+        unit: The unit to classify.
+
+    Returns:
+        The unit's ``Dimension`` (mass, volume, or count), or ``None`` if
+        the unit is a packaging or "other" unit with no fixed physical size.
+    """
+    entry = _DIMENSION_TABLE.get(unit)
+    return entry[0] if entry is not None else None
+
+
+def convert(quantity: float, from_unit: Unit, to_unit: Unit) -> float | None:
+    """Convert a quantity from one unit to another.
+
+    Args:
+        quantity: The numeric quantity in ``from_unit``.
+        from_unit: The unit ``quantity`` is currently expressed in.
+        to_unit: The unit to convert to.
+
+    Returns:
+        The converted quantity, or ``None`` if the two units are not
+        comparable (different dimensions, or either unit is non-convertible).
+        Converting a unit to itself always returns ``quantity`` unchanged.
+    """
+    if from_unit == to_unit:
+        return quantity
+
+    from_entry = _DIMENSION_TABLE.get(from_unit)
+    to_entry = _DIMENSION_TABLE.get(to_unit)
+    if from_entry is None or to_entry is None:
+        return None
+
+    from_dimension, from_factor = from_entry
+    to_dimension, to_factor = to_entry
+    if from_dimension != to_dimension:
+        return None
+
+    base_quantity = quantity * from_factor
+    return base_quantity / to_factor
+
+
+# ---------------------------------------------------------------------------
+# Strict product-size parsing
+# ---------------------------------------------------------------------------
+
+_SIZE_RE = re.compile(r"^\s*([\d.]+)\s*(.*)$")
+
+# Unit tokens with internal spaces or punctuation that don't survive a plain
+# ``Unit(...)`` or ``_UNIT_ALIASES`` lookup once normalized (periods removed,
+# whitespace collapsed).
+_EXTRA_SIZE_UNIT_ALIASES: dict[str, Unit] = {
+    "fl oz": Unit.FL_OZ,
+    "fl_oz": Unit.FL_OZ,
+    "floz": Unit.FL_OZ,
+}
+
+
+def _normalize_unit_token(token: str) -> str:
+    """Normalize a raw unit token for strict lookup.
+
+    Strips surrounding whitespace, lower-cases, removes periods (so
+    ``"fl. oz."`` and ``"fl oz"`` normalize the same), and collapses
+    internal whitespace runs.
+
+    Args:
+        token: Raw unit token text.
+
+    Returns:
+        Normalized token text.
+    """
+    cleaned = token.strip().lower().replace(".", "")
+    return re.sub(r"\s+", " ", cleaned).strip()
+
+
+def _resolve_unit_token(token: str) -> Unit | None:
+    """Strictly resolve a unit token to a ``Unit`` enum member.
+
+    Unlike :func:`grocery_butler.models.parse_unit`, this never falls back
+    to ``Unit.EACH`` for an unrecognized token -- a miss returns ``None`` so
+    callers can flag the size as unparseable instead of silently guessing.
+
+    Args:
+        token: Raw unit token text (e.g. ``"lb"``, ``"fl oz"``).
+
+    Returns:
+        The resolved ``Unit``, or ``None`` if the token isn't recognized.
+    """
+    normalized = _normalize_unit_token(token)
+    if not normalized:
+        return None
+    try:
+        return Unit(normalized)
+    except ValueError:
+        pass
+    alias = _UNIT_ALIASES.get(normalized)
+    if alias is not None:
+        return alias
+    return _EXTRA_SIZE_UNIT_ALIASES.get(normalized)
+
+
+def parse_size(size: str) -> tuple[float, Unit] | None:
+    """Strictly parse a product size string into a quantity and unit.
+
+    Parses a leading numeric quantity followed by an optional unit token
+    (e.g. ``"2 lb"``, ``"32 fl oz"``, ``"1.5 l"``). A bare number with no
+    unit token (e.g. ``"12"``) is treated as a count of ``Unit.EACH``.
+
+    This is a strict parser: any string with no leading number, or with an
+    unrecognized unit token, returns ``None`` rather than guessing. This is
+    the key behavioral difference from
+    :func:`grocery_butler.models.parse_unit`, which falls back to
+    ``Unit.EACH`` for unrecognized unit strings.
+
+    Args:
+        size: Raw product size string, e.g. ``"2 lb"`` or ``"16 oz"``.
+
+    Returns:
+        A ``(quantity, Unit)`` tuple, or ``None`` if the size string can't
+        be confidently parsed.
+    """
+    match = _SIZE_RE.match(size)
+    if not match:
+        return None
+
+    try:
+        quantity = float(match.group(1))
+    except ValueError:
+        return None
+
+    unit_token = match.group(2).strip()
+    if not unit_token:
+        return (quantity, Unit.EACH)
+
+    unit = _resolve_unit_token(unit_token)
+    if unit is None:
+        return None
+
+    return (quantity, unit)

--- a/tests/e2e/test_api_chain.py
+++ b/tests/e2e/test_api_chain.py
@@ -126,6 +126,16 @@ def test_full_chain_meal_to_confirmed_order(
     assert submit_body["status"] == "pending_confirmation"
     action_id = submit_body["action_id"]
 
+    # "spaghetti" (box) and "tomato sauce" (can) don't compare against the
+    # mock's uniform "1 lb" product size, so the real quantity calculator
+    # flags both incomparable_units (issue #59). Per the chief-architect's
+    # ruling, the staged message must name them and their reason before
+    # the human is asked to confirm.
+    staged_message = submit_body["message"]
+    assert "spaghetti" in staged_message
+    assert "tomato sauce" in staged_message
+    assert "incomparable_units" in staged_message
+
     confirmed = client.post(
         "/api/v1/actions/confirm",
         json={"action_id": action_id},

--- a/tests/e2e/test_ordering.py
+++ b/tests/e2e/test_ordering.py
@@ -177,7 +177,19 @@ def test_order_submit_confirm_hits_orders_endpoint_with_confirmation(
         json={"cart": body["cart"], "total": body["total"]},
         headers=headers,
     )
-    action_id = submitted.get_json()["action_id"]
+    submit_body = submitted.get_json()
+    action_id = submit_body["action_id"]
+
+    # "milk" and "eggs" are searched with unit="each" (see
+    # _shopping_list_body) against the mock's uniform "1 lb" product
+    # size, so the real quantity calculator flags both
+    # incomparable_units (issue #59). Per the chief-architect's ruling,
+    # the staged message must name them and their reason before the
+    # human is asked to confirm.
+    staged_message = submit_body["message"]
+    assert "milk" in staged_message
+    assert "eggs" in staged_message
+    assert "incomparable_units" in staged_message
 
     confirmed = client.post(
         "/api/v1/actions/confirm",

--- a/tests/test_api_destructive.py
+++ b/tests/test_api_destructive.py
@@ -112,8 +112,24 @@ def _make_shopping_item(ingredient: str = "pasta") -> ShoppingListItem:
     )
 
 
-def _make_cart_item(ingredient: str, cost: float) -> CartItem:
-    """Return a CartItem with the given estimated cost."""
+def _make_cart_item(
+    ingredient: str,
+    cost: float,
+    *,
+    needs_review: bool = False,
+    review_reason: str = "",
+) -> CartItem:
+    """Return a CartItem with the given estimated cost.
+
+    Args:
+        ingredient: Ingredient name for the underlying shopping list item.
+        cost: Estimated cost assigned to the item.
+        needs_review: Whether to flag the item as needing human review.
+        review_reason: Machine-readable reason code when flagged.
+
+    Returns:
+        A CartItem, optionally flagged for review (issue #59).
+    """
     return CartItem(
         shopping_list_item=_make_shopping_item(ingredient),
         safeway_product=SafewayProduct(
@@ -124,6 +140,8 @@ def _make_cart_item(ingredient: str, cost: float) -> CartItem:
         ),
         quantity_to_order=1,
         estimated_cost=cost,
+        needs_review=needs_review,
+        review_reason=review_reason,
     )
 
 
@@ -139,6 +157,33 @@ def _make_cart(costs: dict[str, float]) -> CartSummary:
         fulfillment_options=[],
         recommended_fulfillment=FulfillmentType.PICKUP,
         estimated_total=sum(costs.values()),
+    )
+
+
+def _make_cart_with_flagged_item() -> CartSummary:
+    """Return a CartSummary with one flagged item and one clean item.
+
+    The flagged item ("spaghetti") carries ``needs_review=True`` with
+    reason code ``"incomparable_units"``, matching the real quantity
+    calculator's flag for a fixture-style unit mismatch (issue #59).
+    """
+    flagged = _make_cart_item(
+        "spaghetti",
+        2.50,
+        needs_review=True,
+        review_reason="incomparable_units",
+    )
+    clean = _make_cart_item("ground beef", 5.00)
+    items = [flagged, clean]
+    return CartSummary(
+        items=items,
+        failed_items=[],
+        substituted_items=[],
+        restock_items=[],
+        subtotal=7.50,
+        fulfillment_options=[],
+        recommended_fulfillment=FulfillmentType.PICKUP,
+        estimated_total=7.50,
     )
 
 
@@ -319,6 +364,39 @@ class TestOrderSubmitStaging:
             )
         assert response.status_code == 200
         factory.assert_not_called()
+
+    def test_staged_message_lists_flagged_items_and_reasons(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """The staged message must surface flagged ingredients and reasons.
+
+        Per the chief-architect's ruling: a human confirm only counts as
+        review approval if flagged items AND their reason codes were
+        rendered to that human first. The staging response is what
+        RubotPaul posts to chat before asking for confirmation, so it
+        must name every flagged ingredient and its reason code.
+        """
+        cart = _make_cart_with_flagged_item()
+        response = client.post(
+            "/api/v1/order/submit",
+            json={"cart": cart.model_dump(mode="json")},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        message = response.get_json()["message"]
+        assert "spaghetti" in message
+        assert "incomparable_units" in message
+
+    def test_staged_message_has_no_review_section_for_clean_cart(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """A cart with no flagged items keeps the plain staging message."""
+        response = client.post(
+            "/api/v1/order/submit", json=_order_body(), headers=auth_headers
+        )
+        assert response.status_code == 200
+        message = response.get_json()["message"]
+        assert "review" not in message.lower()
 
 
 # ---------------------------------------------------------------------------
@@ -501,6 +579,38 @@ class TestActionsConfirm:
         assert action is not None
         assert action.status is PendingActionStatus.APPROVED
         assert action.resolved_at is not None
+
+    def test_confirm_order_forwards_allow_review_items_override(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """Confirming a staged order must override the review gate.
+
+        Per the chief-architect's ruling: the human already saw the
+        flagged items and their reason codes in the staged message
+        before replying "confirm", so that confirm IS the explicit
+        review approval. The confirm executor must therefore call
+        ``pipeline.submit_cart`` with ``allow_review_items=True`` --
+        otherwise a flagged cart the human already approved would still
+        be hard-blocked by ``OrderService.submit_order``.
+        """
+        body = {"cart": _make_cart_with_flagged_item().model_dump(mode="json")}
+        action_id = _stage_via_api(client, auth_headers, "/api/v1/order/submit", body)
+
+        pipeline = MagicMock()
+        pipeline.submit_cart.return_value = _successful_order_result()
+        with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
+            response = client.post(
+                "/api/v1/actions/confirm",
+                json={"action_id": action_id},
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 200
+        pipeline.submit_cart.assert_called_once()
+        _, kwargs = pipeline.submit_cart.call_args
+        assert kwargs.get("allow_review_items") is True
 
     def test_failed_order_submission_returns_502(
         self,

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1764,6 +1764,77 @@ class TestFormatCartSummaryBot:
         assert "$4.99" in result
         assert "```" in result
 
+    def test_format_flagged_item_shows_review_marker(self) -> None:
+        """Test needs_review items get a '(review: <reason>)' marker.
+
+        Regression guard for issue #59, round 3: per the chief-architect's
+        ruling, a human confirm only counts as review approval if the
+        flagged items AND their reason codes were rendered to that human
+        first. A bare "(review)" marker does not satisfy that -- the
+        Discord cart summary must include the machine-readable reason
+        code (e.g. "incomparable_units") on the flagged line so the user
+        actually sees what needs checking before confirming.
+        """
+        from grocery_butler.models import (
+            CartItem,
+            CartSummary,
+            FulfillmentType,
+            SafewayProduct,
+        )
+
+        flagged_product = SafewayProduct(
+            product_id="P1", name="Mystery Item", price=4.99, size=""
+        )
+        flagged_item = CartItem(
+            shopping_list_item=ShoppingListItem(
+                ingredient="mystery item",
+                quantity=1.0,
+                unit="each",
+                category=IngredientCategory.OTHER,
+                search_term="mystery item",
+                from_meals=["manual"],
+            ),
+            safeway_product=flagged_product,
+            quantity_to_order=1,
+            estimated_cost=4.99,
+            needs_review=True,
+            review_reason="unparseable_size",
+        )
+        unflagged_product = SafewayProduct(
+            product_id="P2", name="Milk", price=3.99, size="1 gal"
+        )
+        unflagged_item = CartItem(
+            shopping_list_item=ShoppingListItem(
+                ingredient="milk",
+                quantity=1.0,
+                unit="gal",
+                category=IngredientCategory.DAIRY,
+                search_term="milk",
+                from_meals=["manual"],
+            ),
+            safeway_product=unflagged_product,
+            quantity_to_order=1,
+            estimated_cost=3.99,
+        )
+        cart = CartSummary(
+            items=[flagged_item, unflagged_item],
+            failed_items=[],
+            substituted_items=[],
+            skipped_items=[],
+            restock_items=[],
+            subtotal=8.98,
+            fulfillment_options=[],
+            recommended_fulfillment=FulfillmentType.PICKUP,
+            estimated_total=8.98,
+        )
+
+        result = _format_cart_summary(cart)
+        lines = result.splitlines()
+        mystery_line = next(line for line in lines if "Mystery Item" in line)
+        milk_line = next(line for line in lines if "Milk" in line)
+        assert "(review: unparseable_size)" in mystery_line
+        assert "(review" not in milk_line
+
     def test_format_with_failed_items(self):
         """Test formatting cart with failed items."""
         from grocery_butler.models import CartSummary, FulfillmentType
@@ -2214,7 +2285,14 @@ class TestOrderConfirmView:
 
     @pytest.mark.asyncio()
     async def test_confirm_submits_and_reports_result(self, mock_interaction):
-        """Test confirm submits the cart and reports the confirmation."""
+        """Test confirm submits the cart and reports the confirmation.
+
+        Per the issue #59, round 3 ruling: the Discord confirm button
+        press is itself the human approval, so it must always forward
+        ``allow_review_items=True`` -- the user already saw the flagged
+        items and their reason codes in the preview rendered by
+        ``_format_cart_summary`` before pressing Confirm.
+        """
         cart = _make_cart_summary()
         order_result = _make_order_result(success=True, order_id="ORD-99")
         mock_pipeline = MagicMock()
@@ -2227,9 +2305,30 @@ class TestOrderConfirmView:
         mock_interaction.followup.send.assert_called_once()
         call_args = str(mock_interaction.followup.send.call_args)
         assert "ORD-99" in call_args
-        mock_pipeline.submit_cart.assert_called_once_with(cart)
+        mock_pipeline.submit_cart.assert_called_once_with(cart, allow_review_items=True)
         mock_pipeline.close.assert_called_once()
         assert view.is_finished() is True
+
+    @pytest.mark.asyncio()
+    async def test_confirm_forwards_allow_review_items_override(self, mock_interaction):
+        """Test confirm always passes allow_review_items=True to submit_cart.
+
+        Dedicated regression guard (separate from the result-reporting
+        test above) for the exact kwarg the confirm button must forward,
+        per the chief-architect's ruling: the human already reviewed the
+        flagged items and reasons in the rendered preview, so pressing
+        Confirm is the explicit override.
+        """
+        cart = _make_cart_summary()
+        mock_pipeline = MagicMock()
+        mock_pipeline.submit_cart.return_value = _make_order_result(success=True)
+
+        view = _OrderConfirmView(mock_pipeline, cart)
+        await type(view).confirm(view, mock_interaction, MagicMock())
+
+        mock_pipeline.submit_cart.assert_called_once()
+        _, kwargs = mock_pipeline.submit_cart.call_args
+        assert kwargs.get("allow_review_items") is True
 
     @pytest.mark.asyncio()
     async def test_confirm_submission_failure_reports_and_closes(

--- a/tests/test_cart_builder.py
+++ b/tests/test_cart_builder.py
@@ -6,13 +6,14 @@ from dataclasses import dataclass
 from unittest.mock import MagicMock
 
 from grocery_butler.cart_builder import (
+    MAX_QUANTITY_PER_ITEM,
     CartBuilder,
+    QuantityDecision,
     _calculate_quantity,
     _calculate_subtotal,
     _default_fulfillment_options,
     _get_fulfillment_fee,
     _parse_fulfillment_response,
-    _parse_product_size,
     _recommend_fulfillment,
 )
 from grocery_butler.models import (
@@ -118,71 +119,188 @@ class _MockSelectionResult:
 
 
 # ------------------------------------------------------------------
-# Tests: _parse_product_size
-# ------------------------------------------------------------------
-
-
-class TestParseProductSize:
-    """Tests for _parse_product_size."""
-
-    def test_simple_size(self) -> None:
-        """Test parsing '2 lb'."""
-        assert _parse_product_size("2 lb") == 2.0
-
-    def test_decimal_size(self) -> None:
-        """Test parsing '1.5 gal'."""
-        assert _parse_product_size("1.5 gal") == 1.5
-
-    def test_no_number(self) -> None:
-        """Test unparseable size returns 0."""
-        assert _parse_product_size("each") == 0.0
-
-    def test_empty_string(self) -> None:
-        """Test empty string returns 0."""
-        assert _parse_product_size("") == 0.0
-
-    def test_leading_whitespace(self) -> None:
-        """Test size with leading whitespace."""
-        assert _parse_product_size("  16 oz") == 16.0
-
-
-# ------------------------------------------------------------------
 # Tests: _calculate_quantity
 # ------------------------------------------------------------------
+#
+# NOTE: The old float-returning ``_parse_product_size`` helper (and its
+# ``TestParseProductSize`` test class) was removed as part of issue #59.
+# Its numeric-parsing behavior now lives in ``grocery_butler.units.
+# parse_size`` and is covered by ``tests/test_units.py``.
 
 
 class TestCalculateQuantity:
-    """Tests for _calculate_quantity."""
+    """Tests for _calculate_quantity returning a QuantityDecision."""
 
-    def test_exact_match(self) -> None:
+    def test_exact_match_returns_quantity_one_no_review(self) -> None:
         """Test quantity matches product size exactly."""
         item = _make_item(quantity=2.0)
         product = _make_product(size="2 lb")
-        assert _calculate_quantity(item, product) == 1
+        decision = _calculate_quantity(item, product)
+        assert decision == QuantityDecision(
+            quantity=1, needs_review=False, review_reason=""
+        )
 
-    def test_needs_two(self) -> None:
+    def test_needs_two_products_no_review(self) -> None:
         """Test needing two products."""
         item = _make_item(quantity=3.0)
         product = _make_product(size="2 lb")
-        assert _calculate_quantity(item, product) == 2
-
-    def test_unparseable_size(self) -> None:
-        """Test unparseable product size returns 1."""
-        item = _make_item(quantity=2.0)
-        product = _make_product(size="each")
-        assert _calculate_quantity(item, product) == 1
+        decision = _calculate_quantity(item, product)
+        assert decision.quantity == 2
+        assert decision.needs_review is False
+        assert decision.review_reason == ""
 
     def test_fractional_rounds_up(self) -> None:
         """Test fractional quantity rounds up."""
         item = _make_item(quantity=2.5)
         product = _make_product(size="2 lb")
-        assert _calculate_quantity(item, product) == 2
+        decision = _calculate_quantity(item, product)
+        assert decision.quantity == 2
 
     def test_minimum_one(self) -> None:
         """Test minimum quantity is 1."""
         item = _make_item(quantity=0.5)
         product = _make_product(size="2 lb")
-        assert _calculate_quantity(item, product) == 1
+        decision = _calculate_quantity(item, product)
+        assert decision.quantity == 1
+
+
+class TestCalculateQuantityUnparseableSize:
+    """Tests for _calculate_quantity when the product size can't be parsed."""
+
+    def test_size_each_flags_unparseable(self) -> None:
+        """Test a non-numeric size like 'each' flags unparseable_size."""
+        item = _make_item(quantity=2.0)
+        product = _make_product(size="each")
+        decision = _calculate_quantity(item, product)
+        assert decision == QuantityDecision(
+            quantity=1, needs_review=True, review_reason="unparseable_size"
+        )
+
+    def test_empty_size_flags_unparseable(self) -> None:
+        """Test an empty size string flags unparseable_size.
+
+        Regression guard for issue #59: previously an empty ``size``
+        silently produced a quantity of 1 with no indication that the
+        product's size was unknown.
+        """
+        item = _make_item(quantity=2.0)
+        product = _make_product(size="")
+        decision = _calculate_quantity(item, product)
+        assert decision.quantity == 1
+        assert decision.needs_review is True
+        assert decision.review_reason == "unparseable_size"
+
+
+class TestCalculateQuantityUnitConversion:
+    """Tests for _calculate_quantity unit-aware conversion (issue #59).
+
+    Reproduces the reported bugs: dividing raw numeric quantities without
+    regard to units caused massive over-orders (500 g item vs. a "5 lb"
+    product ordering 100 units) and under-orders (2 lb item vs. a "16 oz"
+    product ordering only 1 unit instead of 2).
+    """
+
+    def test_500g_item_vs_5lb_product_no_overorder(self) -> None:
+        """Test 500 g vs '5 lb' orders 1, not 100 (the reported bug)."""
+        item = _make_item(quantity=500.0, unit="g")
+        product = _make_product(size="5 lb")
+        decision = _calculate_quantity(item, product)
+        assert decision.quantity == 1
+        assert decision.needs_review is False
+
+    def test_2lb_item_vs_16oz_product_orders_two_exactly(self) -> None:
+        """Test 2 lb vs '16 oz' orders exactly 2, not 1 (the reported bug).
+
+        16 oz == 1 lb, so the exact ratio is 2.0. The epsilon applied
+        before ``ceil`` must prevent this from rounding up to 3.
+        """
+        item = _make_item(quantity=2.0, unit="lb")
+        product = _make_product(size="16 oz")
+        decision = _calculate_quantity(item, product)
+        assert decision.quantity == 2
+        assert decision.needs_review is False
+
+    def test_500g_item_vs_1lb_product_orders_two(self) -> None:
+        """Test 500 g vs '1 lb' (453.59237 g) needs 2 units."""
+        item = _make_item(quantity=500.0, unit="g")
+        product = _make_product(size="1 lb")
+        decision = _calculate_quantity(item, product)
+        assert decision.quantity == 2
+
+    def test_8oz_item_vs_1lb_product_orders_one(self) -> None:
+        """Test 8 oz vs '1 lb' is exactly half, so 1 unit suffices."""
+        item = _make_item(quantity=8.0, unit="oz")
+        product = _make_product(size="1 lb")
+        decision = _calculate_quantity(item, product)
+        assert decision.quantity == 1
+
+    def test_4cup_item_vs_1gal_product_orders_one(self) -> None:
+        """Test 4 cups vs '1 gal' (16 cups) needs only 1 unit."""
+        item = _make_item(quantity=4.0, unit="cup")
+        product = _make_product(size="1 gal")
+        decision = _calculate_quantity(item, product)
+        assert decision.quantity == 1
+
+    def test_20cup_item_vs_1gal_product_orders_two(self) -> None:
+        """Test 20 cups vs '1 gal' (16 cups) needs 2 units."""
+        item = _make_item(quantity=20.0, unit="cup")
+        product = _make_product(size="1 gal")
+        decision = _calculate_quantity(item, product)
+        assert decision.quantity == 2
+
+    def test_fractional_excess_still_rounds_up_past_epsilon(self) -> None:
+        """Test a genuine fractional excess still rounds up (regression).
+
+        Regression guard for the epsilon subtracted before ``math.ceil``
+        in ``_calculate_quantity`` (``needed - _QUANTITY_EPSILON``). 2.05
+        lb vs. a "1 lb" product needs 2.05 units, which must still ceil
+        to 3 — the tiny epsilon exists only to absorb floating-point
+        error on exact ratios, and must never mask a real fractional
+        need.
+        """
+        item = _make_item(quantity=2.05, unit="lb")
+        product = _make_product(size="1 lb")
+        decision = _calculate_quantity(item, product)
+        assert decision.quantity == 3
+        assert decision.needs_review is False
+
+
+class TestCalculateQuantityIncomparableUnits:
+    """Tests for _calculate_quantity when units differ in dimension."""
+
+    def test_each_item_vs_lb_product_flags_incomparable(self) -> None:
+        """Test 2 each vs '5 lb' can't be compared and flags for review."""
+        item = _make_item(quantity=2.0, unit="each")
+        product = _make_product(size="5 lb")
+        decision = _calculate_quantity(item, product)
+        assert decision == QuantityDecision(
+            quantity=1, needs_review=True, review_reason="incomparable_units"
+        )
+
+
+class TestCalculateQuantityCap:
+    """Tests for the per-item quantity cap (issue #59)."""
+
+    def test_large_quantity_capped_at_default_max(self) -> None:
+        """Test 100 lb vs '1 lb' is capped at MAX_QUANTITY_PER_ITEM."""
+        item = _make_item(quantity=100.0, unit="lb")
+        product = _make_product(size="1 lb")
+        decision = _calculate_quantity(item, product)
+        assert decision == QuantityDecision(
+            quantity=MAX_QUANTITY_PER_ITEM,
+            needs_review=True,
+            review_reason="quantity_capped",
+        )
+        assert decision.quantity == 10
+
+    def test_large_quantity_capped_at_injected_cap(self) -> None:
+        """Test the cap is injectable via the ``cap`` keyword argument."""
+        item = _make_item(quantity=100.0, unit="lb")
+        product = _make_product(size="1 lb")
+        decision = _calculate_quantity(item, product, cap=3)
+        assert decision == QuantityDecision(
+            quantity=3, needs_review=True, review_reason="quantity_capped"
+        )
 
 
 # ------------------------------------------------------------------
@@ -589,3 +707,76 @@ class TestBuildCart:
         assert result.items == []
         assert result.failed_items == []
         assert result.subtotal == 0.0
+
+    def test_unparseable_product_size_flags_cart_item_for_review(self) -> None:
+        """Test build_cart propagates needs_review/review_reason (issue #59).
+
+        A product with an unparseable size (e.g. "each") must produce a
+        CartItem carrying ``needs_review=True`` and
+        ``review_reason="unparseable_size"`` rather than silently
+        defaulting to a quantity of 1 with no signal to the user.
+        """
+        product = _make_product(price=8.99, size="each")
+        builder = self._make_builder(
+            search_results=[product],
+            selection_product=product,
+        )
+        result = builder.build_cart([_make_item()])
+
+        assert len(result.items) == 1
+        cart_item = result.items[0]
+        assert cart_item.quantity_to_order == 1
+        assert cart_item.needs_review is True
+        assert cart_item.review_reason == "unparseable_size"
+
+    def test_normal_product_size_leaves_cart_item_unflagged(self) -> None:
+        """Test a normal, parseable product size leaves review fields unset."""
+        product = _make_product(price=8.99, size="2 lb")
+        builder = self._make_builder(
+            search_results=[product],
+            selection_product=product,
+        )
+        result = builder.build_cart([_make_item(quantity=2.0)])
+
+        assert len(result.items) == 1
+        cart_item = result.items[0]
+        assert cart_item.needs_review is False
+        assert cart_item.review_reason == ""
+
+    def test_max_quantity_per_item_is_injectable_on_builder(self) -> None:
+        """Test CartBuilder accepts a max_quantity_per_item override.
+
+        With a low cap, a large order requirement must be capped and the
+        resulting CartItem flagged with review_reason="quantity_capped".
+        """
+        product = _make_product(price=1.0, size="1 lb")
+        mock_search = MagicMock()
+        mock_search.search_or_cached.return_value = [product]
+
+        item = _make_item(quantity=100.0, unit="lb")
+        mock_selector = MagicMock()
+        mock_selector.select_product.return_value = _MockSelectionResult(
+            item=item,
+            product=product,
+            reasoning="Test selection",
+        )
+
+        mock_substitution = MagicMock()
+        mock_client = MagicMock()
+        mock_client.store_id = "1234"
+        mock_client.get.return_value = {}
+
+        builder = CartBuilder(
+            search_service=mock_search,
+            product_selector=mock_selector,
+            substitution_service=mock_substitution,
+            safeway_client=mock_client,
+            max_quantity_per_item=3,
+        )
+        result = builder.build_cart([item])
+
+        assert len(result.items) == 1
+        cart_item = result.items[0]
+        assert cart_item.quantity_to_order == 3
+        assert cart_item.needs_review is True
+        assert cart_item.review_reason == "quantity_capped"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1595,6 +1595,60 @@ class TestHandleOrder:
         captured = capsys.readouterr()
         assert "Payment declined" in captured.err
 
+    def test_submit_blocked_by_flagged_cart_surfaces_reasons_and_exits_1(self, capsys):
+        """Test a non-dry-run order with a flagged cart stays blocked.
+
+        Per the chief-architect's ruling for issue #59 round 3: the CLI
+        gets NO change -- non-dry-run flagged carts still hit
+        ``pipeline.run`` on its safe default (``allow_review_items``
+        stays False), so ``OrderService.submit_order`` hard-blocks and
+        ``pipeline.run`` returns the failed OrderResult produced by
+        ``_format_review_block_message`` (naming the flagged ingredient
+        and its reason code). The CLI must surface that message on
+        stderr and exit nonzero -- exactly like any other order failure.
+        """
+        from grocery_butler.order_service import OrderResult
+
+        result = OrderResult(
+            success=False,
+            error_message=(
+                "Order blocked pending review: the following items need "
+                "manual review before ordering: spaghetti "
+                "(incomparable_units). Re-submit with "
+                "allow_review_items=True after confirming quantities."
+            ),
+        )
+
+        cfg = MagicMock()
+        cfg.anthropic_api_key = "sk-test"
+        cfg.safeway_username = "user"
+        cfg.safeway_password = "pass"
+        cfg.safeway_store_id = "1234"
+        cfg.database_path = ":memory:"
+
+        with (
+            patch("grocery_butler.cli._load_config_safe", return_value=cfg),
+            patch("grocery_butler.cli._make_anthropic_client", return_value=None),
+            patch("grocery_butler.cli.SafewayPipeline") as mock_pipeline_cls,
+        ):
+            mock_pipeline = MagicMock()
+            mock_pipeline.run.return_value = result
+            mock_pipeline_cls.return_value = mock_pipeline
+
+            parser = _build_parser()
+            args = parser.parse_args(["order", "--items", "spaghetti"])
+            code = _handle_order(args)
+
+        assert code == 1
+        captured = capsys.readouterr()
+        assert "spaghetti" in captured.err
+        assert "incomparable_units" in captured.err
+        mock_pipeline.run.assert_called_once()
+        # No override: the CLI never opts into allow_review_items — the
+        # block must be the default, safe outcome for a flagged cart.
+        _, kwargs = mock_pipeline.run.call_args
+        assert "allow_review_items" not in kwargs
+
     def test_parser_accepts_order_flags(self):
         """Test argparse wiring for order subcommand."""
         parser = _build_parser()
@@ -1725,6 +1779,73 @@ class TestFormatCartSummary:
         assert "Eggs" in result
         assert "$3.49" in result
         assert "pickup" in result.lower()
+
+    def test_format_flagged_item_shows_review_marker(self) -> None:
+        """Test needs_review items get a '(review)' marker on their line.
+
+        Regression guard for issue #59: quantity decisions that require
+        human review (unparseable size, incomparable units, or a capped
+        quantity) must be visibly flagged in the CLI cart summary.
+        """
+        from grocery_butler.models import (
+            CartItem,
+            CartSummary,
+            FulfillmentType,
+            SafewayProduct,
+        )
+
+        flagged_product = SafewayProduct(
+            product_id="P1", name="Mystery Item", price=4.99, size=""
+        )
+        flagged_item = CartItem(
+            shopping_list_item=ShoppingListItem(
+                ingredient="mystery item",
+                quantity=1.0,
+                unit="each",
+                category=IngredientCategory.OTHER,
+                search_term="mystery item",
+                from_meals=["manual"],
+            ),
+            safeway_product=flagged_product,
+            quantity_to_order=1,
+            estimated_cost=4.99,
+            needs_review=True,
+            review_reason="unparseable_size",
+        )
+        unflagged_product = SafewayProduct(
+            product_id="P2", name="Milk", price=3.99, size="1 gal"
+        )
+        unflagged_item = CartItem(
+            shopping_list_item=ShoppingListItem(
+                ingredient="milk",
+                quantity=1.0,
+                unit="gal",
+                category=IngredientCategory.DAIRY,
+                search_term="milk",
+                from_meals=["manual"],
+            ),
+            safeway_product=unflagged_product,
+            quantity_to_order=1,
+            estimated_cost=3.99,
+        )
+        cart = CartSummary(
+            items=[flagged_item, unflagged_item],
+            failed_items=[],
+            substituted_items=[],
+            skipped_items=[],
+            restock_items=[],
+            subtotal=8.98,
+            fulfillment_options=[],
+            recommended_fulfillment=FulfillmentType.PICKUP,
+            estimated_total=8.98,
+        )
+
+        result = _format_cart_summary(cart)
+        lines = result.splitlines()
+        mystery_line = next(line for line in lines if "Mystery Item" in line)
+        milk_line = next(line for line in lines if "Milk" in line)
+        assert "(review)" in mystery_line
+        assert "(review)" not in milk_line
 
     def test_format_with_substitution_shows_name(self) -> None:
         """Test substituted items show the selected product name."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -638,6 +638,62 @@ class TestCartItem:
         assert cart_item.quantity_to_order == 1
         assert cart_item.estimated_cost == 5.99
 
+    def test_default_review_fields_are_unset(self) -> None:
+        """Test needs_review/review_reason default to False and empty string.
+
+        Regression guard for issue #59: existing callers that construct
+        CartItem without the new fields must continue to work.
+        """
+        shopping_item = ShoppingListItem(
+            ingredient="milk",
+            quantity=1.0,
+            unit="gallon",
+            category=IngredientCategory.DAIRY,
+            search_term="whole milk",
+            from_meals=["Cereal"],
+        )
+        product = SafewayProduct(
+            product_id="SW-001",
+            name="Whole Milk",
+            price=5.99,
+            size="1 gallon",
+        )
+        cart_item = CartItem(
+            shopping_list_item=shopping_item,
+            safeway_product=product,
+            quantity_to_order=1,
+            estimated_cost=5.99,
+        )
+        assert cart_item.needs_review is False
+        assert cart_item.review_reason == ""
+
+    def test_explicit_review_fields_are_preserved(self) -> None:
+        """Test needs_review/review_reason can be set explicitly."""
+        shopping_item = ShoppingListItem(
+            ingredient="milk",
+            quantity=1.0,
+            unit="gallon",
+            category=IngredientCategory.DAIRY,
+            search_term="whole milk",
+            from_meals=["Cereal"],
+        )
+        product = SafewayProduct(
+            product_id="SW-001",
+            name="Whole Milk",
+            price=5.99,
+            size="",
+        )
+        cart_item = CartItem(
+            shopping_list_item=shopping_item,
+            safeway_product=product,
+            quantity_to_order=1,
+            estimated_cost=5.99,
+            needs_review=True,
+            review_reason="unparseable_size",
+        )
+        assert cart_item.needs_review is True
+        assert cart_item.review_reason == "unparseable_size"
+
 
 class TestFulfillmentOption:
     """Tests for FulfillmentOption model."""

--- a/tests/test_order_service.py
+++ b/tests/test_order_service.py
@@ -79,6 +79,8 @@ def _make_cart_item(
     ingredient: str = "chicken thighs",
     product_id: str = "P001",
     price: float = 8.99,
+    needs_review: bool = False,
+    review_reason: str = "",
 ) -> CartItem:
     """Create a test CartItem.
 
@@ -86,6 +88,10 @@ def _make_cart_item(
         ingredient: Ingredient name.
         product_id: Product ID.
         price: Product price.
+        needs_review: Whether this item should be flagged for human
+            review (issue #59 review-gate enforcement).
+        review_reason: Machine-readable reason code when ``needs_review``
+            is ``True``.
 
     Returns:
         CartItem for testing.
@@ -95,6 +101,8 @@ def _make_cart_item(
         safeway_product=_make_product(product_id=product_id, price=price),
         quantity_to_order=1,
         estimated_cost=price,
+        needs_review=needs_review,
+        review_reason=review_reason,
     )
 
 
@@ -433,6 +441,154 @@ class TestSubmitOrder:
 
         assert result.success is True
         assert result.confirmation is not None
+
+
+# ------------------------------------------------------------------
+# Tests: OrderService.submit_order review-gate enforcement (issue #59)
+# ------------------------------------------------------------------
+#
+# Gate 2.5 blocker: needs_review was computed by the cart builder but
+# never enforced before real money was spent. These tests pin the
+# required behavior: any flagged item (regular or restock) blocks
+# submission before the Safeway client is ever called, unless the
+# caller explicitly opts in via allow_review_items=True.
+
+
+class TestSubmitOrderReviewGate:
+    """Tests for OrderService.submit_order blocking flagged cart items."""
+
+    def _make_service(
+        self,
+        api_response: dict[str, Any] | None = None,
+    ) -> OrderService:
+        """Create an OrderService with mock dependencies.
+
+        Args:
+            api_response: Response the mocked client should return if
+                the order submission is allowed to proceed.
+
+        Returns:
+            OrderService with mocked client and pantry.
+        """
+        mock_client = MagicMock()
+        mock_client.post.return_value = api_response or {}
+
+        mock_pantry = MagicMock()
+        mock_pantry.mark_restocked.return_value = 0
+
+        return OrderService(mock_client, mock_pantry)
+
+    def test_blocks_cart_with_flagged_regular_item(self) -> None:
+        """Test a flagged regular item blocks submission before any spend.
+
+        No HTTP post should occur, the result must fail, and the error
+        message must name the flagged ingredient and its reason code.
+        """
+        service = self._make_service()
+        flagged = _make_cart_item(
+            ingredient="flour",
+            product_id="P002",
+            needs_review=True,
+            review_reason="incomparable_units",
+        )
+        cart = _make_cart(items=[flagged])
+
+        result = service.submit_order(cart)
+
+        assert result.success is False
+        assert "flour (incomparable_units)" in result.error_message
+        assert "review" in result.error_message.lower()
+        service._client.post.assert_not_called()
+
+    def test_blocks_cart_with_flagged_restock_item(self) -> None:
+        """Test a flagged restock item also blocks submission.
+
+        Restock items carry real money too, so a flag on a restock item
+        must block the order exactly like a flag on a regular item.
+        """
+        service = self._make_service()
+        flagged_restock = _make_cart_item(
+            ingredient="milk",
+            product_id="R1",
+            needs_review=True,
+            review_reason="quantity_capped",
+        )
+        cart = _make_cart(restock_items=[flagged_restock])
+
+        result = service.submit_order(cart)
+
+        assert result.success is False
+        assert "milk (quantity_capped)" in result.error_message
+        service._client.post.assert_not_called()
+
+    def test_blocks_multiple_flagged_items_names_each(self) -> None:
+        """Test the error message names every flagged item, not just one."""
+        service = self._make_service()
+        flagged_a = _make_cart_item(
+            ingredient="flour",
+            product_id="P002",
+            needs_review=True,
+            review_reason="incomparable_units",
+        )
+        flagged_b = _make_cart_item(
+            ingredient="sugar",
+            product_id="P003",
+            needs_review=True,
+            review_reason="unparseable_size",
+        )
+        cart = _make_cart(items=[flagged_a, flagged_b])
+
+        result = service.submit_order(cart)
+
+        assert result.success is False
+        assert "flour (incomparable_units)" in result.error_message
+        assert "sugar (unparseable_size)" in result.error_message
+        service._client.post.assert_not_called()
+
+    def test_allow_review_items_true_submits_flagged_cart_normally(self) -> None:
+        """Test allow_review_items=True is an explicit human override.
+
+        With the override set, submission must proceed exactly like the
+        unflagged happy path: the client is called and success is True.
+        """
+        service = self._make_service(
+            api_response={
+                "orderId": "ORD-123",
+                "status": "confirmed",
+                "total": 8.99,
+            }
+        )
+        flagged = _make_cart_item(
+            ingredient="flour",
+            needs_review=True,
+            review_reason="incomparable_units",
+        )
+        cart = _make_cart(items=[flagged])
+
+        result = service.submit_order(cart, allow_review_items=True)
+
+        assert result.success is True
+        assert result.confirmation is not None
+        service._client.post.assert_called_once()
+
+    def test_unflagged_cart_unaffected_by_default_kwarg(self) -> None:
+        """Test a cart with no flagged items submits normally by default.
+
+        Pins that the new ``allow_review_items`` keyword argument
+        defaults to False without changing behavior for carts that have
+        nothing to flag.
+        """
+        service = self._make_service(
+            api_response={
+                "orderId": "ORD-456",
+                "status": "confirmed",
+                "total": 8.99,
+            }
+        )
+        result = service.submit_order(_make_cart())
+
+        assert result.success is True
+        service._client.post.assert_called_once()
 
 
 # ------------------------------------------------------------------

--- a/tests/test_safeway_pipeline.py
+++ b/tests/test_safeway_pipeline.py
@@ -403,9 +403,104 @@ class TestSubmitCart:
 
         assert result is expected
         mock_order_cls.return_value.submit_order.assert_called_once_with(
-            mock_cart_summary
+            mock_cart_summary, allow_review_items=False
         )
         mock_cart_cls.return_value.build_cart.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Submit cart review-gate forwarding tests (issue #59)
+# ---------------------------------------------------------------------------
+#
+# Gate 2.5 blocker: SafewayPipeline.submit_cart must accept and forward
+# allow_review_items to OrderService.submit_order so bot/api/cli callers
+# can pass the human override through, while defaulting to the safe
+# (blocked) behavior when not supplied.
+
+
+class TestSubmitCartReviewGate:
+    """Tests for SafewayPipeline.submit_cart forwarding allow_review_items."""
+
+    @patch("grocery_butler.safeway_pipeline.RecipeStore")
+    @patch("grocery_butler.safeway_pipeline.ProductSearchService")
+    @patch("grocery_butler.safeway_pipeline.ProductSelector")
+    @patch("grocery_butler.safeway_pipeline.SubstitutionService")
+    @patch("grocery_butler.safeway_pipeline.SafewayClient")
+    @patch("grocery_butler.safeway_pipeline.PantryManager")
+    @patch("grocery_butler.safeway_pipeline.CartBuilder")
+    @patch("grocery_butler.safeway_pipeline.OrderService")
+    def test_submit_cart_blocks_flagged_cart_by_default(
+        self,
+        mock_order_cls: MagicMock,
+        mock_cart_cls: MagicMock,
+        mock_pantry: MagicMock,
+        mock_client_cls: MagicMock,
+        mock_sub: MagicMock,
+        mock_selector: MagicMock,
+        mock_search: MagicMock,
+        mock_store: MagicMock,
+        safeway_config: Config,
+        mock_cart_summary: CartSummary,
+    ):
+        """Test submit_cart forwards the default (blocking) review gate.
+
+        Without an explicit override, submit_cart must call
+        OrderService.submit_order with allow_review_items=False so a
+        flagged cart is blocked pending review.
+        """
+        mock_client_cls.return_value.is_authenticated = True
+        blocked = OrderResult(
+            success=False,
+            error_message="Order blocked pending review: flour (incomparable_units)",
+        )
+        mock_order_cls.return_value.submit_order.return_value = blocked
+
+        pipeline = SafewayPipeline(safeway_config, ":memory:")
+        result = pipeline.submit_cart(mock_cart_summary)
+
+        assert result is blocked
+        mock_order_cls.return_value.submit_order.assert_called_once_with(
+            mock_cart_summary, allow_review_items=False
+        )
+
+    @patch("grocery_butler.safeway_pipeline.RecipeStore")
+    @patch("grocery_butler.safeway_pipeline.ProductSearchService")
+    @patch("grocery_butler.safeway_pipeline.ProductSelector")
+    @patch("grocery_butler.safeway_pipeline.SubstitutionService")
+    @patch("grocery_butler.safeway_pipeline.SafewayClient")
+    @patch("grocery_butler.safeway_pipeline.PantryManager")
+    @patch("grocery_butler.safeway_pipeline.CartBuilder")
+    @patch("grocery_butler.safeway_pipeline.OrderService")
+    def test_submit_cart_forwards_allow_review_items_true(
+        self,
+        mock_order_cls: MagicMock,
+        mock_cart_cls: MagicMock,
+        mock_pantry: MagicMock,
+        mock_client_cls: MagicMock,
+        mock_sub: MagicMock,
+        mock_selector: MagicMock,
+        mock_search: MagicMock,
+        mock_store: MagicMock,
+        safeway_config: Config,
+        mock_cart_summary: CartSummary,
+    ):
+        """Test submit_cart forwards an explicit human override.
+
+        Callers (bot confirm view, API confirm endpoint) must be able to
+        pass allow_review_items=True through submit_cart to proceed with
+        a flagged cart after explicit human confirmation.
+        """
+        mock_client_cls.return_value.is_authenticated = True
+        expected = OrderResult(success=True)
+        mock_order_cls.return_value.submit_order.return_value = expected
+
+        pipeline = SafewayPipeline(safeway_config, ":memory:")
+        result = pipeline.submit_cart(mock_cart_summary, allow_review_items=True)
+
+        assert result is expected
+        mock_order_cls.return_value.submit_order.assert_called_once_with(
+            mock_cart_summary, allow_review_items=True
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,183 @@
+"""Tests for grocery_butler.units module.
+
+Covers the unit-dimension classifier, cross-unit conversion, and the
+strict product-size parser introduced to fix issue #59 (quantity
+calculations that ignored units, causing gross over/under-ordering).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from grocery_butler.models import Unit
+from grocery_butler.units import Dimension, convert, dimension_of, parse_size
+
+# ------------------------------------------------------------------
+# Tests: dimension_of
+# ------------------------------------------------------------------
+
+
+class TestDimensionOf:
+    """Tests for dimension_of."""
+
+    @pytest.mark.parametrize(
+        "unit",
+        [Unit.G, Unit.KG, Unit.OZ, Unit.LB],
+    )
+    def test_mass_units_return_mass_dimension(self, unit: Unit) -> None:
+        """Test mass units classify as Dimension.MASS."""
+        assert dimension_of(unit) == Dimension.MASS
+
+    @pytest.mark.parametrize(
+        "unit",
+        [Unit.ML, Unit.L, Unit.TSP, Unit.TBSP, Unit.FL_OZ, Unit.CUP, Unit.GAL],
+    )
+    def test_volume_units_return_volume_dimension(self, unit: Unit) -> None:
+        """Test volume units classify as Dimension.VOLUME."""
+        assert dimension_of(unit) == Dimension.VOLUME
+
+    @pytest.mark.parametrize("unit", [Unit.EACH, Unit.DOZEN])
+    def test_count_units_return_count_dimension(self, unit: Unit) -> None:
+        """Test count units classify as Dimension.COUNT."""
+        assert dimension_of(unit) == Dimension.COUNT
+
+    @pytest.mark.parametrize("unit", [Unit.BAG, Unit.PINCH, Unit.BUNCH])
+    def test_packaging_and_other_units_return_none(self, unit: Unit) -> None:
+        """Test non-convertible units (packaging, "other") return None."""
+        assert dimension_of(unit) is None
+
+
+# ------------------------------------------------------------------
+# Tests: convert
+# ------------------------------------------------------------------
+
+
+class TestConvert:
+    """Tests for convert."""
+
+    def test_identity_same_unit(self) -> None:
+        """Test converting a unit to itself returns the same quantity."""
+        assert convert(5.0, Unit.LB, Unit.LB) == 5.0
+
+    def test_g_to_lb(self) -> None:
+        """Test grams to pounds mass conversion."""
+        assert convert(453.59237, Unit.G, Unit.LB) == pytest.approx(1.0)
+
+    def test_lb_to_g(self) -> None:
+        """Test pounds to grams mass conversion."""
+        assert convert(1.0, Unit.LB, Unit.G) == pytest.approx(453.59237)
+
+    def test_oz_to_lb(self) -> None:
+        """Test ounces to pounds mass conversion (16 oz == 1 lb)."""
+        assert convert(16.0, Unit.OZ, Unit.LB) == pytest.approx(1.0)
+
+    def test_kg_to_g(self) -> None:
+        """Test kilograms to grams mass conversion."""
+        assert convert(2.0, Unit.KG, Unit.G) == pytest.approx(2000.0)
+
+    def test_g_to_kg(self) -> None:
+        """Test grams to kilograms mass conversion."""
+        assert convert(2000.0, Unit.G, Unit.KG) == pytest.approx(2.0)
+
+    def test_cup_to_gal(self) -> None:
+        """Test cups to gallons volume conversion (16 cups == 1 gal)."""
+        assert convert(16.0, Unit.CUP, Unit.GAL) == pytest.approx(1.0)
+
+    def test_gal_to_cup(self) -> None:
+        """Test gallons to cups volume conversion."""
+        assert convert(1.0, Unit.GAL, Unit.CUP) == pytest.approx(16.0)
+
+    def test_tsp_to_tbsp(self) -> None:
+        """Test teaspoons to tablespoons volume conversion (3 tsp == 1 tbsp)."""
+        assert convert(3.0, Unit.TSP, Unit.TBSP) == pytest.approx(1.0)
+
+    def test_tbsp_to_tsp(self) -> None:
+        """Test tablespoons to teaspoons volume conversion."""
+        assert convert(1.0, Unit.TBSP, Unit.TSP) == pytest.approx(3.0)
+
+    def test_l_to_ml(self) -> None:
+        """Test liters to milliliters volume conversion."""
+        assert convert(1.0, Unit.L, Unit.ML) == pytest.approx(1000.0)
+
+    def test_ml_to_l(self) -> None:
+        """Test milliliters to liters volume conversion."""
+        assert convert(1000.0, Unit.ML, Unit.L) == pytest.approx(1.0)
+
+    def test_dozen_to_each(self) -> None:
+        """Test dozen to each count conversion."""
+        assert convert(1.0, Unit.DOZEN, Unit.EACH) == pytest.approx(12.0)
+
+    def test_each_to_dozen(self) -> None:
+        """Test each to dozen count conversion."""
+        assert convert(12.0, Unit.EACH, Unit.DOZEN) == pytest.approx(1.0)
+
+    def test_cross_dimension_lb_to_cup_returns_none(self) -> None:
+        """Test mass-to-volume conversion is rejected."""
+        assert convert(1.0, Unit.LB, Unit.CUP) is None
+
+    def test_cross_dimension_each_to_g_returns_none(self) -> None:
+        """Test count-to-mass conversion is rejected."""
+        assert convert(1.0, Unit.EACH, Unit.G) is None
+
+    def test_non_convertible_bag_to_g_returns_none(self) -> None:
+        """Test a non-convertible packaging unit (bag) returns None."""
+        assert convert(1.0, Unit.BAG, Unit.G) is None
+
+    def test_non_convertible_g_to_bag_returns_none(self) -> None:
+        """Test converting into a non-convertible packaging unit returns None."""
+        assert convert(1.0, Unit.G, Unit.BAG) is None
+
+
+# ------------------------------------------------------------------
+# Tests: parse_size
+# ------------------------------------------------------------------
+
+
+class TestParseSize:
+    """Tests for parse_size."""
+
+    def test_pounds(self) -> None:
+        """Test parsing '5 lb'."""
+        assert parse_size("5 lb") == (5.0, Unit.LB)
+
+    def test_ounces(self) -> None:
+        """Test parsing '16 oz'."""
+        assert parse_size("16 oz") == (16.0, Unit.OZ)
+
+    def test_gallon(self) -> None:
+        """Test parsing '1 gal'."""
+        assert parse_size("1 gal") == (1.0, Unit.GAL)
+
+    def test_fluid_ounces_with_space(self) -> None:
+        """Test parsing '32 fl oz' (two-word unit token)."""
+        assert parse_size("32 fl oz") == (32.0, Unit.FL_OZ)
+
+    def test_decimal_liters(self) -> None:
+        """Test parsing '1.5 l'."""
+        assert parse_size("1.5 l") == (1.5, Unit.L)
+
+    def test_bare_number_defaults_to_each(self) -> None:
+        """Test a bare number like '12' parses as (12.0, Unit.EACH)."""
+        assert parse_size("12") == (12.0, Unit.EACH)
+
+    def test_empty_string_returns_none(self) -> None:
+        """Test an empty size string is unparseable."""
+        assert parse_size("") is None
+
+    def test_no_leading_number_returns_none(self) -> None:
+        """Test a string with no leading number is unparseable."""
+        assert parse_size("each") is None
+
+    def test_unrecognized_unit_token_returns_none(self) -> None:
+        """Test a strict resolver: unknown unit tokens return None.
+
+        This is the key behavioral difference from ``parse_unit`` in
+        ``grocery_butler.models``, which falls back to ``Unit.EACH`` for
+        unrecognized tokens. ``parse_size`` must NOT do that fallback --
+        garbage like "5 zorbs" must not silently resolve to 5 each.
+        """
+        assert parse_size("5 zorbs") is None
+
+    def test_leading_whitespace(self) -> None:
+        """Test size with leading whitespace is still parsed."""
+        assert parse_size("  16 oz") == (16.0, Unit.OZ)


### PR DESCRIPTION
## Summary

- **Unit-aware quantity math**: new `grocery_butler/units.py` (mass/volume/count conversion tables, strict `parse_size()` that never guesses on garbage tokens); `_calculate_quantity` now converts the shopping-list quantity to the product-size unit before dividing, so `500 g` vs `"5 lb"` orders 1 bag (was 100) and `2 lb` vs `"16 oz"` orders 2 (was 1).
- **Fail-safe + per-item cap**: unparseable sizes (incl. `size=""`) and incomparable units (count vs weight) order 1 and set `CartItem.needs_review`/`review_reason`; quantities are hard-capped at `MAX_QUANTITY_PER_ITEM = 10` (injectable via `CartBuilder(max_quantity_per_item=...)`) with a `quantity_capped` flag.
- **Money-path enforcement**: `OrderService.submit_order` hard-blocks carts containing flagged items (no HTTP call, error names each ingredient + reason) unless `allow_review_items=True`. The override is only reachable after an informed preview: the API staged-confirmation message and the Discord cart summary render flagged items with reasons before their confirm actions forward `allow_review_items=True`; the CLI non-dry-run path has no preview and stays blocked by default.

## Test plan

- TDD: failing tests first reproducing the 100x over-order (500 g vs "5 lb"), the under-order (2 lb vs "16 oz"), the `size=""` silent-1 case, cross-unit correctness (g↔lb, oz↔lb, cup↔gal), incomparable-unit fail-safe, cap enforcement + injectability, and the epsilon boundary (2.05 lb vs "1 lb" → 3).
- New `tests/test_units.py` (conversion factors, cross-dimension → None, strict `parse_size`); extended `tests/test_cart_builder.py`, `test_models.py`, `test_order_service.py` (review gate: blocked cart never hits the client; override submits), `test_safeway_pipeline.py` (kwarg forwarding), `test_api_destructive.py` (staged message surfaces flags; confirm forwards override), `test_bot.py` (reason rendered; confirm button forwards override), `test_cli.py` (blocked path surfaces reasons, exit 1); e2e chain tests extended to pin the staged review section.
- `./scripts/check-all.sh` exit 0: ruff lint+format, mypy strict, bandit + pip-audit, radon/xenon, 1276 tests passing (unit + e2e), branch coverage 95.58% (threshold 90%).

## Notes

- Pre-existing, out-of-scope bug found during this work: `scripts/complexity.sh:70` runs `radon mi -a grocery_butler/ || true` — `-a` is not a valid `radon mi` flag, so the Maintainability Index sub-check silently no-ops. Needs its own issue (automated issue creation was not permitted from this run).
- Non-blocking follow-up suggested by self-review: promote `order_service._collect_review_items` to a public name now that `api.py` reuses it cross-module.

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)
