### PR TITLE
fix(security): enforce tailnet-only boundary with fail-closed network guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,8 +448,10 @@ unchanged. The blueprint lives in `grocery_butler/api.py` and is registered by
 `create_app()`.
 
 - **Base URL:** `https://grocery-butler.tailnet.ts.net/api/v1` — reached over
-  the Tailscale tailnet; the API is not meant to be exposed on the public
-  Railway domain.
+  the Tailscale tailnet. The tailnet-only boundary is enforced in code, not
+  just by network configuration: see
+  [Network boundary guard](#network-boundary-guard-tailnet-only) for how
+  requests from outside the allow-list are rejected.
 - **Auth:** every `/api/v1` route requires a bearer token in the
   `<caller_id>.<timestamp>.<hmac_hex>` format, signed with
   `RUBOTPAUL_SHARED_SECRET` (HMAC-SHA256, 5-minute TTL). Mint with
@@ -790,6 +792,50 @@ Set these in your Railway project settings:
 | `SAFEWAY_PASSWORD` | Yes (ordering) | Safeway account password. |
 | `SAFEWAY_STORE_ID` | Yes (ordering) | Safeway store ID for product searches. |
 | `PORT` | Auto | Injected by Railway for the web process. |
+| `TAILNET_GUARD_ENABLED` | No (defaults secure) | Kill switch for the network boundary guard (below); the guard is active unless explicitly set to `false`/`0`/`no` (case-insensitive). |
+| `TAILNET_GUARD_ALLOWED_CIDRS` | No (defaults secure) | Comma-separated CIDR allow-list for the network boundary guard (below); replaces (does not extend) the default `127.0.0.0/8,::1/128,100.64.0.0/10`. |
+
+### Network boundary guard (tailnet-only)
+
+Grocery Butler is meant to be reached only over the Tailscale tailnet (or
+loopback, locally). A fail-closed `app.before_request` hook, registered by
+`create_app()` in `grocery_butler/network_guard.py`, rejects any request
+whose **socket peer address** (`request.remote_addr`) falls outside an
+allow-list of CIDR ranges.
+
+- **No forwarded-header trust.** Admission is keyed only on
+  `request.remote_addr`; the guard never trusts `X-Forwarded-For` (or any
+  other client-supplied header), and Werkzeug's `ProxyFix` must never be
+  added. Railway's edge is a shared, multi-tenant proxy, so any header it
+  forwards from the original client is attacker-controlled input — trusting
+  it would let a public request simply set `X-Forwarded-For: 127.0.0.1` and
+  walk back through the hole this guard exists to close.
+- **`TAILNET_GUARD_ENABLED`** — kill switch, read once at app-creation time.
+  The guard is active unless explicitly set to `false`/`0`/`no`
+  (case-insensitive); unset means enabled (fail-closed by default).
+- **`TAILNET_GUARD_ALLOWED_CIDRS`** — comma-separated CIDR allow-list, read
+  once at app-creation time. Defaults to
+  `127.0.0.0/8,::1/128,100.64.0.0/10` (loopback + IPv6 loopback + the
+  Tailscale CGNAT range). Setting this variable **replaces** the default
+  list; it does not extend it. RFC1918 private ranges are deliberately
+  excluded from the default so a misconfigured office/home LAN is never
+  accidentally trusted.
+- **Health check exemption.** `/health` and `/healthz` are always exempt
+  (matched by Flask endpoint name, not path) so Railway's own health
+  checks — which arrive from Railway's infrastructure, not the tailnet —
+  keep working. This is intentional: both endpoints expose only
+  status/DB-connectivity information.
+- **Rejection behavior.** Requests from outside the allow-list receive a
+  `403`: a JSON `{"error": "forbidden"}` body for `/api/*` paths, an HTML
+  error page otherwise.
+
+**Rate limiting:** flask-limiter is deliberately deferred. With the
+fail-closed tailnet boundary above, public HMAC brute-forcing of `/api/v1`
+and abuse of paid Claude endpoints (e.g. `/api/v1/meals/parse`) already
+require tailnet access, so a limiter would add a dependency without closing
+a live gap — and a naive in-memory limiter is ineffective across
+per-gunicorn-worker processes without a shared store (no Redis is
+provisioned). Revisit if multi-tenant tailnet access is ever introduced.
 
 ### Quick start
 
@@ -801,6 +847,10 @@ Set these in your Railway project settings:
    schema before serving traffic (see above).
 5. Attach the Railway service to your Tailscale tailnet so RubotPaul can reach
    `/api/v1` privately.
+6. In the Railway service's Settings -> Networking, remove the default
+   public domain so the app is reachable only through the Tailscale
+   sidecar/tailnet. The in-code network boundary guard above is
+   defense-in-depth, not a substitute for removing the public domain.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -793,7 +793,7 @@ Set these in your Railway project settings:
 | `SAFEWAY_STORE_ID` | Yes (ordering) | Safeway store ID for product searches. |
 | `PORT` | Auto | Injected by Railway for the web process. |
 | `TAILNET_GUARD_ENABLED` | No (defaults secure) | Kill switch for the network boundary guard (below); the guard is active unless explicitly set to `false`/`0`/`no` (case-insensitive). |
-| `TAILNET_GUARD_ALLOWED_CIDRS` | No (defaults secure) | Comma-separated CIDR allow-list for the network boundary guard (below); replaces (does not extend) the default `127.0.0.0/8,::1/128,100.64.0.0/10`. |
+| `TAILNET_GUARD_ALLOWED_CIDRS` | No (defaults secure) | Comma-separated CIDR allow-list for the network boundary guard (below); replaces (does not extend) the default `127.0.0.0/8,::1/128,100.64.0.0/10`. An explicitly-empty value trusts nothing (full lockout, logged at startup) — delete the variable to restore defaults. |
 
 ### Network boundary guard (tailnet-only)
 
@@ -820,6 +820,24 @@ allow-list of CIDR ranges.
   list; it does not extend it. RFC1918 private ranges are deliberately
   excluded from the default so a misconfigured office/home LAN is never
   accidentally trusted.
+  - **Blank is not unset.** Setting the variable to an *empty string*
+    (e.g. clearing the value in the Railway UI instead of deleting the
+    variable) is a legitimate "trust nothing" configuration: every
+    non-health request is rejected, including loopback and the tailnet.
+    This fails closed, and the app logs a startup warning
+    (`network_guard_empty_allowlist`) so the lockout is loud rather than
+    silent — but to restore the defaults, *delete* the variable, don't
+    blank it.
+  - **Entries are parsed strictly.** A CIDR entry with host bits set
+    (e.g. `100.64.1.5/24` instead of `100.64.1.0/24`) or any other
+    malformed entry raises `ValueError` at startup rather than being
+    silently corrected or dropped — misconfiguration fails loud, at
+    deploy time.
+  - **IPv4-mapped IPv6 peers are normalized.** If the WSGI server ever
+    listens dual-stack, an IPv4 peer can be reported as
+    `::ffff:100.64.1.2`; the guard also checks the unmapped IPv4 form so
+    such peers get IPv4 CIDR semantics (this widens availability only —
+    a mapped public address is still rejected).
 - **Health check exemption.** `/health` and `/healthz` are always exempt
   (matched by Flask endpoint name, not path) so Railway's own health
   checks — which arrive from Railway's infrastructure, not the tailnet —
@@ -828,6 +846,39 @@ allow-list of CIDR ranges.
 - **Rejection behavior.** Requests from outside the allow-list receive a
   `403`: a JSON `{"error": "forbidden"}` body for `/api/*` paths, an HTML
   error page otherwise.
+- **Observability.** At startup the guard logs the resolved allow-list
+  (`network_guard_enabled allowed_cidrs=...`), or
+  `network_guard_disabled` if the kill switch is set, or
+  `network_guard_empty_allowlist` (warning) if the resolved list is
+  empty. Every rejection logs
+  `network_guard_rejected path=... remote_addr=...` at warning level —
+  path and peer address only, never headers or bodies.
+
+#### Verifying the boundary on the live deployment
+
+The guard's correctness rests on one assumption unit tests cannot prove:
+that `request.remote_addr`, as seen by gunicorn on Railway's specific
+proxy/sidecar topology, actually distinguishes tailnet peers from
+public-edge traffic. **Verify this once against the real deployment
+before relying on the guard:**
+
+1. Deploy and check the deploy logs for the startup line
+   `network_guard_enabled allowed_cidrs=127.0.0.0/8,::1/128,100.64.0.0/10`
+   (confirms which allow-list the running process resolved).
+2. From a device on the tailnet, load the dashboard and hit
+   `/api/v1/inventory` with a valid bearer token — both must succeed. If
+   they 403 instead, check the logs for `network_guard_rejected` lines:
+   the logged `remote_addr` tells you what address the Tailscale
+   sidecar/tailnet hop actually presents (e.g. loopback if the sidecar
+   proxies via localhost, or a `100.64.0.0/10` address) so you can
+   confirm or correct the allow-list.
+3. While the Railway public domain is still attached, request the
+   dashboard from a non-tailnet network — it must return 403, and the
+   logs must show `network_guard_rejected` with the public-edge
+   `remote_addr`. If public traffic is *not* rejected, the logged
+   address reveals which allowed range it incidentally lands in.
+4. Then remove the public domain (Quick start step 6 below) so the
+   guard is defense-in-depth rather than the only line.
 
 **Rate limiting:** flask-limiter is deliberately deferred. With the
 fail-closed tailnet boundary above, public HMAC brute-forcing of `/api/v1`

--- a/grocery_butler/app.py
+++ b/grocery_butler/app.py
@@ -99,12 +99,13 @@ def create_app(db_path: str | None = None) -> Flask:
 
 
 def _register_network_guard(app: Flask) -> None:
-    """Register the tailnet-only boundary guard before request routing.
+    """Register the tailnet-only boundary guard.
 
-    Registered before ``_register_routes``/``_register_api`` so the
-    guard's ``before_request`` hook is installed ahead of any
-    route-specific logic and applies uniformly to HTML routes and the
-    ``/api/v1`` blueprint alike.
+    Installs an app-level ``before_request`` hook, which Flask runs
+    ahead of route handlers and blueprint-level hooks regardless of
+    registration order, so the guard applies uniformly to HTML routes
+    and the ``/api/v1`` blueprint alike. The local import keeps this
+    wrapper consistent with ``_register_api``'s import pattern.
 
     Args:
         app: Flask application instance.

--- a/grocery_butler/app.py
+++ b/grocery_butler/app.py
@@ -91,10 +91,27 @@ def create_app(db_path: str | None = None) -> Flask:
     _register_teardown(app)
     _register_error_handlers(app)
     _register_context_processors(app)
+    _register_network_guard(app)
     _register_routes(app)
     _register_api(app)
 
     return app
+
+
+def _register_network_guard(app: Flask) -> None:
+    """Register the tailnet-only boundary guard before request routing.
+
+    Registered before ``_register_routes``/``_register_api`` so the
+    guard's ``before_request`` hook is installed ahead of any
+    route-specific logic and applies uniformly to HTML routes and the
+    ``/api/v1`` blueprint alike.
+
+    Args:
+        app: Flask application instance.
+    """
+    from grocery_butler.network_guard import register_network_guard
+
+    register_network_guard(app)
 
 
 def _register_api(app: Flask) -> None:

--- a/grocery_butler/network_guard.py
+++ b/grocery_butler/network_guard.py
@@ -1,0 +1,204 @@
+"""Tailnet-only network boundary guard (issue #62).
+
+Grocery Butler is designed to be reached only over the Tailscale tailnet
+(or from loopback, for local development). Historically nothing enforced
+that assumption at the application layer -- Railway's public edge would
+happily forward any request straight through to Flask, so a stray public
+DNS record or a Railway domain guess was enough to reach every
+state-mutating route. This module closes that hole with a single
+``app.before_request`` hook that rejects requests whose *socket peer
+address* falls outside an explicit allow-list of CIDR ranges.
+
+SECURITY-CRITICAL: admission is keyed **only** on ``request.remote_addr``
+(the actual TCP peer address Werkzeug sees), never on
+``X-Forwarded-For`` or any other client-supplied header, and this module
+does not install (and must never install) Werkzeug's ``ProxyFix``.
+Railway's edge is a shared, multi-tenant proxy: any header it forwards
+from the original client is attacker-controlled input. If a future
+change trusts ``X-Forwarded-For`` (directly, or indirectly via
+``ProxyFix`` rewriting ``remote_addr`` from that header) *without* also
+verifying the request arrived through a proxy hop that itself
+authenticates the header, a public request can simply set
+``X-Forwarded-For: 127.0.0.1`` and walk right back through the hole this
+module exists to close. If proxy trust is ever required, it must be
+paired with cryptographic or network-level verification of the proxy
+hop -- never bare header trust.
+
+Configuration (read once, at ``register_network_guard`` call time):
+
+- ``TAILNET_GUARD_ENABLED``: kill switch. The guard is active unless
+  this is explicitly set to one of ``false``/``0``/``no``
+  (case-insensitive). Unset means enabled -- the guard is fail-closed
+  by default.
+- ``TAILNET_GUARD_ALLOWED_CIDRS``: comma-separated CIDR list. When
+  unset, defaults to loopback + IPv6 loopback + the Tailscale CGNAT
+  range (``127.0.0.0/8,::1/128,100.64.0.0/10``). Setting this variable
+  *replaces* the default list entirely; it does not extend it.
+
+``/health`` and ``/healthz`` are always exempt (matched by Flask
+endpoint name, not path) so Railway's own health checks -- which arrive
+from Railway's infrastructure, not the tailnet -- keep working.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import os
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from flask import Flask
+    from flask.typing import ResponseReturnValue
+
+LOG = logging.getLogger("network_guard")
+
+#: Environment variable that toggles the guard on or off.
+ENABLED_ENV_VAR = "TAILNET_GUARD_ENABLED"
+
+#: Environment variable holding the comma-separated allow-list override.
+ALLOWED_CIDRS_ENV_VAR = "TAILNET_GUARD_ALLOWED_CIDRS"
+
+#: Production default: loopback + IPv6 loopback + Tailscale CGNAT range.
+#: RFC1918 private ranges are deliberately excluded so a misconfigured
+#: office/home LAN is never accidentally trusted.
+DEFAULT_ALLOWED_CIDRS = "127.0.0.0/8,::1/128,100.64.0.0/10"
+
+#: Case-insensitive spellings of "disabled" accepted for the kill switch.
+_DISABLING_VALUES = frozenset({"false", "0", "no"})
+
+#: Flask endpoint names exempt from the guard regardless of source.
+_EXEMPT_ENDPOINTS = frozenset({"health", "healthz"})
+
+#: Union alias for the network types produced by ``ipaddress.ip_network``.
+IPNetwork = ipaddress.IPv4Network | ipaddress.IPv6Network
+
+
+def parse_allowed_cidrs(raw: str) -> list[IPNetwork]:
+    """Parse a comma-separated CIDR list into network objects.
+
+    Surrounding whitespace around each entry is stripped, and blank
+    entries produced by empty/trailing/doubled commas are skipped. An
+    empty (or whitespace-only) input yields an empty list rather than
+    raising, since that is a legitimate "trust nothing" configuration.
+
+    Args:
+        raw: Comma-separated CIDR string, e.g. ``"127.0.0.0/8,::1/128"``.
+
+    Returns:
+        List of parsed IPv4/IPv6 network objects, in input order.
+
+    Raises:
+        ValueError: If any non-empty entry is not a valid CIDR network.
+            This fails loud rather than silently dropping a
+            misconfigured entry, since a dropped entry could
+            unintentionally narrow (or, if it were the only entry,
+            fully disable) the allow-list.
+    """
+    networks: list[IPNetwork] = []
+    for entry in raw.split(","):
+        stripped = entry.strip()
+        if not stripped:
+            continue
+        networks.append(ipaddress.ip_network(stripped))
+    return networks
+
+
+def is_trusted_source(remote_addr: str | None, allowed: Sequence[IPNetwork]) -> bool:
+    """Check whether a source address is within an allowed CIDR list.
+
+    Fails closed: a missing address, a malformed address string, or an
+    empty allow-list are all treated as untrusted rather than raising.
+
+    Args:
+        remote_addr: The socket peer address to check, or ``None`` if
+            unavailable.
+        allowed: Parsed networks to check membership against.
+
+    Returns:
+        ``True`` if ``remote_addr`` is a valid address contained in at
+        least one network in ``allowed``, ``False`` otherwise.
+    """
+    if remote_addr is None:
+        return False
+    try:
+        address = ipaddress.ip_address(remote_addr)
+    except ValueError:
+        return False
+    return any(address in network for network in allowed)
+
+
+def _is_guard_enabled() -> bool:
+    """Return whether the guard should be active, per the kill switch.
+
+    Returns:
+        ``False`` only if ``TAILNET_GUARD_ENABLED`` is explicitly set to
+        one of ``false``/``0``/``no`` (case-insensitive); ``True``
+        otherwise, including when the variable is unset.
+    """
+    raw = os.environ.get(ENABLED_ENV_VAR, "true")
+    return raw.strip().lower() not in _DISABLING_VALUES
+
+
+def _resolve_allowed_networks() -> list[IPNetwork]:
+    """Resolve the allow-list from the environment at registration time.
+
+    Returns:
+        Parsed networks from ``TAILNET_GUARD_ALLOWED_CIDRS`` if set
+        (replacing the default entirely), otherwise the parsed
+        production default.
+    """
+    raw = os.environ.get(ALLOWED_CIDRS_ENV_VAR, DEFAULT_ALLOWED_CIDRS)
+    return parse_allowed_cidrs(raw)
+
+
+def register_network_guard(app: Flask) -> None:
+    """Install the tailnet boundary guard on a Flask application.
+
+    Reads ``TAILNET_GUARD_ENABLED`` and ``TAILNET_GUARD_ALLOWED_CIDRS``
+    from the environment once, at registration time, and -- unless the
+    kill switch disables it -- installs an ``app.before_request`` hook
+    that rejects any request whose ``request.remote_addr`` is not in the
+    resolved allow-list, except for the ``health``/``healthz``
+    endpoints, which are always reachable.
+
+    Rejected requests get a 403: a JSON ``{"error": "forbidden"}`` body
+    for paths under ``/api/``, and the app's standard HTML error page
+    everywhere else. Every rejection is logged at warning level with the
+    request path and remote address (no headers, no bodies, no secrets).
+
+    Args:
+        app: Flask application instance to guard.
+    """
+    if not _is_guard_enabled():
+        LOG.info("network_guard_disabled")
+        return
+
+    allowed = _resolve_allowed_networks()
+
+    from flask import jsonify, render_template, request
+
+    @app.before_request
+    def _enforce_tailnet_boundary() -> ResponseReturnValue | None:
+        """Reject any non-exempt request from outside the allow-list.
+
+        Returns:
+            ``None`` to let Flask continue normal routing when the
+            request is exempt or trusted; otherwise a ``(body, 403)``
+            response tuple.
+        """
+        if request.endpoint in _EXEMPT_ENDPOINTS:
+            return None
+        if is_trusted_source(request.remote_addr, allowed):
+            return None
+
+        LOG.warning(
+            "network_guard_rejected path=%s remote_addr=%s",
+            request.path,
+            request.remote_addr,
+        )
+        if request.path.startswith("/api/"):
+            return jsonify({"error": "forbidden"}), 403
+        return render_template("error.html", code=403, message="Forbidden"), 403

--- a/grocery_butler/network_guard.py
+++ b/grocery_butler/network_guard.py
@@ -112,6 +112,14 @@ def is_trusted_source(remote_addr: str | None, allowed: Sequence[IPNetwork]) -> 
     Fails closed: a missing address, a malformed address string, or an
     empty allow-list are all treated as untrusted rather than raising.
 
+    IPv4-mapped IPv6 addresses (``::ffff:a.b.c.d``, as reported by a
+    dual-stack listener for an IPv4 peer) are additionally checked in
+    their unmapped IPv4 form, so a legitimate ``::ffff:100.64.1.2``
+    tailnet peer is not false-rejected by the exact-version CIDR match.
+    This only widens availability, never trust: the unmapped form is
+    the *same* socket peer, and a mapped public address stays outside
+    the allow-list either way.
+
     Args:
         remote_addr: The socket peer address to check, or ``None`` if
             unavailable.
@@ -119,7 +127,8 @@ def is_trusted_source(remote_addr: str | None, allowed: Sequence[IPNetwork]) -> 
 
     Returns:
         ``True`` if ``remote_addr`` is a valid address contained in at
-        least one network in ``allowed``, ``False`` otherwise.
+        least one network in ``allowed`` (directly, or via its unmapped
+        IPv4 form for IPv4-mapped IPv6 addresses), ``False`` otherwise.
     """
     if remote_addr is None:
         return False
@@ -127,7 +136,10 @@ def is_trusted_source(remote_addr: str | None, allowed: Sequence[IPNetwork]) -> 
         address = ipaddress.ip_address(remote_addr)
     except ValueError:
         return False
-    return any(address in network for network in allowed)
+    candidates: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = [address]
+    if isinstance(address, ipaddress.IPv6Address) and address.ipv4_mapped is not None:
+        candidates.append(address.ipv4_mapped)
+    return any(candidate in network for candidate in candidates for network in allowed)
 
 
 def _is_guard_enabled() -> bool:
@@ -169,6 +181,14 @@ def register_network_guard(app: Flask) -> None:
     everywhere else. Every rejection is logged at warning level with the
     request path and remote address (no headers, no bodies, no secrets).
 
+    Startup observability: when active, the resolved allow-list CIDRs
+    are logged at info level (``network_guard_enabled``) so operators
+    can verify the live configuration from the deploy logs. If the
+    resolved allow-list is *empty* (an explicitly-blank
+    ``TAILNET_GUARD_ALLOWED_CIDRS``), a warning
+    (``network_guard_empty_allowlist``) is logged instead, since that
+    trust-nothing configuration locks out every non-health request.
+
     Args:
         app: Flask application instance to guard.
     """
@@ -177,6 +197,19 @@ def register_network_guard(app: Flask) -> None:
         return
 
     allowed = _resolve_allowed_networks()
+    if allowed:
+        LOG.info(
+            "network_guard_enabled allowed_cidrs=%s",
+            ",".join(str(network) for network in allowed),
+        )
+    else:
+        LOG.warning(
+            "network_guard_empty_allowlist -- resolved allow-list is empty; "
+            "every non-health request will be rejected (403). If this is "
+            "not intentional, unset %s entirely (do not set it to an empty "
+            "string) to restore the default allow-list.",
+            ALLOWED_CIDRS_ENV_VAR,
+        )
 
     from flask import jsonify, render_template, request
 

--- a/tests/test_app_boundary.py
+++ b/tests/test_app_boundary.py
@@ -26,6 +26,7 @@ design.
 from __future__ import annotations
 
 import json
+import logging
 from typing import TYPE_CHECKING
 
 import pytest
@@ -53,6 +54,10 @@ LOOPBACK_ADDR = "127.0.0.1"
 
 #: Inside a custom override range used by the CIDR-override tests below.
 CUSTOM_RANGE_ADDR = "192.0.2.10"
+
+#: IPv4-mapped IPv6 form of a CGNAT address, as reported by a dual-stack
+#: listener (bound to ``::`` with ``IPV6_V6ONLY`` off) for an IPv4 peer.
+MAPPED_CGNAT_ADDR = "::ffff:100.64.1.2"
 
 #: Shared HMAC secret for this module's bearer-token tests.
 TEST_SECRET = "test-shared-secret-boundary"
@@ -478,6 +483,156 @@ class TestCustomCidrOverride:
     ) -> None:
         """Test an address outside the custom range is still rejected."""
         response = custom_client.get("/", environ_base={"REMOTE_ADDR": PUBLIC_ADDR})
+        assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Explicitly-empty CIDR override: loud, fail-closed lockout
+# ---------------------------------------------------------------------------
+
+
+class TestExplicitlyEmptyCidrOverride:
+    """TAILNET_GUARD_ALLOWED_CIDRS="" trusts nothing -- and says so loudly."""
+
+    def test_empty_override_rejects_loopback(
+        self, make_app: Callable[[dict[str, str] | None], Flask]
+    ) -> None:
+        """Test an explicitly-empty allow-list locks out even loopback."""
+        application = make_app({"TAILNET_GUARD_ALLOWED_CIDRS": ""})
+        client = application.test_client()
+
+        response = client.get("/", environ_base={"REMOTE_ADDR": LOOPBACK_ADDR})
+
+        assert response.status_code == 403
+
+    def test_empty_override_health_still_exempt(
+        self, make_app: Callable[[dict[str, str] | None], Flask]
+    ) -> None:
+        """Test /health stays reachable even under a trust-nothing list."""
+        application = make_app({"TAILNET_GUARD_ALLOWED_CIDRS": ""})
+        client = application.test_client()
+
+        response = client.get("/health", environ_base={"REMOTE_ADDR": PUBLIC_ADDR})
+
+        assert response.status_code == 200
+
+    def test_empty_override_logs_startup_warning(
+        self,
+        make_app: Callable[[dict[str, str] | None], Flask],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Test a blanked-out CIDR env var produces a loud startup warning.
+
+        A stray empty-string value in a platform UI (e.g. Railway) must
+        not cause a *silent* full lockout: the guard warns at startup so
+        the misconfiguration is visible in the deploy logs.
+        """
+        with caplog.at_level(logging.WARNING, logger="network_guard"):
+            make_app({"TAILNET_GUARD_ALLOWED_CIDRS": ""})
+
+        warnings = [
+            record
+            for record in caplog.records
+            if record.name == "network_guard" and record.levelno == logging.WARNING
+        ]
+        assert any("network_guard_empty_allowlist" in r.getMessage() for r in warnings)
+        assert any("TAILNET_GUARD_ALLOWED_CIDRS" in r.getMessage() for r in warnings)
+
+
+# ---------------------------------------------------------------------------
+# Startup and rejection observability (supports live-deployment verification)
+# ---------------------------------------------------------------------------
+
+
+class TestGuardObservability:
+    """The guard logs its resolved config at startup and every rejection."""
+
+    def test_startup_logs_resolved_allowlist(
+        self,
+        make_app: Callable[[dict[str, str] | None], Flask],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Test the resolved allow-list CIDRs are logged at startup.
+
+        Operators verifying the guard against the live deployment need
+        to see, in the deploy logs, exactly which CIDRs the running
+        process resolved -- without reverse-engineering env precedence.
+        """
+        with caplog.at_level(logging.INFO, logger="network_guard"):
+            make_app(None)
+
+        messages = [
+            record.getMessage()
+            for record in caplog.records
+            if record.name == "network_guard"
+        ]
+        enabled_lines = [m for m in messages if "network_guard_enabled" in m]
+        assert enabled_lines
+        assert any(
+            "127.0.0.0/8" in m and "::1/128" in m and "100.64.0.0/10" in m
+            for m in enabled_lines
+        )
+
+    def test_startup_logs_custom_override_cidrs(
+        self,
+        make_app: Callable[[dict[str, str] | None], Flask],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Test a custom CIDR override is reflected in the startup log."""
+        with caplog.at_level(logging.INFO, logger="network_guard"):
+            make_app({"TAILNET_GUARD_ALLOWED_CIDRS": "192.0.2.0/24"})
+
+        messages = [
+            record.getMessage()
+            for record in caplog.records
+            if record.name == "network_guard"
+        ]
+        assert any(
+            "network_guard_enabled" in m and "192.0.2.0/24" in m for m in messages
+        )
+
+    def test_rejection_logs_path_and_remote_addr(
+        self,
+        client: FlaskClient,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Test each rejection logs the request path and observed peer.
+
+        This is the log line operators use to confirm what
+        ``request.remote_addr`` Railway's edge actually hands the app
+        for public-domain traffic (see README "Verifying the boundary
+        on the live deployment").
+        """
+        with caplog.at_level(logging.WARNING, logger="network_guard"):
+            client.get("/", environ_base={"REMOTE_ADDR": PUBLIC_ADDR})
+
+        messages = [
+            record.getMessage()
+            for record in caplog.records
+            if record.name == "network_guard"
+        ]
+        assert any(
+            "network_guard_rejected" in m and "path=/" in m and PUBLIC_ADDR in m
+            for m in messages
+        )
+
+
+# ---------------------------------------------------------------------------
+# IPv4-mapped IPv6 peers (dual-stack listener) are normalized, not rejected
+# ---------------------------------------------------------------------------
+
+
+class TestIpv4MappedPeers:
+    """A dual-stack listener's ::ffff:a.b.c.d peers get IPv4 semantics."""
+
+    def test_mapped_cgnat_source_allowed(self, client: FlaskClient) -> None:
+        """Test an IPv4-mapped CGNAT peer reaches the dashboard normally."""
+        response = client.get("/", environ_base={"REMOTE_ADDR": MAPPED_CGNAT_ADDR})
+        assert response.status_code == 200
+
+    def test_mapped_public_source_still_forbidden(self, client: FlaskClient) -> None:
+        """Test an IPv4-mapped *public* peer is still rejected (403)."""
+        response = client.get("/", environ_base={"REMOTE_ADDR": "::ffff:203.0.113.7"})
         assert response.status_code == 403
 
 

--- a/tests/test_app_boundary.py
+++ b/tests/test_app_boundary.py
@@ -1,0 +1,542 @@
+"""Integration tests for the tailnet-only network boundary (issue #62).
+
+Exercises the real Flask app built by ``create_app`` end-to-end through
+the test client to prove two things:
+
+1. RED: today, state-mutating HTML routes and the dashboard respond to
+   requests from a public (non-tailnet) source IP with normal 2xx/3xx
+   behavior instead of being rejected. That is the vulnerability.
+2. The full green-spec matrix the ``grocery_butler.network_guard`` module
+   must satisfy once built: fail-closed defaults, the
+   ``TAILNET_GUARD_ENABLED`` kill switch, CIDR overrides via
+   ``TAILNET_GUARD_ALLOWED_CIDRS``, the ``/health``/``/healthz``
+   exemption, X-Forwarded-For spoof resistance (admission is keyed only
+   on ``request.remote_addr``), independence from the HMAC bearer check
+   on ``/api/v1``, and the JSON-vs-HTML 403 response shape.
+
+Because the module and its ``app.before_request`` hook do not exist yet,
+every assertion of ``status_code == 403`` below currently fails against
+today's ``grocery_butler/app.py`` -- that failure is the expected Gate 1
+RED state for issue #62. Tests that assert *current* (pre-guard,
+trusted-source) behavior are expected to pass now and continue passing
+once the guard is implemented, since trusted sources are unaffected by
+design.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+    from pathlib import Path
+
+    from flask import Flask
+    from flask.testing import FlaskClient
+
+from grocery_butler.app import create_app
+from grocery_butler.auth_middleware import SECRET_ENV_VAR, mint_token
+from grocery_butler.models import IngredientCategory, InventoryItem, InventoryStatus
+from grocery_butler.pantry_manager import PantryManager
+
+#: A source address outside every default and custom-CIDR range used below.
+PUBLIC_ADDR = "203.0.113.7"
+
+#: Inside the default Tailscale CGNAT range (100.64.0.0/10).
+CGNAT_ADDR = "100.64.1.2"
+
+#: The Flask test client's own default REMOTE_ADDR (IPv4 loopback).
+LOOPBACK_ADDR = "127.0.0.1"
+
+#: Inside a custom override range used by the CIDR-override tests below.
+CUSTOM_RANGE_ADDR = "192.0.2.10"
+
+#: Shared HMAC secret for this module's bearer-token tests.
+TEST_SECRET = "test-shared-secret-boundary"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> str:
+    """Return a temporary database path for test isolation.
+
+    Args:
+        tmp_path: Pytest's per-test temporary directory.
+
+    Returns:
+        Absolute path string for a database file that does not yet exist.
+    """
+    return str(tmp_path / "test_boundary.db")
+
+
+@pytest.fixture()
+def make_app(
+    monkeypatch: pytest.MonkeyPatch, db_path: str
+) -> Callable[[dict[str, str] | None], Flask]:
+    """Return a factory that builds a fresh app with given guard env vars.
+
+    Always clears ``TAILNET_GUARD_ENABLED`` and
+    ``TAILNET_GUARD_ALLOWED_CIDRS`` first (so each call starts from a
+    clean, unconfigured slate), then applies any overrides, then calls
+    ``create_app`` -- the guard's env config is read at registration
+    time, so the env must be set before the factory runs, never after.
+
+    Args:
+        monkeypatch: Pytest's monkeypatch fixture.
+        db_path: The temporary database path for this test.
+
+    Returns:
+        A callable ``(env=None) -> Flask`` that builds one fresh app per
+        call, honoring the given guard environment variable overrides.
+    """
+
+    def _make(env: dict[str, str] | None = None) -> Flask:
+        """Build one fresh Flask app with the given guard env overrides."""
+        monkeypatch.delenv("TAILNET_GUARD_ENABLED", raising=False)
+        monkeypatch.delenv("TAILNET_GUARD_ALLOWED_CIDRS", raising=False)
+        for key, value in (env or {}).items():
+            monkeypatch.setenv(key, value)
+        application = create_app(db_path=db_path)
+        application.config["TESTING"] = True
+        return application
+
+    return _make
+
+
+@pytest.fixture()
+def app(make_app: Callable[[dict[str, str] | None], Flask]) -> Flask:
+    """Return the default app: no TAILNET_GUARD_* env set at all.
+
+    This is the fail-closed-by-default configuration: the guard must be
+    fully active with the production default CIDR list even though the
+    test never set any TAILNET_GUARD_* variable.
+
+    Args:
+        make_app: Factory fixture for building apps with env overrides.
+
+    Returns:
+        A configured Flask application in TESTING mode.
+    """
+    return make_app(None)
+
+
+@pytest.fixture()
+def client(app: Flask) -> FlaskClient:
+    """Return a Flask test client bound to the default app.
+
+    Args:
+        app: The default configured Flask application.
+
+    Returns:
+        A Flask test client.
+    """
+    return app.test_client()
+
+
+@pytest.fixture()
+def pantry_mgr(db_path: str) -> PantryManager:
+    """Return a PantryManager bound to the test database.
+
+    Args:
+        db_path: The temporary database path for this test.
+
+    Returns:
+        A PantryManager instance.
+    """
+    return PantryManager(db_path)
+
+
+@pytest.fixture()
+def seeded_item(app: Flask, pantry_mgr: PantryManager) -> InventoryItem:
+    """Seed a single trackable inventory item ("milk") for update tests.
+
+    Depends on ``app`` (not just ``db_path``) so the schema exists
+    before this fixture writes to it -- ``create_app`` is what runs
+    ``init_db``.
+
+    Args:
+        app: The configured Flask application (forces schema creation
+            before this fixture writes to the database).
+        pantry_mgr: PantryManager bound to the same database.
+
+    Returns:
+        The InventoryItem as added to the database.
+    """
+    item = InventoryItem(
+        ingredient="milk",
+        display_name="Milk",
+        category=IngredientCategory.DAIRY,
+        status=InventoryStatus.ON_HAND,
+    )
+    pantry_mgr.add_item(item)
+    return item
+
+
+@pytest.fixture()
+def auth_headers(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
+    """Return a valid Authorization header minted with a test shared secret.
+
+    Args:
+        monkeypatch: Pytest's monkeypatch fixture.
+
+    Returns:
+        A dict with a Bearer Authorization header signed with
+        ``TEST_SECRET``.
+    """
+    monkeypatch.setenv(SECRET_ENV_VAR, TEST_SECRET)
+    token = mint_token("rubotpaul")
+    return {"Authorization": f"Bearer {token}"}
+
+
+# ---------------------------------------------------------------------------
+# RED headline: state-mutating routes and the dashboard reject public IPs
+# ---------------------------------------------------------------------------
+
+
+class TestStateMutatingRoutesRejectPublicSource:
+    """Every state-mutating HTML route must 403 a public-source request."""
+
+    def test_recipe_delete_public_source_forbidden(self, client: FlaskClient) -> None:
+        """Test POST /recipes/<id>/delete from a public IP returns 403."""
+        response = client.post(
+            "/recipes/1/delete",
+            environ_base={"REMOTE_ADDR": PUBLIC_ADDR},
+        )
+        assert response.status_code == 403
+
+    def test_inventory_update_public_source_forbidden(
+        self, client: FlaskClient, seeded_item: InventoryItem
+    ) -> None:
+        """Test POST /inventory/update from a public IP returns 403."""
+        response = client.post(
+            "/inventory/update",
+            data=json.dumps({"ingredient": "milk", "status": "low"}),
+            content_type="application/json",
+            environ_base={"REMOTE_ADDR": PUBLIC_ADDR},
+        )
+        assert response.status_code == 403
+
+    def test_brands_add_public_source_forbidden(self, client: FlaskClient) -> None:
+        """Test POST /brands/add from a public IP returns 403."""
+        response = client.post(
+            "/brands/add",
+            data={
+                "match_target": "milk",
+                "match_type": "ingredient",
+                "brand": "Organic Valley",
+                "preference_type": "preferred",
+                "notes": "",
+            },
+            environ_base={"REMOTE_ADDR": PUBLIC_ADDR},
+        )
+        assert response.status_code == 403
+
+    def test_preferences_save_public_source_forbidden(
+        self, client: FlaskClient
+    ) -> None:
+        """Test POST /preferences from a public IP returns 403."""
+        response = client.post(
+            "/preferences",
+            data={"default_servings": "6"},
+            environ_base={"REMOTE_ADDR": PUBLIC_ADDR},
+        )
+        assert response.status_code == 403
+
+    def test_dashboard_public_source_forbidden(self, client: FlaskClient) -> None:
+        """Test GET / (dashboard) from a public IP returns 403."""
+        response = client.get("/", environ_base={"REMOTE_ADDR": PUBLIC_ADDR})
+        assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Trusted sources are unaffected
+# ---------------------------------------------------------------------------
+
+
+class TestAllowedSourcesNotAffected:
+    """Loopback and CGNAT sources must see normal, pre-guard behavior."""
+
+    @pytest.mark.parametrize("remote_addr", [LOOPBACK_ADDR, CGNAT_ADDR])
+    def test_recipe_delete_trusted_source_not_forbidden(
+        self, client: FlaskClient, remote_addr: str
+    ) -> None:
+        """Test recipe delete from loopback/CGNAT redirects normally."""
+        response = client.post(
+            "/recipes/1/delete",
+            environ_base={"REMOTE_ADDR": remote_addr},
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+
+    @pytest.mark.parametrize("remote_addr", [LOOPBACK_ADDR, CGNAT_ADDR])
+    def test_inventory_update_trusted_source_not_forbidden(
+        self,
+        client: FlaskClient,
+        seeded_item: InventoryItem,
+        remote_addr: str,
+    ) -> None:
+        """Test inventory update from loopback/CGNAT succeeds normally."""
+        response = client.post(
+            "/inventory/update",
+            data=json.dumps({"ingredient": "milk", "status": "low"}),
+            content_type="application/json",
+            environ_base={"REMOTE_ADDR": remote_addr},
+        )
+        assert response.status_code == 200
+
+    @pytest.mark.parametrize("remote_addr", [LOOPBACK_ADDR, CGNAT_ADDR])
+    def test_brands_add_trusted_source_not_forbidden(
+        self, client: FlaskClient, remote_addr: str
+    ) -> None:
+        """Test brand add from loopback/CGNAT redirects normally."""
+        response = client.post(
+            "/brands/add",
+            data={
+                "match_target": "milk",
+                "match_type": "ingredient",
+                "brand": "Organic Valley",
+                "preference_type": "preferred",
+                "notes": "",
+            },
+            environ_base={"REMOTE_ADDR": remote_addr},
+        )
+        assert response.status_code == 302
+
+    @pytest.mark.parametrize("remote_addr", [LOOPBACK_ADDR, CGNAT_ADDR])
+    def test_preferences_save_trusted_source_not_forbidden(
+        self, client: FlaskClient, remote_addr: str
+    ) -> None:
+        """Test preferences save from loopback/CGNAT redirects normally."""
+        response = client.post(
+            "/preferences",
+            data={"default_servings": "6"},
+            environ_base={"REMOTE_ADDR": remote_addr},
+        )
+        assert response.status_code == 302
+
+    @pytest.mark.parametrize("remote_addr", [LOOPBACK_ADDR, CGNAT_ADDR])
+    def test_dashboard_trusted_source_not_forbidden(
+        self, client: FlaskClient, remote_addr: str
+    ) -> None:
+        """Test dashboard GET from loopback/CGNAT renders normally."""
+        response = client.get("/", environ_base={"REMOTE_ADDR": remote_addr})
+        assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# X-Forwarded-For must never influence admission (spoof resistance)
+# ---------------------------------------------------------------------------
+
+
+class TestForwardedForSpoofResistance:
+    """A public source cannot forge trust via X-Forwarded-For."""
+
+    def test_public_source_xff_cgnat_still_forbidden(self, client: FlaskClient) -> None:
+        """Test XFF claiming a CGNAT address does not bypass the guard."""
+        response = client.get(
+            "/",
+            environ_base={"REMOTE_ADDR": PUBLIC_ADDR},
+            headers={"X-Forwarded-For": CGNAT_ADDR},
+        )
+        assert response.status_code == 403
+
+    def test_public_source_xff_loopback_still_forbidden(
+        self, client: FlaskClient
+    ) -> None:
+        """Test XFF claiming loopback does not bypass the guard."""
+        response = client.get(
+            "/",
+            environ_base={"REMOTE_ADDR": PUBLIC_ADDR},
+            headers={"X-Forwarded-For": LOOPBACK_ADDR},
+        )
+        assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Health exemption
+# ---------------------------------------------------------------------------
+
+
+class TestHealthExemption:
+    """/health and /healthz must be reachable from any source."""
+
+    def test_health_public_source_allowed(self, client: FlaskClient) -> None:
+        """Test GET /health from a public IP still returns 200."""
+        response = client.get("/health", environ_base={"REMOTE_ADDR": PUBLIC_ADDR})
+        assert response.status_code == 200
+
+    def test_healthz_public_source_allowed(self, client: FlaskClient) -> None:
+        """Test GET /healthz from a public IP still returns 200."""
+        response = client.get("/healthz", environ_base={"REMOTE_ADDR": PUBLIC_ADDR})
+        assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed default
+# ---------------------------------------------------------------------------
+
+
+class TestFailClosedDefault:
+    """With no TAILNET_GUARD_* env set at all, public sources are rejected."""
+
+    def test_no_guard_env_public_source_rejected(
+        self, make_app: Callable[[dict[str, str] | None], Flask]
+    ) -> None:
+        """Test the guard is active by default with zero configuration."""
+        application = make_app(None)
+        client = application.test_client()
+
+        response = client.get("/", environ_base={"REMOTE_ADDR": PUBLIC_ADDR})
+
+        assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Kill switch
+# ---------------------------------------------------------------------------
+
+
+class TestKillSwitch:
+    """TAILNET_GUARD_ENABLED can disable the guard entirely."""
+
+    @pytest.mark.parametrize("value", ["false", "0", "no", "FALSE", "No"])
+    def test_disabled_value_allows_public_source(
+        self,
+        make_app: Callable[[dict[str, str] | None], Flask],
+        value: str,
+    ) -> None:
+        """Test each disabling spelling (case-insensitive) opens the guard."""
+        application = make_app({"TAILNET_GUARD_ENABLED": value})
+        client = application.test_client()
+
+        response = client.get("/", environ_base={"REMOTE_ADDR": PUBLIC_ADDR})
+
+        assert response.status_code == 200
+
+    def test_enabled_value_still_rejects_public_source(
+        self, make_app: Callable[[dict[str, str] | None], Flask]
+    ) -> None:
+        """Test an explicit enabling value keeps the guard active."""
+        application = make_app({"TAILNET_GUARD_ENABLED": "true"})
+        client = application.test_client()
+
+        response = client.get("/", environ_base={"REMOTE_ADDR": PUBLIC_ADDR})
+
+        assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Custom CIDR override
+# ---------------------------------------------------------------------------
+
+
+class TestCustomCidrOverride:
+    """TAILNET_GUARD_ALLOWED_CIDRS replaces (not extends) the default list."""
+
+    @pytest.fixture()
+    def custom_client(
+        self, make_app: Callable[[dict[str, str] | None], Flask]
+    ) -> FlaskClient:
+        """Return a client for an app configured with a custom CIDR range.
+
+        Args:
+            make_app: Factory fixture for building apps with env overrides.
+
+        Returns:
+            A test client whose app only trusts 192.0.2.0/24.
+        """
+        application = make_app({"TAILNET_GUARD_ALLOWED_CIDRS": "192.0.2.0/24"})
+        return application.test_client()
+
+    def test_custom_range_source_allowed(self, custom_client: FlaskClient) -> None:
+        """Test an address inside the custom range is trusted."""
+        response = custom_client.get(
+            "/", environ_base={"REMOTE_ADDR": CUSTOM_RANGE_ADDR}
+        )
+        assert response.status_code == 200
+
+    def test_default_loopback_rejected_once_overridden(
+        self, custom_client: FlaskClient
+    ) -> None:
+        """Test loopback is rejected once the default list is overridden.
+
+        Proves the override *replaces* the default CIDR list rather than
+        extending it.
+        """
+        response = custom_client.get("/", environ_base={"REMOTE_ADDR": LOOPBACK_ADDR})
+        assert response.status_code == 403
+
+    def test_public_source_still_rejected_under_override(
+        self, custom_client: FlaskClient
+    ) -> None:
+        """Test an address outside the custom range is still rejected."""
+        response = custom_client.get("/", environ_base={"REMOTE_ADDR": PUBLIC_ADDR})
+        assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# Response shape
+# ---------------------------------------------------------------------------
+
+
+class TestResponseShape:
+    """403 responses are JSON under /api/ and HTML everywhere else."""
+
+    def test_api_path_public_source_json_body(self, client: FlaskClient) -> None:
+        """Test a rejected /api/v1 request gets a JSON forbidden body."""
+        response = client.get(
+            "/api/v1/inventory", environ_base={"REMOTE_ADDR": PUBLIC_ADDR}
+        )
+
+        assert response.status_code == 403
+        assert response.content_type == "application/json"
+        assert response.get_json() == {"error": "forbidden"}
+
+    def test_html_path_public_source_html_content_type(
+        self, client: FlaskClient
+    ) -> None:
+        """Test a rejected HTML-page request gets an HTML error page."""
+        response = client.get("/", environ_base={"REMOTE_ADDR": PUBLIC_ADDR})
+
+        assert response.status_code == 403
+        assert "text/html" in response.content_type
+
+
+# ---------------------------------------------------------------------------
+# The IP guard and the HMAC bearer are independent gates on /api/v1
+# ---------------------------------------------------------------------------
+
+
+class TestApiGuardIndependentOfBearer:
+    """A valid bearer token does not bypass the IP guard, and vice versa."""
+
+    def test_valid_bearer_public_source_still_forbidden(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """Test a valid bearer from a public IP is still rejected by the
+        guard (403, not 200) -- the two gates are independent.
+        """
+        response = client.get(
+            "/api/v1/inventory",
+            headers=auth_headers,
+            environ_base={"REMOTE_ADDR": PUBLIC_ADDR},
+        )
+        assert response.status_code == 403
+
+    def test_valid_bearer_loopback_source_succeeds(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """Test a valid bearer from loopback passes both gates (200)."""
+        response = client.get(
+            "/api/v1/inventory",
+            headers=auth_headers,
+            environ_base={"REMOTE_ADDR": LOOPBACK_ADDR},
+        )
+        assert response.status_code == 200

--- a/tests/test_network_guard.py
+++ b/tests/test_network_guard.py
@@ -173,3 +173,44 @@ class TestIsTrustedSource:
     def test_is_trusted_source_empty_allowed_list_false(self) -> None:
         """Test any address is rejected when the allowed list is empty."""
         assert is_trusted_source("127.0.0.1", []) is False
+
+    def test_is_trusted_source_ipv4_mapped_cgnat_true(
+        self, allowed: list[ipaddress.IPv4Network | ipaddress.IPv6Network]
+    ) -> None:
+        """Test an IPv4-mapped IPv6 CGNAT peer is trusted under the default.
+
+        A dual-stack listener (bound to ``::`` with ``IPV6_V6ONLY`` off)
+        reports IPv4 peers as IPv4-mapped IPv6 strings like
+        ``::ffff:100.64.1.2``. The mapped form must be normalized to its
+        IPv4 equivalent before the CIDR check, or legitimate tailnet
+        peers would be false-rejected.
+        """
+        assert is_trusted_source("::ffff:100.64.1.2", allowed) is True
+
+    def test_is_trusted_source_ipv4_mapped_loopback_true(
+        self, allowed: list[ipaddress.IPv4Network | ipaddress.IPv6Network]
+    ) -> None:
+        """Test an IPv4-mapped IPv6 loopback peer is trusted under the default."""
+        assert is_trusted_source("::ffff:127.0.0.1", allowed) is True
+
+    def test_is_trusted_source_ipv4_mapped_public_false(
+        self, allowed: list[ipaddress.IPv4Network | ipaddress.IPv6Network]
+    ) -> None:
+        """Test an IPv4-mapped IPv6 *public* peer is still rejected.
+
+        Normalization must widen only availability (mapped trusted
+        peers admitted), never trust (mapped public peers stay out).
+        """
+        assert is_trusted_source("::ffff:8.8.8.8", allowed) is False
+
+    def test_is_trusted_source_ipv4_mapped_just_past_cgnat_false(
+        self, allowed: list[ipaddress.IPv4Network | ipaddress.IPv6Network]
+    ) -> None:
+        """Test the mapped form of the first post-CGNAT address is rejected."""
+        assert is_trusted_source("::ffff:100.128.0.0", allowed) is False
+
+    def test_is_trusted_source_plain_ipv6_non_loopback_false(
+        self, allowed: list[ipaddress.IPv4Network | ipaddress.IPv6Network]
+    ) -> None:
+        """Test a non-mapped, non-loopback IPv6 address is still rejected."""
+        assert is_trusted_source("2001:db8::1", allowed) is False

--- a/tests/test_network_guard.py
+++ b/tests/test_network_guard.py
@@ -1,0 +1,175 @@
+"""Unit tests for ``grocery_butler.network_guard``.
+
+Covers the two pure functions that back the tailnet-only admission guard
+(issue #62): CIDR-list parsing (:func:`parse_allowed_cidrs`) and the
+source-IP admission check (:func:`is_trusted_source`). Integration of the
+guard into the Flask app (env wiring, exemptions, response shape) is
+covered separately in ``tests/test_app_boundary.py``.
+
+This module does not exist yet, so collection itself is expected to fail
+with ``ModuleNotFoundError`` until ``grocery_butler/network_guard.py`` is
+implemented -- that is the intended Gate 1 RED state for issue #62.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+
+import pytest
+
+from grocery_butler.network_guard import is_trusted_source, parse_allowed_cidrs
+
+#: The production default CIDR list: loopback + IPv6 loopback + Tailscale CGNAT.
+#: RFC1918 private ranges are deliberately excluded from the default.
+DEFAULT_CIDRS = "127.0.0.0/8,::1/128,100.64.0.0/10"
+
+
+# ---------------------------------------------------------------------------
+# parse_allowed_cidrs
+# ---------------------------------------------------------------------------
+
+
+class TestParseAllowedCidrs:
+    """Tests for parsing a comma-separated CIDR list into network objects."""
+
+    def test_parse_allowed_cidrs_default_string_returns_three_networks(self) -> None:
+        """Test the production default string parses to three networks."""
+        result = parse_allowed_cidrs(DEFAULT_CIDRS)
+
+        assert result == [
+            ipaddress.ip_network("127.0.0.0/8"),
+            ipaddress.ip_network("::1/128"),
+            ipaddress.ip_network("100.64.0.0/10"),
+        ]
+
+    def test_parse_allowed_cidrs_whitespace_around_entries_stripped(self) -> None:
+        """Test surrounding whitespace around entries does not break parsing."""
+        result = parse_allowed_cidrs("  127.0.0.0/8 , ::1/128  ")
+
+        assert result == [
+            ipaddress.ip_network("127.0.0.0/8"),
+            ipaddress.ip_network("::1/128"),
+        ]
+
+    def test_parse_allowed_cidrs_empty_entries_skipped(self) -> None:
+        """Test blank entries from double commas/trailing commas are skipped."""
+        result = parse_allowed_cidrs("127.0.0.0/8,,   ,::1/128,")
+
+        assert result == [
+            ipaddress.ip_network("127.0.0.0/8"),
+            ipaddress.ip_network("::1/128"),
+        ]
+
+    def test_parse_allowed_cidrs_empty_string_returns_empty_list(self) -> None:
+        """Test an empty (or whitespace-only) raw string yields no networks."""
+        assert parse_allowed_cidrs("") == []
+        assert parse_allowed_cidrs("   ") == []
+
+    def test_parse_allowed_cidrs_invalid_cidr_raises_value_error(self) -> None:
+        """Test a malformed CIDR entry raises ValueError rather than being
+        silently dropped (fail loud on operator misconfiguration).
+        """
+        with pytest.raises(ValueError):
+            parse_allowed_cidrs("not-a-cidr")
+
+    def test_parse_allowed_cidrs_out_of_range_octet_raises_value_error(self) -> None:
+        """Test an out-of-range IPv4 octet in a CIDR entry raises ValueError."""
+        with pytest.raises(ValueError):
+            parse_allowed_cidrs("300.300.300.300/24")
+
+    def test_parse_allowed_cidrs_one_bad_entry_among_good_raises_value_error(
+        self,
+    ) -> None:
+        """Test one invalid entry among otherwise-valid entries still raises."""
+        with pytest.raises(ValueError):
+            parse_allowed_cidrs("127.0.0.0/8,garbage,::1/128")
+
+
+# ---------------------------------------------------------------------------
+# is_trusted_source
+# ---------------------------------------------------------------------------
+
+
+class TestIsTrustedSource:
+    """Tests for the source-IP admission check against a parsed CIDR list."""
+
+    @pytest.fixture()
+    def allowed(self) -> list[ipaddress.IPv4Network | ipaddress.IPv6Network]:
+        """Return the parsed production-default allowed network list."""
+        return parse_allowed_cidrs(DEFAULT_CIDRS)
+
+    def test_is_trusted_source_loopback_v4_true(
+        self, allowed: list[ipaddress.IPv4Network | ipaddress.IPv6Network]
+    ) -> None:
+        """Test 127.0.0.1 (IPv4 loopback) is trusted under the default list."""
+        assert is_trusted_source("127.0.0.1", allowed) is True
+
+    def test_is_trusted_source_loopback_v6_true(
+        self, allowed: list[ipaddress.IPv4Network | ipaddress.IPv6Network]
+    ) -> None:
+        """Test ::1 (IPv6 loopback) is trusted under the default list."""
+        assert is_trusted_source("::1", allowed) is True
+
+    def test_is_trusted_source_cgnat_lower_bound_true(
+        self, allowed: list[ipaddress.IPv4Network | ipaddress.IPv6Network]
+    ) -> None:
+        """Test 100.64.0.0 (CGNAT range start) is trusted under the default."""
+        assert is_trusted_source("100.64.0.0", allowed) is True
+
+    def test_is_trusted_source_cgnat_upper_bound_true(
+        self, allowed: list[ipaddress.IPv4Network | ipaddress.IPv6Network]
+    ) -> None:
+        """Test 100.127.255.255 (CGNAT range end) is trusted under the default."""
+        assert is_trusted_source("100.127.255.255", allowed) is True
+
+    def test_is_trusted_source_just_past_cgnat_upper_bound_false(
+        self, allowed: list[ipaddress.IPv4Network | ipaddress.IPv6Network]
+    ) -> None:
+        """Test 100.128.0.0, one address past the CGNAT range, is rejected."""
+        assert is_trusted_source("100.128.0.0", allowed) is False
+
+    def test_is_trusted_source_just_before_cgnat_lower_bound_false(
+        self, allowed: list[ipaddress.IPv4Network | ipaddress.IPv6Network]
+    ) -> None:
+        """Test 100.63.255.255, one address before the CGNAT range, is rejected."""
+        assert is_trusted_source("100.63.255.255", allowed) is False
+
+    def test_is_trusted_source_public_ip_false(
+        self, allowed: list[ipaddress.IPv4Network | ipaddress.IPv6Network]
+    ) -> None:
+        """Test a public internet address (8.8.8.8) is rejected."""
+        assert is_trusted_source("8.8.8.8", allowed) is False
+
+    def test_is_trusted_source_rfc1918_private_address_false(
+        self, allowed: list[ipaddress.IPv4Network | ipaddress.IPv6Network]
+    ) -> None:
+        """Test RFC1918 private 10.0.0.1 is rejected under the default list.
+
+        RFC1918 ranges are deliberately excluded from the default so a
+        misconfigured office/home LAN is not accidentally trusted.
+        """
+        assert is_trusted_source("10.0.0.1", allowed) is False
+
+    def test_is_trusted_source_none_remote_addr_false(
+        self, allowed: list[ipaddress.IPv4Network | ipaddress.IPv6Network]
+    ) -> None:
+        """Test a None remote_addr (fail-closed) is rejected."""
+        assert is_trusted_source(None, allowed) is False
+
+    def test_is_trusted_source_malformed_string_false(
+        self, allowed: list[ipaddress.IPv4Network | ipaddress.IPv6Network]
+    ) -> None:
+        """Test a malformed IP string is rejected rather than raising."""
+        assert is_trusted_source("not-an-ip-address", allowed) is False
+
+    def test_is_trusted_source_out_of_range_octet_string_false(
+        self, allowed: list[ipaddress.IPv4Network | ipaddress.IPv6Network]
+    ) -> None:
+        """Test an out-of-range IPv4 octet string is rejected rather than
+        raising.
+        """
+        assert is_trusted_source("999.999.999.999", allowed) is False
+
+    def test_is_trusted_source_empty_allowed_list_false(self) -> None:
+        """Test any address is rejected when the allowed list is empty."""
+        assert is_trusted_source("127.0.0.1", []) is False


### PR DESCRIPTION
## Summary

- Adds a fail-closed tailnet-only network boundary guard (`grocery_butler/network_guard.py`): an `app.before_request` hook registered by `create_app()` rejects (403) any request whose socket peer address (`request.remote_addr`) is outside an allow-list of CIDR ranges — default `127.0.0.0/8,::1/128,100.64.0.0/10` (loopback + IPv6 loopback + Tailscale CGNAT). Admission never trusts `X-Forwarded-For` or any client-supplied header, closing the hole where the unauthenticated state-mutating HTML UI (recipe delete, inventory update, brand prefs, preferences) and `/api/v1` were reachable on the public Railway domain.
- Configurable but secure by default: `TAILNET_GUARD_ENABLED` kill switch (active unless explicitly `false`/`0`/`no`), `TAILNET_GUARD_ALLOWED_CIDRS` override (replaces, never extends, the default list). `/health` and `/healthz` stay exempt (matched by endpoint name) so Railway health checks keep working. Rejections are 403 JSON under `/api/*`, HTML error page elsewhere, logged with path + remote address only.
- README: new "Network boundary guard (tailnet-only)" section, env-var table rows, Railway Quick Start step to remove the default public domain (guard is defense-in-depth, not a substitute), and a documented decision to defer flask-limiter rate limiting now that public brute-forcing requires tailnet access.

## Test plan

- `tests/test_network_guard.py`: unit tests for `parse_allowed_cidrs` (whitespace/blank entries, fail-loud on malformed CIDR) and `is_trusted_source` (CGNAT boundary addresses, RFC1918 excluded, `None`/malformed address and empty allow-list all fail closed).
- `tests/test_app_boundary.py`: integration tests through the real app — public-source 403 on every state-mutating route and the dashboard; loopback/CGNAT flows unchanged (302/200 as before); `X-Forwarded-For` spoof resistance; health exemption; fail-closed with zero configuration; kill-switch spellings; CIDR override replaces defaults; JSON-vs-HTML 403 shape; IP guard independent of the `/api/v1` HMAC bearer gate (valid token from a public IP is still rejected).
- `./scripts/check-all.sh` exits 0: 1306 passed, 95.65% branch coverage, ruff/mypy/bandit/pip-audit/radon clean.

Closes #62
