### PR TITLE
fix: descope Safeway order submission for v1.0 behind fail-safe gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,7 @@ RUBOTPAUL_SHARED_SECRET=
 SAFEWAY_USERNAME=
 SAFEWAY_PASSWORD=
 SAFEWAY_STORE_ID=
+
+# Issue #60: real order submission is descoped for v1.0 (unverified
+# checkout API surface). Leave false until the live flow is verified.
+SAFEWAY_ORDER_SUBMISSION_ENABLED=false

--- a/README.md
+++ b/README.md
@@ -165,6 +165,51 @@ invoked ad-hoc as a single-shot process (no daemon).
 4. **The Safeway integration is optional.** Removing it leaves a fully usable
    meal-planning + inventory tracking system.
 
+### Safeway Order Submission Status (v1.0)
+
+The Safeway integration's **checkout API surface is unverified** against the
+live Safeway/Albertsons API (Issue #60). Concretely: the Okta auth flow uses
+an `aus`-prefixed `OKTA_CLIENT_ID`, which looks like an authorization-server
+id rather than a client id, and `/abs/pub/web/orders` has no modeled payment
+method or delivery/pickup slot reservation. No real order has ever been
+confirmed to go through this client.
+
+For v1.0, real order submission is **disabled by default** and fails safe:
+
+- **Building and reviewing a cart still works** end-to-end —
+  `SafewayPipeline.build_cart_only` (Python API), CLI
+  `order review`/`order submit --dry-run`, `/order review` (Discord), and
+  the RubotPaul `/order/preview` endpoint all function normally.
+- **Submitting an order does not.** `OrderService.submit_order`,
+  `SafewayPipeline.submit_cart`/`run()`, CLI `order submit`, `/order submit`
+  (Discord), and the RubotPaul `/order/submit` → `/actions/confirm` flow all
+  return a failed result, raise, or respond `501`, with an actionable
+  message pointing at manual checkout — instead of silently pretending to
+  place an order.
+- **Checkout for v1.0 is manual**: build and review the cart in-app, then
+  complete the purchase yourself on safeway.com or in the Safeway app.
+
+Set `SAFEWAY_ORDER_SUBMISSION_ENABLED=true` (see `.env.example`) to lift the
+guard once the checklist below is complete. **Do not enable it in
+production before that.**
+
+**Human verification checklist** (gates enabling the flag — see Issue #60):
+
+- [ ] Verify the Okta `authn`/`authorize` flow against real credentials. The
+      `aus`-prefixed `OKTA_CLIENT_ID` is likely an authorization-server id,
+      not a `0oa` client id — capture the real value from web-app network
+      traffic.
+- [ ] Verify each endpoint against the live API —
+      `/api/v2/grocerystore/search`,
+      `/abs/pub/web/stores/{id}/fulfillment`, `/abs/pub/web/orders` — and
+      check in recorded request/response fixtures for tests.
+- [ ] Model the checkout requirements this client currently omits (payment
+      method selection, delivery/pickup slot reservation, address/contact),
+      or make an explicit decision to keep the descope.
+- [ ] Record one successful end-to-end order against a real account (see
+      the manual verification checklist in #32 and the automated test plan
+      in #31).
+
 ## Code Choices
 
 Each technology choice is deliberate. The shared theme: **boring, well-typed,
@@ -224,8 +269,12 @@ and easy to operate alone.**
 ### HTTP
 
 - **httpx** for the Safeway client — async-capable and gives precise control
-  over cookies, headers, and timeouts. Required because Safeway's web API is
-  cookie-session-based and not officially documented.
+  over headers, timeouts, and bearer-token auth. Safeway's web API is not
+  officially documented; the client authenticates via an Okta-issued bearer
+  token (no cookie session). The full auth flow and every endpoint are
+  **unverified** against the live Safeway/Albertsons API — see
+  [Safeway Order Submission Status (v1.0)](#safeway-order-submission-status-v10)
+  and Issue #60.
 
 ### Quality tooling
 

--- a/grocery_butler/api.py
+++ b/grocery_butler/api.py
@@ -35,6 +35,7 @@ from grocery_butler.models import (
     PendingActionStatus,
     ShoppingListItem,
 )
+from grocery_butler.order_service import ORDER_SUBMISSION_DISABLED_MESSAGE
 from grocery_butler.pantry_manager import PantryManager
 from grocery_butler.pending_actions import PendingActionsStore
 from grocery_butler.recipe_store import RecipeStore
@@ -560,6 +561,12 @@ def _confirm_order_submit(
         # Not claimed yet: the action stays pending so it can be retried
         # (until it expires) once configuration is fixed.
         return jsonify(error=f"safeway pipeline unavailable: {exc}"), 503
+    if not pipeline.order_submission_enabled:
+        # Issue #60: order submission is descoped for v1.0. Not claimed —
+        # the action stays pending so it can be retried once the flag is
+        # flipped on after live verification.
+        pipeline.close()
+        return jsonify(error=ORDER_SUBMISSION_DISABLED_MESSAGE), 501
     _claim_pending(store, action.action_id)
     try:
         result = pipeline.submit_cart(cart)

--- a/grocery_butler/bot.py
+++ b/grocery_butler/bot.py
@@ -288,6 +288,8 @@ class _OrderConfirmView(discord.ui.View):
             interaction: Discord interaction context.
             button: The button that was pressed.
         """
+        from grocery_butler.safeway_pipeline import SafewayPipelineError
+
         await interaction.response.defer()
         try:
             order_result = await asyncio.to_thread(
@@ -295,6 +297,9 @@ class _OrderConfirmView(discord.ui.View):
             )
             msg = _format_order_result(order_result)
             await interaction.followup.send(msg)
+        except SafewayPipelineError as exc:
+            logger.exception("Order submission failed")
+            await interaction.followup.send(f"Order submission failed: {exc}")
         except Exception:
             logger.exception("Order submission failed")
             await interaction.followup.send("Order submission failed.")

--- a/grocery_butler/config.py
+++ b/grocery_butler/config.py
@@ -47,6 +47,11 @@ class Config:
     safeway_password: str = ""
     safeway_store_id: str = ""
 
+    # Issue #60: order submission is descoped for v1.0 (unverified checkout
+    # API surface). Fail-safe default is off; opt in explicitly once the
+    # live Safeway checkout flow has been verified.
+    safeway_order_submission_enabled: bool = False
+
 
 def load_config(env_path: str | Path | None = None) -> Config:
     """Load and validate configuration from environment / .env file.
@@ -99,4 +104,8 @@ def load_config(env_path: str | Path | None = None) -> Config:
         safeway_username=os.getenv("SAFEWAY_USERNAME", ""),
         safeway_password=os.getenv("SAFEWAY_PASSWORD", ""),
         safeway_store_id=os.getenv("SAFEWAY_STORE_ID", ""),
+        safeway_order_submission_enabled=os.getenv(
+            "SAFEWAY_ORDER_SUBMISSION_ENABLED", "false"
+        ).lower()
+        in ("true", "1", "yes"),
     )

--- a/grocery_butler/order_service.py
+++ b/grocery_butler/order_service.py
@@ -17,6 +17,20 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+#: Issue #60: real order submission is descoped for v1.0. The Safeway
+#: checkout API surface (Okta auth, payment method, delivery slot
+#: reservation) is unverified against the live API, so submission is
+#: gated off by default and this message is returned instead of ever
+#: calling the client.
+ORDER_SUBMISSION_DISABLED_MESSAGE = (
+    "Order submission is descoped for v1.0 (Issue #60): unverified "
+    "checkout surface (no payment method, no delivery slot reservation, "
+    "and a likely-invalid Okta client id). Build or review the cart "
+    "instead — that dry-run path works today. Once the live checkout "
+    "flow has been verified end-to-end, set "
+    "SAFEWAY_ORDER_SUBMISSION_ENABLED=true to enable real submissions."
+)
+
 
 @dataclass
 class OrderConfirmation:
@@ -62,21 +76,31 @@ class OrderService:
     Args:
         safeway_client: Authenticated Safeway API client.
         pantry_manager: Pantry manager for inventory updates.
+        submission_enabled: Issue #60 fail-safe gate. Real submission to
+            Safeway is descoped for v1.0 because the checkout API surface
+            is unverified, so this defaults to ``False``. Callers must
+            opt in explicitly (see ``SAFEWAY_ORDER_SUBMISSION_ENABLED``).
     """
 
     def __init__(
         self,
         safeway_client: Any,
         pantry_manager: PantryManager,
+        *,
+        submission_enabled: bool = False,
     ) -> None:
         """Initialize the order service.
 
         Args:
             safeway_client: Safeway API client.
             pantry_manager: Pantry manager for restocking.
+            submission_enabled: Issue #60 fail-safe gate. Defaults to
+                ``False`` so submission is blocked unless explicitly
+                enabled by the caller.
         """
         self._client = safeway_client
         self._pantry = pantry_manager
+        self._submission_enabled = submission_enabled
 
     def submit_order(
         self,
@@ -88,8 +112,17 @@ class OrderService:
             cart: The built cart summary to submit.
 
         Returns:
-            OrderResult with confirmation or error details.
+            OrderResult with confirmation or error details. If order
+            submission is disabled (Issue #60), returns a failure result
+            with :data:`ORDER_SUBMISSION_DISABLED_MESSAGE` before any
+            other validation or API call.
         """
+        if not self._submission_enabled:
+            return OrderResult(
+                success=False,
+                error_message=ORDER_SUBMISSION_DISABLED_MESSAGE,
+            )
+
         if not cart.items and not cart.restock_items:
             return OrderResult(
                 success=False,

--- a/grocery_butler/safeway_client.py
+++ b/grocery_butler/safeway_client.py
@@ -9,6 +9,28 @@ Authentication flow:
 2. Exchange session token for access token via OAuth2 implicit grant
 3. Use bearer token for Nimbus API calls
 4. Auto-refresh when token approaches expiry
+
+Issue #60 — UNVERIFIED API SURFACE, ORDER SUBMISSION DESCOPED FOR v1.0:
+    This entire client is unverified against the live Safeway/Albertsons
+    API. It was written from inference, not from a confirmed working
+    integration, and has several concrete red flags:
+
+    - ``OKTA_CLIENT_ID`` (``ausp6soxrIyPrm8rS2p6``) is used as *both* the
+      Okta authorization-server segment in the auth URL *and* the OAuth2
+      ``client_id``. An ``aus``-prefixed value is an authorization-server
+      id, not a client id (client ids are normally ``0oa``-prefixed), so
+      the OAuth2 implicit-grant exchange this client performs is
+      unverified and may not work against the real Okta tenant.
+    - The order-submission endpoint (``/abs/pub/web/orders``) and its
+      header scheme are unverified: no payment method is wired up and no
+      delivery slot reservation step exists before submission.
+
+    Because this surface is unverified, real order submission is
+    disabled by default (see :mod:`grocery_butler.order_service`,
+    ``ORDER_SUBMISSION_DISABLED_MESSAGE``) and gated behind the
+    ``SAFEWAY_ORDER_SUBMISSION_ENABLED`` environment variable. Do not
+    enable it in production until this client has been verified against
+    a live Safeway/Albertsons account.
 """
 
 from __future__ import annotations

--- a/grocery_butler/safeway_pipeline.py
+++ b/grocery_butler/safeway_pipeline.py
@@ -10,7 +10,11 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from grocery_butler.cart_builder import CartBuilder
-from grocery_butler.order_service import OrderResult, OrderService
+from grocery_butler.order_service import (
+    ORDER_SUBMISSION_DISABLED_MESSAGE,
+    OrderResult,
+    OrderService,
+)
 from grocery_butler.pantry_manager import PantryManager
 from grocery_butler.product_search import ProductSearchService
 from grocery_butler.product_selector import ProductSelector
@@ -27,6 +31,17 @@ logger = logging.getLogger(__name__)
 
 class SafewayPipelineError(Exception):
     """Raised when the pipeline encounters an unrecoverable error."""
+
+
+class OrderSubmissionDisabledError(SafewayPipelineError):
+    """Raised when order submission is attempted while descoped (Issue #60).
+
+    Real order submission is disabled by default because the Safeway
+    checkout API surface is unverified. This is raised as the first
+    action of :meth:`SafewayPipeline.run` and
+    :meth:`SafewayPipeline.submit_cart` when the gate is off, before any
+    authentication or cart-building I/O occurs.
+    """
 
 
 class SafewayPipeline:
@@ -84,8 +99,27 @@ class SafewayPipeline:
             search_service, selector, substitution, self._client
         )
 
+        # Issue #60: fail-safe order-submission gate. Defense in depth —
+        # OrderService also defaults to disabled, and this pipeline
+        # additionally short-circuits run()/submit_cart() before any I/O.
+        self._submission_enabled = config.safeway_order_submission_enabled
+
         pantry_manager = PantryManager(db_path, anthropic_client)
-        self._order_service = OrderService(self._client, pantry_manager)
+        self._order_service = OrderService(
+            self._client,
+            pantry_manager,
+            submission_enabled=self._submission_enabled,
+        )
+
+    @property
+    def order_submission_enabled(self) -> bool:
+        """Whether real order submission is enabled (Issue #60 gate).
+
+        Returns:
+            True if ``SAFEWAY_ORDER_SUBMISSION_ENABLED`` was set truthy
+            when this pipeline's config was loaded, False otherwise.
+        """
+        return self._submission_enabled
 
     def run(
         self,
@@ -102,8 +136,13 @@ class SafewayPipeline:
             OrderResult with confirmation or error details.
 
         Raises:
+            OrderSubmissionDisabledError: If order submission is disabled
+                (Issue #60). Raised before authentication or cart
+                building.
             SafewayPipelineError: If authentication fails.
         """
+        if not self._submission_enabled:
+            raise OrderSubmissionDisabledError(ORDER_SUBMISSION_DISABLED_MESSAGE)
         self._authenticate()
         cart = self._cart_builder.build_cart(items, restock_items)
         return self._order_service.submit_order(cart)
@@ -141,8 +180,12 @@ class SafewayPipeline:
             OrderResult with confirmation or error details.
 
         Raises:
+            OrderSubmissionDisabledError: If order submission is disabled
+                (Issue #60). Raised before authentication.
             SafewayPipelineError: If authentication fails.
         """
+        if not self._submission_enabled:
+            raise OrderSubmissionDisabledError(ORDER_SUBMISSION_DISABLED_MESSAGE)
         self._authenticate()
         return self._order_service.submit_order(cart)
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -88,6 +88,12 @@ def e2e_env(monkeypatch: pytest.MonkeyPatch, db_path: str) -> None:
     monkeypatch.setenv("SAFEWAY_PASSWORD", "e2e-safeway-pass")
     monkeypatch.setenv("SAFEWAY_STORE_ID", "e2e-store-1")
     monkeypatch.setenv("DATABASE_PATH", db_path)
+    # Issue #60: order submission is opted in for this suite's full-chain
+    # tests, which exercise real submission against the mocked transport.
+    # The production default (env var unset) is False -- see
+    # test_api_chain.py::test_disabled_submission_returns_501_default_off
+    # for coverage of the fail-safe default itself.
+    monkeypatch.setenv("SAFEWAY_ORDER_SUBMISSION_ENABLED", "true")
 
 
 @pytest.fixture()

--- a/tests/e2e/test_api_chain.py
+++ b/tests/e2e/test_api_chain.py
@@ -143,6 +143,47 @@ def test_full_chain_meal_to_confirmed_order(
     assert "/abs/pub/web/orders" in safeway_mock.requested_paths
 
 
+def test_disabled_submission_returns_501_default_off(
+    client: FlaskClient,
+    signed_headers: Callable[..., dict[str, str]],
+    seed_recipe: ParsedMeal,
+    no_claude: None,
+    safeway_mock: SafewayMockState,
+    db_path: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #60: with the flag unset (the production default), confirm returns 501.
+
+    ``e2e_env`` opts this suite's full-chain tests into submission via
+    ``SAFEWAY_ORDER_SUBMISSION_ENABLED=true`` (see conftest.py); this test
+    reverts to the real, unset production default to prove the fail-safe
+    gate blocks a live submission end-to-end -- through the real
+    ``SafewayPipeline`` and Flask confirm endpoint, not just unit mocks --
+    and that the mocked Safeway order endpoint is never hit.
+    """
+    from grocery_butler.order_service import ORDER_SUBMISSION_DISABLED_MESSAGE
+
+    monkeypatch.delenv("SAFEWAY_ORDER_SUBMISSION_ENABLED", raising=False)
+    headers = signed_headers()
+    action_id = _stage_order(client, headers, seed_recipe.name)
+
+    confirmed = client.post(
+        "/api/v1/actions/confirm",
+        json={"action_id": action_id},
+        headers=headers,
+    )
+
+    assert confirmed.status_code == 501
+    assert confirmed.get_json()["error"] == ORDER_SUBMISSION_DISABLED_MESSAGE
+
+    pending = PendingActionsStore(db_path).get_pending_action(action_id)
+    assert pending is not None
+    assert pending.status is PendingActionStatus.PENDING
+
+    # The disabled gate must fire before any network call reaches Safeway.
+    assert "/abs/pub/web/orders" not in safeway_mock.requested_paths
+
+
 def test_confirming_same_action_twice_returns_409(
     client: FlaskClient,
     signed_headers: Callable[..., dict[str, str]],

--- a/tests/test_api_destructive.py
+++ b/tests/test_api_destructive.py
@@ -552,6 +552,42 @@ class TestActionsConfirm:
         assert action is not None
         assert action.status is PendingActionStatus.PENDING
 
+    def test_disabled_submission_returns_501_and_keeps_action_pending(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        pending_store: PendingActionsStore,
+    ) -> None:
+        """Issue #60: a disabled pipeline returns 501 and leaves the row pending.
+
+        The pending action must remain retriable (not claimed) so that
+        flipping ``SAFEWAY_ORDER_SUBMISSION_ENABLED`` on later lets the
+        same confirm request succeed.
+        """
+        from grocery_butler.order_service import ORDER_SUBMISSION_DISABLED_MESSAGE
+
+        action_id = _stage_via_api(
+            client, auth_headers, "/api/v1/order/submit", _order_body()
+        )
+        pipeline = MagicMock()
+        pipeline.order_submission_enabled = False
+        pipeline.submit_cart.return_value = _successful_order_result()
+        with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
+            response = client.post(
+                "/api/v1/actions/confirm",
+                json={"action_id": action_id},
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 501
+        assert response.get_json()["error"] == ORDER_SUBMISSION_DISABLED_MESSAGE
+        pipeline.submit_cart.assert_not_called()
+        pipeline.close.assert_called_once()
+
+        action = pending_store.get_pending_action(action_id)
+        assert action is not None
+        assert action.status is PendingActionStatus.PENDING
+
     def test_double_confirm_returns_409(
         self,
         client: FlaskClient,

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -2249,6 +2249,47 @@ class TestOrderConfirmView:
         assert view.is_finished() is True
 
     @pytest.mark.asyncio()
+    async def test_confirm_pipeline_error_reports_message(self, mock_interaction):
+        """Test confirm surfaces a SafewayPipelineError message, not the generic one."""
+        from grocery_butler.safeway_pipeline import SafewayPipelineError
+
+        cart = _make_cart_summary()
+        mock_pipeline = MagicMock()
+        mock_pipeline.submit_cart.side_effect = SafewayPipelineError("auth expired")
+
+        view = _OrderConfirmView(mock_pipeline, cart)
+        await type(view).confirm(view, mock_interaction, MagicMock())
+
+        call_args = str(mock_interaction.followup.send.call_args)
+        assert "auth expired" in call_args
+        mock_pipeline.close.assert_called_once()
+        assert view.is_finished() is True
+
+    @pytest.mark.asyncio()
+    async def test_confirm_disabled_submission_reports_actionable_message(
+        self, mock_interaction
+    ):
+        """Issue #60: confirm surfaces the actionable disabled-submission message."""
+        from grocery_butler.safeway_pipeline import OrderSubmissionDisabledError
+
+        cart = _make_cart_summary()
+        mock_pipeline = MagicMock()
+        mock_pipeline.submit_cart.side_effect = OrderSubmissionDisabledError(
+            "Order submission is descoped for v1.0 (Issue #60): "
+            "unverified checkout surface. Build/review the cart instead, "
+            "or set SAFEWAY_ORDER_SUBMISSION_ENABLED=true after live "
+            "verification."
+        )
+
+        view = _OrderConfirmView(mock_pipeline, cart)
+        await type(view).confirm(view, mock_interaction, MagicMock())
+
+        call_args = str(mock_interaction.followup.send.call_args)
+        assert "Issue #60" in call_args
+        mock_pipeline.close.assert_called_once()
+        assert view.is_finished() is True
+
+    @pytest.mark.asyncio()
     async def test_cancel_closes_pipeline_and_notifies(self, mock_interaction):
         """Test cancel closes the pipeline and notifies the user."""
         cart = _make_cart_summary()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1562,6 +1562,43 @@ class TestHandleOrder:
         assert "ORD-001" in captured.out
         assert "Restocked" in captured.out
 
+    def test_disabled_submission_reports_actionable_error(self, capsys):
+        """Issue #60: a disabled pipeline surfaces the actionable message.
+
+        ``OrderSubmissionDisabledError`` is a ``SafewayPipelineError``
+        subclass, so the existing ``except SafewayPipelineError`` handler
+        must already print it and exit 1 without any further changes.
+        """
+        from grocery_butler.safeway_pipeline import OrderSubmissionDisabledError
+
+        cfg = MagicMock()
+        cfg.anthropic_api_key = "sk-test"
+        cfg.safeway_username = "user"
+        cfg.safeway_password = "pass"
+        cfg.safeway_store_id = "1234"
+        cfg.database_path = ":memory:"
+
+        with (
+            patch("grocery_butler.cli._load_config_safe", return_value=cfg),
+            patch("grocery_butler.cli._make_anthropic_client", return_value=None),
+            patch("grocery_butler.cli.SafewayPipeline") as mock_pipeline_cls,
+        ):
+            mock_pipeline = MagicMock()
+            mock_pipeline.run.side_effect = OrderSubmissionDisabledError(
+                "Order submission is descoped for v1.0 (Issue #60): "
+                "unverified checkout surface."
+            )
+            mock_pipeline_cls.return_value = mock_pipeline
+
+            parser = _build_parser()
+            args = parser.parse_args(["order", "--items", "milk"])
+            code = _handle_order(args)
+
+        assert code == 1
+        captured = capsys.readouterr()
+        assert "Issue #60" in captured.err
+        mock_pipeline.close.assert_called_once()
+
     def test_submit_failure(self, capsys):
         """Test failed order submission."""
         from grocery_butler.order_service import OrderResult

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -27,6 +27,8 @@ class TestConfig:
         assert cfg.flask_debug is False
         assert cfg.default_servings == 4
         assert cfg.default_units == "imperial"
+        # Issue #60: order submission must be off by default (fail-safe gate).
+        assert cfg.safeway_order_submission_enabled is False
 
     def test_config_all_fields(self) -> None:
         """Test Config accepts all fields."""
@@ -38,6 +40,7 @@ class TestConfig:
             flask_debug=True,
             default_servings=2,
             default_units="metric",
+            safeway_order_submission_enabled=True,
         )
         assert cfg.anthropic_api_key == "sk-test"
         assert cfg.discord_bot_token == "tok-123"
@@ -46,6 +49,7 @@ class TestConfig:
         assert cfg.flask_debug is True
         assert cfg.default_servings == 2
         assert cfg.default_units == "metric"
+        assert cfg.safeway_order_submission_enabled is True
 
     def test_config_is_frozen(self) -> None:
         """Test Config is immutable (frozen dataclass)."""
@@ -203,3 +207,39 @@ class TestLoadConfig:
         """Test database_url defaults to empty string when not set."""
         cfg = load_config()
         assert cfg.database_url == ""
+
+    @patch.dict(
+        os.environ,
+        {"ANTHROPIC_API_KEY": "sk-test"},
+        clear=True,
+    )
+    def test_load_config_safeway_order_submission_unset_defaults_false(self) -> None:
+        """Test Issue #60 gate defaults to False when the env var is unset."""
+        cfg = load_config()
+        assert cfg.safeway_order_submission_enabled is False
+
+    @pytest.mark.parametrize(
+        ("raw_value", "expected"),
+        [
+            ("true", True),
+            ("1", True),
+            ("yes", True),
+            ("TRUE", True),
+            ("Yes", True),
+            ("false", False),
+            ("0", False),
+            ("garbage", False),
+            ("", False),
+        ],
+    )
+    def test_load_config_safeway_order_submission_enabled_parsing(
+        self, raw_value: str, expected: bool
+    ) -> None:
+        """Test SAFEWAY_ORDER_SUBMISSION_ENABLED uses the flask_debug truthy parse."""
+        env = {
+            "ANTHROPIC_API_KEY": "sk-test",
+            "SAFEWAY_ORDER_SUBMISSION_ENABLED": raw_value,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            cfg = load_config()
+        assert cfg.safeway_order_submission_enabled is expected

--- a/tests/test_order_service.py
+++ b/tests/test_order_service.py
@@ -294,12 +294,17 @@ class TestSubmitOrder:
         self,
         api_response: dict[str, Any] | None = None,
         api_error: bool = False,
+        submission_enabled: bool = True,
     ) -> OrderService:
         """Create an OrderService with mock dependencies.
 
         Args:
             api_response: Response from Safeway API.
             api_error: Whether API should raise an exception.
+            submission_enabled: Issue #60 gate — defaults to True here so
+                the pre-existing submission-path tests in this file keep
+                exercising the real submit flow (the OrderService default
+                is False; production callers must opt in explicitly).
 
         Returns:
             OrderService with mocked client and pantry.
@@ -313,7 +318,9 @@ class TestSubmitOrder:
         mock_pantry = MagicMock()
         mock_pantry.mark_restocked.return_value = 0
 
-        return OrderService(mock_client, mock_pantry)
+        return OrderService(
+            mock_client, mock_pantry, submission_enabled=submission_enabled
+        )
 
     def test_successful_order(self) -> None:
         """Test successful order submission."""
@@ -433,6 +440,94 @@ class TestSubmitOrder:
 
         assert result.success is True
         assert result.confirmation is not None
+
+
+# ------------------------------------------------------------------
+# Tests: Issue #60 — order submission descoped for v1.0 by default
+# ------------------------------------------------------------------
+
+
+class TestSubmissionDisabledGate:
+    """Tests for the Issue #60 fail-safe order-submission gate."""
+
+    def test_default_construction_blocks_submission(self) -> None:
+        """Test default OrderService blocks submission without calling out."""
+        from grocery_butler.order_service import ORDER_SUBMISSION_DISABLED_MESSAGE
+
+        mock_client = MagicMock()
+        mock_pantry = MagicMock()
+        service = OrderService(mock_client, mock_pantry)
+
+        result = service.submit_order(_make_cart())
+
+        assert result.success is False
+        assert result.error_message == ORDER_SUBMISSION_DISABLED_MESSAGE
+        mock_client.post.assert_not_called()
+        mock_pantry.mark_restocked.assert_not_called()
+
+    def test_explicit_disabled_blocks_submission(self) -> None:
+        """Test submission_enabled=False explicitly blocks submission."""
+        from grocery_butler.order_service import ORDER_SUBMISSION_DISABLED_MESSAGE
+
+        mock_client = MagicMock()
+        mock_pantry = MagicMock()
+        service = OrderService(mock_client, mock_pantry, submission_enabled=False)
+
+        result = service.submit_order(_make_cart())
+
+        assert result.success is False
+        assert result.error_message == ORDER_SUBMISSION_DISABLED_MESSAGE
+        mock_client.post.assert_not_called()
+        mock_pantry.mark_restocked.assert_not_called()
+
+    def test_disabled_blocks_even_empty_cart(self) -> None:
+        """Test the disabled gate fires before any other submission logic.
+
+        Regardless of whether the guard is checked before or after the
+        empty-cart check, a disabled service must never reach the client.
+        """
+        from grocery_butler.order_service import ORDER_SUBMISSION_DISABLED_MESSAGE
+
+        mock_client = MagicMock()
+        mock_pantry = MagicMock()
+        service = OrderService(mock_client, mock_pantry, submission_enabled=False)
+
+        result = service.submit_order(_make_cart(items=[], restock_items=[]))
+
+        assert result.success is False
+        assert result.error_message == ORDER_SUBMISSION_DISABLED_MESSAGE
+        mock_client.post.assert_not_called()
+
+    def test_disabled_message_is_actionable(self) -> None:
+        """Test the disabled message references Issue #60 and the enable var."""
+        from grocery_butler.order_service import ORDER_SUBMISSION_DISABLED_MESSAGE
+
+        message = ORDER_SUBMISSION_DISABLED_MESSAGE
+        assert "Issue #60" in message
+        assert "SAFEWAY_ORDER_SUBMISSION_ENABLED=true" in message
+        assert "unverified" in message.lower()
+        assert "v1.0" in message
+        # Actionable alternative: build/review still works.
+        assert "review" in message.lower() or "build" in message.lower()
+
+    def test_enabled_true_preserves_happy_path(self) -> None:
+        """Test submission_enabled=True preserves the existing successful flow."""
+        mock_client = MagicMock()
+        mock_client.post.return_value = {
+            "orderId": "ORD-999",
+            "status": "confirmed",
+            "total": 8.99,
+        }
+        mock_pantry = MagicMock()
+        mock_pantry.mark_restocked.return_value = 0
+        service = OrderService(mock_client, mock_pantry, submission_enabled=True)
+
+        result = service.submit_order(_make_cart())
+
+        assert result.success is True
+        assert result.confirmation is not None
+        assert result.confirmation.order_id == "ORD-999"
+        mock_client.post.assert_called_once()
 
 
 # ------------------------------------------------------------------

--- a/tests/test_safeway_client.py
+++ b/tests/test_safeway_client.py
@@ -570,3 +570,19 @@ class TestConfigSafewayFields:
         assert cfg.safeway_username == "user@example.com"
         assert cfg.safeway_password == "pass123"
         assert cfg.safeway_store_id == "5678"
+
+
+# ---------------------------------------------------------------------------
+# Issue #60 — unverified surface must be documented in-module
+# ---------------------------------------------------------------------------
+
+
+class TestModuleDocumentsUnverifiedSurface:
+    """Tests that this module flags itself as an unverified real-money surface."""
+
+    def test_module_docstring_references_issue_60(self) -> None:
+        """Test the module docstring flags Issue #60 as unverified."""
+        import grocery_butler.safeway_client as safeway_client_module
+
+        assert safeway_client_module.__doc__ is not None
+        assert "Issue #60" in safeway_client_module.__doc__

--- a/tests/test_safeway_pipeline.py
+++ b/tests/test_safeway_pipeline.py
@@ -25,13 +25,32 @@ from grocery_butler.safeway_pipeline import SafewayPipeline, SafewayPipelineErro
 
 @pytest.fixture()
 def safeway_config() -> Config:
-    """Return a Config with Safeway credentials set."""
+    """Return a Config with Safeway credentials set.
+
+    Issue #60: order submission is opted in here (``True``) so the
+    pre-existing run/submit_cart tests below keep exercising the real
+    submission path — the ``Config`` default is ``False``.
+    """
     return Config(
         anthropic_api_key="sk-test",
         safeway_username="user@example.com",
         safeway_password="secret",
         safeway_store_id="1234",
         database_path=":memory:",
+        safeway_order_submission_enabled=True,
+    )
+
+
+@pytest.fixture()
+def disabled_safeway_config() -> Config:
+    """Return a Config with Safeway credentials set but submission disabled."""
+    return Config(
+        anthropic_api_key="sk-test",
+        safeway_username="user@example.com",
+        safeway_password="secret",
+        safeway_store_id="1234",
+        database_path=":memory:",
+        safeway_order_submission_enabled=False,
     )
 
 
@@ -461,3 +480,183 @@ class TestEmptyShoppingList:
 
         assert result.success is False
         assert "empty" in result.error_message.lower()
+
+
+# ---------------------------------------------------------------------------
+# Issue #60 — order submission descoped for v1.0 behind a fail-safe gate
+# ---------------------------------------------------------------------------
+
+
+class TestOrderSubmissionDisabledError:
+    """Tests for the OrderSubmissionDisabledError exception type."""
+
+    def test_is_a_safeway_pipeline_error(self) -> None:
+        """Test OrderSubmissionDisabledError subclasses SafewayPipelineError."""
+        from grocery_butler.safeway_pipeline import OrderSubmissionDisabledError
+
+        assert issubclass(OrderSubmissionDisabledError, SafewayPipelineError)
+
+    def test_message_matches_the_shared_disabled_message(self) -> None:
+        """Test the exception message is the shared actionable message."""
+        from grocery_butler.order_service import ORDER_SUBMISSION_DISABLED_MESSAGE
+        from grocery_butler.safeway_pipeline import OrderSubmissionDisabledError
+
+        err = OrderSubmissionDisabledError(ORDER_SUBMISSION_DISABLED_MESSAGE)
+        assert str(err) == ORDER_SUBMISSION_DISABLED_MESSAGE
+
+
+class TestOrderSubmissionEnabledProperty:
+    """Tests for SafewayPipeline.order_submission_enabled."""
+
+    @patch("grocery_butler.safeway_pipeline.RecipeStore")
+    @patch("grocery_butler.safeway_pipeline.ProductSearchService")
+    @patch("grocery_butler.safeway_pipeline.ProductSelector")
+    @patch("grocery_butler.safeway_pipeline.SubstitutionService")
+    @patch("grocery_butler.safeway_pipeline.SafewayClient")
+    @patch("grocery_butler.safeway_pipeline.PantryManager")
+    def test_reflects_enabled_config(
+        self,
+        mock_pantry: MagicMock,
+        mock_client_cls: MagicMock,
+        mock_sub: MagicMock,
+        mock_selector: MagicMock,
+        mock_search: MagicMock,
+        mock_store: MagicMock,
+        safeway_config: Config,
+    ):
+        """Test the property is True when the config gate is enabled."""
+        pipeline = SafewayPipeline(safeway_config, ":memory:")
+        assert pipeline.order_submission_enabled is True
+
+    @patch("grocery_butler.safeway_pipeline.RecipeStore")
+    @patch("grocery_butler.safeway_pipeline.ProductSearchService")
+    @patch("grocery_butler.safeway_pipeline.ProductSelector")
+    @patch("grocery_butler.safeway_pipeline.SubstitutionService")
+    @patch("grocery_butler.safeway_pipeline.SafewayClient")
+    @patch("grocery_butler.safeway_pipeline.PantryManager")
+    def test_reflects_disabled_config(
+        self,
+        mock_pantry: MagicMock,
+        mock_client_cls: MagicMock,
+        mock_sub: MagicMock,
+        mock_selector: MagicMock,
+        mock_search: MagicMock,
+        mock_store: MagicMock,
+        disabled_safeway_config: Config,
+    ):
+        """Test the property is False when the config gate is disabled."""
+        pipeline = SafewayPipeline(disabled_safeway_config, ":memory:")
+        assert pipeline.order_submission_enabled is False
+
+
+class TestSubmissionDisabledBlocksRun:
+    """Tests that a disabled config short-circuits run() before any I/O."""
+
+    @patch("grocery_butler.safeway_pipeline.RecipeStore")
+    @patch("grocery_butler.safeway_pipeline.ProductSearchService")
+    @patch("grocery_butler.safeway_pipeline.ProductSelector")
+    @patch("grocery_butler.safeway_pipeline.SubstitutionService")
+    @patch("grocery_butler.safeway_pipeline.SafewayClient")
+    @patch("grocery_butler.safeway_pipeline.PantryManager")
+    @patch("grocery_butler.safeway_pipeline.CartBuilder")
+    @patch("grocery_butler.safeway_pipeline.OrderService")
+    def test_run_raises_without_authenticating_or_building_cart(
+        self,
+        mock_order_cls: MagicMock,
+        mock_cart_cls: MagicMock,
+        mock_pantry: MagicMock,
+        mock_client_cls: MagicMock,
+        mock_sub: MagicMock,
+        mock_selector: MagicMock,
+        mock_search: MagicMock,
+        mock_store: MagicMock,
+        disabled_safeway_config: Config,
+        sample_items: list[ShoppingListItem],
+    ):
+        """Test run() raises OrderSubmissionDisabledError before any I/O."""
+        from grocery_butler.safeway_pipeline import OrderSubmissionDisabledError
+
+        mock_client = mock_client_cls.return_value
+        mock_client.is_authenticated = False
+
+        pipeline = SafewayPipeline(disabled_safeway_config, ":memory:")
+
+        with pytest.raises(OrderSubmissionDisabledError):
+            pipeline.run(sample_items)
+
+        mock_client.authenticate.assert_not_called()
+        mock_cart_cls.return_value.build_cart.assert_not_called()
+        mock_order_cls.return_value.submit_order.assert_not_called()
+
+
+class TestSubmissionDisabledBlocksSubmitCart:
+    """Tests that a disabled config short-circuits submit_cart() before auth."""
+
+    @patch("grocery_butler.safeway_pipeline.RecipeStore")
+    @patch("grocery_butler.safeway_pipeline.ProductSearchService")
+    @patch("grocery_butler.safeway_pipeline.ProductSelector")
+    @patch("grocery_butler.safeway_pipeline.SubstitutionService")
+    @patch("grocery_butler.safeway_pipeline.SafewayClient")
+    @patch("grocery_butler.safeway_pipeline.PantryManager")
+    @patch("grocery_butler.safeway_pipeline.CartBuilder")
+    @patch("grocery_butler.safeway_pipeline.OrderService")
+    def test_submit_cart_raises_without_authenticating(
+        self,
+        mock_order_cls: MagicMock,
+        mock_cart_cls: MagicMock,
+        mock_pantry: MagicMock,
+        mock_client_cls: MagicMock,
+        mock_sub: MagicMock,
+        mock_selector: MagicMock,
+        mock_search: MagicMock,
+        mock_store: MagicMock,
+        disabled_safeway_config: Config,
+        mock_cart_summary: CartSummary,
+    ):
+        """Test submit_cart raises OrderSubmissionDisabledError before auth."""
+        from grocery_butler.safeway_pipeline import OrderSubmissionDisabledError
+
+        mock_client = mock_client_cls.return_value
+        mock_client.is_authenticated = False
+
+        pipeline = SafewayPipeline(disabled_safeway_config, ":memory:")
+
+        with pytest.raises(OrderSubmissionDisabledError):
+            pipeline.submit_cart(mock_cart_summary)
+
+        mock_client.authenticate.assert_not_called()
+        mock_order_cls.return_value.submit_order.assert_not_called()
+
+
+class TestSubmissionDisabledDoesNotAffectBuildCartOnly:
+    """Tests that build_cart_only is unaffected by the Issue #60 gate."""
+
+    @patch("grocery_butler.safeway_pipeline.RecipeStore")
+    @patch("grocery_butler.safeway_pipeline.ProductSearchService")
+    @patch("grocery_butler.safeway_pipeline.ProductSelector")
+    @patch("grocery_butler.safeway_pipeline.SubstitutionService")
+    @patch("grocery_butler.safeway_pipeline.SafewayClient")
+    @patch("grocery_butler.safeway_pipeline.PantryManager")
+    @patch("grocery_butler.safeway_pipeline.CartBuilder")
+    def test_build_cart_only_works_when_disabled(
+        self,
+        mock_cart_cls: MagicMock,
+        mock_pantry: MagicMock,
+        mock_client_cls: MagicMock,
+        mock_sub: MagicMock,
+        mock_selector: MagicMock,
+        mock_search: MagicMock,
+        mock_store: MagicMock,
+        disabled_safeway_config: Config,
+        sample_items: list[ShoppingListItem],
+        mock_cart_summary: CartSummary,
+    ):
+        """Test cart building/review keeps working when submission is disabled."""
+        mock_client = mock_client_cls.return_value
+        mock_client.is_authenticated = True
+        mock_cart_cls.return_value.build_cart.return_value = mock_cart_summary
+
+        pipeline = SafewayPipeline(disabled_safeway_config, ":memory:")
+        cart = pipeline.build_cart_only(sample_items)
+
+        assert cart is mock_cart_summary


### PR DESCRIPTION
## Summary
- Explicitly descopes Safeway order submission for v1.0 behind a fail-safe gate (`SAFEWAY_ORDER_SUBMISSION_ENABLED`, default **off**): the unverified real-money surface (Okta authorize with a likely-invalid `aus`-prefixed client id, `POST /abs/pub/web/orders` with no payment/slot modeling) is now unreachable by default, satisfying the issue's third acceptance criterion ("submit path explicitly descoped for v1.0").
- Defense in depth: `OrderService.submit_order` returns a failed `OrderResult` with an actionable message before any transport call; `SafewayPipeline.run()`/`submit_cart()` raise `OrderSubmissionDisabledError` before authenticating; the API confirm endpoint returns 501 **before** claiming the pending action (stays retriable); Discord and CLI surface the actionable error. Cart build/review (`build_cart_only`, `--dry-run`) keep working.
- Documents the unverified surface: `safeway_client.py` module docstring carries an "Issue #60 — UNVERIFIED API SURFACE" warning; README corrects the inaccurate cookie-session claim (client sends an Okta bearer token) and adds the human verification checklist (live Okta auth flow, recorded endpoint fixtures, payment/slot modeling, one recorded end-to-end order per #31/#32) that gates ever enabling the flag.

Live endpoint/auth verification with real credentials (acceptance criteria a/b) remains a human task tracked on the issue and cannot be performed in CI.

## Test plan
- 29 new tests (TDD, red-first): config env parsing matrix (unset/garbage → off), OrderService gate (transport never called, no restock, message content), pipeline guards (no auth when disabled, `build_cart_only` unaffected, exception hierarchy, `order_submission_enabled` property), API confirm 501 with pending action left unclaimed and pipeline closed, Discord followup surfaces the actionable message, CLI exits 1 with the message and closes the pipeline, module-docstring warning assertion, plus an e2e test proving the default-off 501 through the full Flask app with the mocked Safeway endpoint never hit.
- Existing submission-path tests updated to opt in explicitly (`submission_enabled=True` / env flag) so the previously verified enabled behavior is preserved unchanged.
- `./scripts/check-all.sh` exit 0: 1242 passed, 8 skipped (pre-existing Postgres guards), coverage 95.65%+, ruff/mypy strict/bandit/pip-audit/radon all green. Security-specialist audit of the guardrail returned SOUND; pre-push code review returned CLEAN.

Closes #60
Refs #31, #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)
