### PR TITLE
fix: remove brand preferences by real database id, not list position

### DIFF
--- a/grocery_butler/api.py
+++ b/grocery_butler/api.py
@@ -589,7 +589,7 @@ def _confirm_brands_set(action: PendingAction, store: PendingActionsStore) -> Re
     pref = BrandPreference.model_validate(action.payload)
     _claim_pending(store, action.action_id)
     pref_id = _recipe_store().add_brand_preference(pref)
-    return _approved(action, {"id": pref_id, **pref.model_dump(mode="json")})
+    return _approved(action, {**pref.model_dump(mode="json"), "id": pref_id})
 
 
 def _confirm_preferences_set(

--- a/grocery_butler/app.py
+++ b/grocery_butler/app.py
@@ -896,8 +896,10 @@ def _register_brand_routes(app: Flask) -> None:
         """
         db_path = app.config["DATABASE_PATH"]
         recipe_store = RecipeStore(db_path)
-        recipe_store.remove_brand_preference(pref_id)
-        flash("Brand preference removed.", "success")
+        if recipe_store.remove_brand_preference(pref_id):
+            flash("Brand preference removed.", "success")
+        else:
+            flash("Brand preference not found.", "error")
         return redirect(url_for("brands"))
 
 

--- a/grocery_butler/bot.py
+++ b/grocery_butler/bot.py
@@ -905,6 +905,8 @@ def create_bot(config: Config) -> discord.Client:
             removed = 0
             for pref in prefs:
                 matches = pref.match_target.lower() == target.lower()
+                # pref.id is always populated by get_brand_preferences(); the
+                # None check only narrows the Optional type for mypy.
                 if matches and pref.id is not None:
                     await asyncio.to_thread(
                         recipe_store.remove_brand_preference, pref.id

--- a/grocery_butler/bot.py
+++ b/grocery_butler/bot.py
@@ -903,12 +903,11 @@ def create_bot(config: Config) -> discord.Client:
         try:
             prefs = await asyncio.to_thread(recipe_store.get_brand_preferences)
             removed = 0
-            for idx, pref in enumerate(prefs):
-                if pref.match_target.lower() == target.lower():
-                    # Brand preference IDs start at 1 and are sequential
-                    # Re-fetch to get current IDs
+            for pref in prefs:
+                matches = pref.match_target.lower() == target.lower()
+                if matches and pref.id is not None:
                     await asyncio.to_thread(
-                        recipe_store.remove_brand_preference, idx + 1
+                        recipe_store.remove_brand_preference, pref.id
                     )
                     removed += 1
 

--- a/grocery_butler/models.py
+++ b/grocery_butler/models.py
@@ -326,13 +326,18 @@ class InventoryUpdate(BaseModel):
 
 
 class BrandPreference(BaseModel):
-    """A brand preference rule (preferred or avoided)."""
+    """A brand preference rule (preferred or avoided).
+
+    The ``id`` field is the database row id. It is ``None`` for models
+    built in memory and is populated only when read back from the store.
+    """
 
     match_target: str
     match_type: BrandMatchType
     brand: str
     preference_type: BrandPreferenceType
     notes: str = ""
+    id: int | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/grocery_butler/recipe_store.py
+++ b/grocery_butler/recipe_store.py
@@ -520,6 +520,7 @@ class RecipeStore:
                     brand=row["brand"],
                     preference_type=BrandPreferenceType(row["preference_type"]),
                     notes=row["notes"] or "",
+                    id=row["id"],
                 )
                 for row in rows
             ]
@@ -558,16 +559,22 @@ class RecipeStore:
         finally:
             conn.close()
 
-    def remove_brand_preference(self, pref_id: int) -> None:
+    def remove_brand_preference(self, pref_id: int) -> bool:
         """Remove a brand preference by ID.
 
         Args:
             pref_id: Database ID of preference to remove.
+
+        Returns:
+            True if a row was deleted, False if no row matched the ID.
         """
         conn = self._connect()
         try:
-            conn.execute("DELETE FROM brand_preferences WHERE id = ?", (pref_id,))
+            cursor = conn.execute(
+                "DELETE FROM brand_preferences WHERE id = ?", (pref_id,)
+            )
             conn.commit()
+            return cursor.rowcount > 0
         finally:
             conn.close()
 
@@ -628,6 +635,7 @@ class RecipeStore:
                 brand=row["brand"],
                 preference_type=BrandPreferenceType(row["preference_type"]),
                 notes=row["notes"] or "",
+                id=row["id"],
             )
             for row in rows
         ]

--- a/grocery_butler/templates/brands.html
+++ b/grocery_butler/templates/brands.html
@@ -61,7 +61,7 @@
                     <span class="brand-card-notes">{{ pref.notes }}</span>
                     {% endif %}
                 </div>
-                <form action="/brands/{{ loop.index }}/remove" method="post" class="inline-form">
+                <form action="/brands/{{ pref.id }}/remove" method="post" class="inline-form">
                     <button type="submit" class="btn btn-danger btn-sm">Remove</button>
                 </form>
             </div>
@@ -83,7 +83,7 @@
                     <span class="brand-card-notes">{{ pref.notes }}</span>
                     {% endif %}
                 </div>
-                <form action="/brands/{{ loop.index }}/remove" method="post" class="inline-form">
+                <form action="/brands/{{ pref.id }}/remove" method="post" class="inline-form">
                     <button type="submit" class="btn btn-danger btn-sm">Remove</button>
                 </form>
             </div>

--- a/tests/e2e/test_brands.py
+++ b/tests/e2e/test_brands.py
@@ -1,13 +1,10 @@
 """E2E: brand preference staging via ``/brands/set`` -> confirm/deny.
 
-The web ``/brands/<id>/remove`` form flow is excluded here: it is an
-open bug (#63) where ``templates/brands.html`` links using
-``loop.index`` instead of the preference's real database id (the
-``BrandPreference`` model returned by ``get_brand_preferences`` has no
-``id`` field at all, so the template can only be coincidentally
-correct). That is a templating defect in a different layer than the
-``/api/v1`` blueprint this suite covers, and is reported back rather
-than fixed here.
+The web ``/brands/<id>/remove`` form flow lives in a different layer
+than the ``/api/v1`` blueprint this suite covers. It is exercised by
+the template-rendering and removal tests in ``tests/test_app.py``
+(added for issue #63, which fixed ``templates/brands.html`` to post
+the preference's real database id instead of ``loop.index``).
 """
 
 from __future__ import annotations

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -265,7 +265,7 @@ class TestBrandsEndpoint:
         recipe_store: RecipeStore,
     ) -> None:
         """Seeded brand preferences come back with full field shape."""
-        recipe_store.add_brand_preference(
+        pref_id = recipe_store.add_brand_preference(
             BrandPreference(
                 match_target="milk",
                 match_type=BrandMatchType.INGREDIENT,
@@ -278,6 +278,7 @@ class TestBrandsEndpoint:
         assert response.status_code == 200
         brands = response.get_json()["brands"]
         assert len(brands) == 1
+        assert brands[0]["id"] == pref_id
         assert brands[0]["match_target"] == "milk"
         assert brands[0]["match_type"] == "ingredient"
         assert brands[0]["brand"] == "Clover"

--- a/tests/test_api_destructive.py
+++ b/tests/test_api_destructive.py
@@ -658,6 +658,10 @@ class TestActionsConfirm:
         assert len(prefs) == 1
         assert prefs[0].brand == "Clover"
         assert prefs[0].match_target == "milk"
+        # The confirmation payload must carry the real inserted row id, not
+        # the BrandPreference model's None default (regression: issue #63).
+        assert prefs[0].id is not None
+        assert data["result"]["id"] == prefs[0].id
 
         action = pending_store.get_pending_action(action_id)
         assert action is not None

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1574,6 +1574,119 @@ class TestBrandsRemove:
         assert response.status_code == 302
         assert "/brands" in response.headers["Location"]
 
+    def test_brands_page_renders_real_ids_with_gap(
+        self, client: FlaskClient, recipe_store: RecipeStore
+    ) -> None:
+        """Test the brands page uses real DB ids, not loop.index, in forms."""
+        from grocery_butler.models import (
+            BrandMatchType,
+            BrandPreference,
+            BrandPreferenceType,
+        )
+
+        first_id = recipe_store.add_brand_preference(
+            BrandPreference(
+                match_target="aardvark",
+                match_type=BrandMatchType.INGREDIENT,
+                brand="First Brand",
+                preference_type=BrandPreferenceType.PREFERRED,
+            )
+        )
+        middle_id = recipe_store.add_brand_preference(
+            BrandPreference(
+                match_target="middleman",
+                match_type=BrandMatchType.INGREDIENT,
+                brand="Middle Brand",
+                preference_type=BrandPreferenceType.PREFERRED,
+            )
+        )
+        third_id = recipe_store.add_brand_preference(
+            BrandPreference(
+                match_target="zucchini",
+                match_type=BrandMatchType.INGREDIENT,
+                brand="Third Brand",
+                preference_type=BrandPreferenceType.PREFERRED,
+            )
+        )
+        # Force an id gap: the surviving prefs' ids are no longer sequential
+        # starting at 1, so a template that renders loop.index instead of
+        # pref.id would point at the wrong row.
+        recipe_store.remove_brand_preference(middle_id)
+
+        response = client.get("/brands")
+        html = response.data.decode()
+
+        assert f"/brands/{first_id}/remove" in html
+        assert f"/brands/{third_id}/remove" in html
+        # loop.index over the two surviving prefs would produce "1" and "2".
+        # The surviving real ids are not 1 and 2, so a "/brands/2/remove"
+        # action would only appear if the template incorrectly used
+        # loop.index instead of the real id.
+        assert "/brands/2/remove" not in html
+        assert f"/brands/{middle_id}/remove" not in html
+
+    def test_brands_remove_nonexistent_id_shows_not_found_flash(
+        self, client: FlaskClient
+    ) -> None:
+        """Test removing a nonexistent id flashes an error, not success."""
+        response = client.post(
+            "/brands/9999/remove",
+            follow_redirects=True,
+        )
+        assert response.status_code == 200
+        assert b"Brand preference removed" not in response.data
+        assert b"not found" in response.data.lower()
+
+    def test_brands_remove_clicked_row_deletes_correct_pref(
+        self, client: FlaskClient, recipe_store: RecipeStore
+    ) -> None:
+        """Test clicking Remove on a row deletes only that row, ids gapped."""
+        from grocery_butler.models import (
+            BrandMatchType,
+            BrandPreference,
+            BrandPreferenceType,
+        )
+
+        first_id = recipe_store.add_brand_preference(
+            BrandPreference(
+                match_target="apple",
+                match_type=BrandMatchType.INGREDIENT,
+                brand="Survivor Brand",
+                preference_type=BrandPreferenceType.PREFERRED,
+            )
+        )
+        middle_id = recipe_store.add_brand_preference(
+            BrandPreference(
+                match_target="banana",
+                match_type=BrandMatchType.INGREDIENT,
+                brand="Gap Creator Brand",
+                preference_type=BrandPreferenceType.PREFERRED,
+            )
+        )
+        highest_id = recipe_store.add_brand_preference(
+            BrandPreference(
+                match_target="cherry",
+                match_type=BrandMatchType.INGREDIENT,
+                brand="Target Brand",
+                preference_type=BrandPreferenceType.PREFERRED,
+            )
+        )
+        # Create the id gap directly via the store, then remove the
+        # highest-id row through the web route, as a user clicking the
+        # "Remove" button on that row would.
+        recipe_store.remove_brand_preference(middle_id)
+
+        response = client.post(
+            f"/brands/{highest_id}/remove",
+            follow_redirects=True,
+        )
+
+        assert response.status_code == 200
+        remaining = recipe_store.get_brand_preferences()
+        remaining_ids = {pref.id for pref in remaining}
+        assert highest_id not in remaining_ids
+        assert first_id in remaining_ids
+
 
 # ---------------------------------------------------------------------------
 # TestPreferencesPage

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1268,6 +1268,81 @@ class TestBrandsCommands:
         call_args = str(mock_interaction.response.send_message.call_args)
         assert "went wrong" in call_args
 
+    @pytest.mark.asyncio()
+    async def test_brands_clear_removes_correct_rows_with_id_gap(
+        self, mock_interaction, tmp_path
+    ):
+        """Test /brands clear removes matching rows even with gapped ids.
+
+        Regression test for issue #63: the clear handler used to delete
+        by ``enumerate`` position instead of the real database id, so a
+        gap in ids (from an earlier deletion) caused it to target the
+        wrong row.
+
+        Uses a dedicated file-backed database (rather than the shared
+        ``bot``/``config`` fixtures, which point at a process-wide
+        ``:memory:`` database) so this test's id numbering is fully
+        isolated from any other test and cannot pass by accidental
+        alignment between enumerate-position and real DB id.
+        """
+        from grocery_butler.recipe_store import RecipeStore
+
+        isolated_config = Config(
+            anthropic_api_key="sk-test",
+            discord_bot_token="test-bot-token",
+            database_path=str(tmp_path / "brands_clear_gap.db"),
+        )
+        isolated_bot = create_bot(isolated_config)
+        store = RecipeStore(isolated_config.database_path)
+        target = "gap-clear-target-63"
+        other_target = "gap-clear-other-63"
+
+        # Seed and delete several filler rows first so the target and
+        # other prefs get ids far from their position in the final
+        # sorted list, regardless of alphabetical ordering.
+        filler_ids = [
+            store.add_brand_preference(
+                BrandPreference(
+                    match_target=f"gap-clear-filler-{i}-63",
+                    match_type=BrandMatchType.INGREDIENT,
+                    brand=f"Filler Brand {i}",
+                    preference_type=BrandPreferenceType.PREFERRED,
+                )
+            )
+            for i in range(5)
+        ]
+        store.add_brand_preference(
+            BrandPreference(
+                match_target=target,
+                match_type=BrandMatchType.INGREDIENT,
+                brand="Match Brand",
+                preference_type=BrandPreferenceType.PREFERRED,
+            )
+        )
+        store.add_brand_preference(
+            BrandPreference(
+                match_target=other_target,
+                match_type=BrandMatchType.INGREDIENT,
+                brand="Other Brand",
+                preference_type=BrandPreferenceType.PREFERRED,
+            )
+        )
+        # Force id gaps: deleting the filler rows means the surviving
+        # rows' ids are no longer sequential positions in the sorted list.
+        for filler_id in filler_ids:
+            store.remove_brand_preference(filler_id)
+
+        cmd = self._get_subcommand(isolated_bot, "clear")
+        assert cmd is not None
+        await cmd.callback(mock_interaction, target=target)
+
+        remaining = store.get_brand_preferences()
+        remaining_target_brands = {
+            (pref.match_target, pref.brand) for pref in remaining
+        }
+        assert (target, "Match Brand") not in remaining_target_brands
+        assert (other_target, "Other Brand") in remaining_target_brands
+
 
 class TestRecipesCommands:
     """Tests for the /recipes command group."""

--- a/tests/test_recipe_store.py
+++ b/tests/test_recipe_store.py
@@ -578,3 +578,63 @@ class TestBrandPreferences:
         )
         result = store.get_brands_for_ingredient("chicken")
         assert result == []
+
+    def test_get_brand_preferences_populates_id(self, store: RecipeStore) -> None:
+        """Test get_brand_preferences populates the real DB id on each pref."""
+        pref_a = BrandPreference(
+            match_target="dairy",
+            match_type=BrandMatchType.CATEGORY,
+            brand="Organic Valley",
+            preference_type=BrandPreferenceType.PREFERRED,
+        )
+        pref_b = BrandPreference(
+            match_target="soda",
+            match_type=BrandMatchType.CATEGORY,
+            brand="Generic Cola",
+            preference_type=BrandPreferenceType.AVOID,
+        )
+        id_a = store.add_brand_preference(pref_a)
+        id_b = store.add_brand_preference(pref_b)
+
+        result = store.get_brand_preferences()
+        by_brand = {pref.brand: pref for pref in result}
+        assert by_brand["Organic Valley"].id == id_a
+        assert by_brand["Generic Cola"].id == id_b
+
+    def test_get_brands_for_ingredient_populates_id(self, store: RecipeStore) -> None:
+        """Test get_brands_for_ingredient (via _rows_to_brand_prefs) sets id."""
+        pref = BrandPreference(
+            match_target="milk",
+            match_type=BrandMatchType.INGREDIENT,
+            brand="Organic Valley",
+            preference_type=BrandPreferenceType.PREFERRED,
+        )
+        pref_id = store.add_brand_preference(pref)
+
+        result = store.get_brands_for_ingredient("milk")
+        assert len(result) == 1
+        assert result[0].id == pref_id
+
+    def test_remove_brand_preference_returns_true_when_deleted(
+        self, store: RecipeStore
+    ) -> None:
+        """Test remove_brand_preference returns True for an existing id."""
+        pref = BrandPreference(
+            match_target="dairy",
+            match_type=BrandMatchType.CATEGORY,
+            brand="Store Brand",
+            preference_type=BrandPreferenceType.AVOID,
+        )
+        pref_id = store.add_brand_preference(pref)
+
+        result = store.remove_brand_preference(pref_id)
+
+        assert result is True
+
+    def test_remove_brand_preference_returns_false_when_missing(
+        self, store: RecipeStore
+    ) -> None:
+        """Test remove_brand_preference returns False for a nonexistent id."""
+        result = store.remove_brand_preference(9999)
+
+        assert result is False


### PR DESCRIPTION
## Summary

- Fix wrong-row deletion of brand preferences: `templates/brands.html` posted `loop.index` (position within the preferred/avoid sub-list) to `/brands/<id>/remove`, and the bot's `/brands clear` deleted `idx + 1` — both guesses break as soon as ids have gaps. `BrandPreference` now carries its real database `id` (populated on read), and both the template and the bot remove by `pref.id`.
- No-op deletes no longer flash success: `remove_brand_preference` returns whether a row matched, and the web route flashes "Brand preference not found." (error) when nothing was deleted.
- Reordered the `_confirm_brands_set` response payload spread so the returned `id` is the real inserted row id rather than the model's `None` default; `GET /api/v1/brands` now additively includes each preference's `id`.

## Test plan

- 8 new regression tests written RED-first (all failed against the old code for the documented reasons, all pass with the fix):
  - `tests/test_recipe_store.py`: id population via `get_brand_preferences` and `get_brands_for_ingredient`; `remove_brand_preference` returns `True` on delete / `False` on miss.
  - `tests/test_app.py`: `/brands` renders form actions with real DB ids under id gaps (not `loop.index`); POST to a nonexistent id flashes "not found" instead of success; removing the clicked row with gapped ids deletes exactly that row.
  - `tests/test_bot.py`: `/brands clear` with non-sequential ids removes exactly the matching preferences and leaves others intact.
- Full suite: 1262 passed, 8 pre-existing env-dependent skips (Postgres `TEST_DATABASE_URL`).
- `./scripts/check-all.sh` exit 0: ruff lint/format clean, mypy strict clean, bandit + pip-audit clean, radon complexity/MI within limits, coverage 95.79% (threshold 90%).
- Gate 2.5 self-review (code-review-orchestrator): CLEAN, no blockers; its one nit (stale "open bug #63" docstring in `tests/e2e/test_brands.py`) is fixed in this PR.

Closes #63
