### PR TITLE
fix(config): fail fast at boot on missing production secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,22 @@ FLASK_DEBUG=true
 DEFAULT_SERVINGS=4
 DEFAULT_UNITS=imperial
 
+# Issue #64: the Docker runtime image sets this to "production". In
+# production mode, create_app() fails fast at startup if a required
+# secret (FLASK_SECRET_KEY, RUBOTPAUL_SHARED_SECRET) is missing, instead
+# of booting with an unsafe fallback or deferring the failure to the
+# first request.
+APP_ENV=
+
+# Stable session-signing key. Generate once and reuse it across restarts
+# and gunicorn workers -- without it, sessions won't survive a restart or
+# be shared between worker processes. Required in production.
+FLASK_SECRET_KEY=
+
+# Postgres connection URL used in production (Railway-provisioned).
+# Falls back to DATABASE_PATH (SQLite) when unset.
+DATABASE_URL=
+
 # RubotPaul HMAC bearer auth (required for auth-protected API endpoints)
 RUBOTPAUL_SHARED_SECRET=
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,9 @@ RUN chown -R butler:butler /app
 
 USER butler
 
+# Issue #64: arms create_app()'s production fail-fast startup checks
+# (missing FLASK_SECRET_KEY / RUBOTPAUL_SHARED_SECRET refuse to boot).
+ENV APP_ENV=production
 ENV PORT=8000
 EXPOSE $PORT
 

--- a/README.md
+++ b/README.md
@@ -325,10 +325,11 @@ $EDITOR .env
 
 | Variable | When required | Purpose |
 |----------|---------------|---------|
-| `ANTHROPIC_API_KEY` | Always | Claude API access for parsing and consolidation. |
-| `RUBOTPAUL_SHARED_SECRET` | RubotPaul API | HMAC secret for `/api/v1` bearer tokens (shared with RubotPaul). |
+| `ANTHROPIC_API_KEY` | Always | Claude API access for parsing and consolidation. Missing key logs a startup warning and degrades to stub/saved-recipe paths rather than blocking boot. |
+| `APP_ENV` | Set by the Docker image | Set to `production` in the runtime image; arms fail-fast startup checks for `FLASK_SECRET_KEY` and `RUBOTPAUL_SHARED_SECRET` (see [Fail-fast startup checks](#fail-fast-startup-checks), issue #64). Leave unset for local dev. |
+| `RUBOTPAUL_SHARED_SECRET` | RubotPaul API | HMAC secret for `/api/v1` bearer tokens (shared with RubotPaul). Required at boot when `APP_ENV=production`; otherwise only enforced per-request (401). |
 | `DISCORD_BOT_TOKEN` | Local bot runs only | Authenticates the (retired-from-production) Discord bot. |
-| `FLASK_SECRET_KEY` | Web (production) | Stable session signing key. |
+| `FLASK_SECRET_KEY` | Web (production) | Stable session signing key. Required at boot when `APP_ENV=production`; in dev, an unset key falls back to a random per-process key (see [Fail-fast startup checks](#fail-fast-startup-checks)). |
 | `DATABASE_PATH` | SQLite (dev) | Path to the local SQLite file. Defaults to `mealbot.db`. |
 | `DATABASE_URL` | Postgres (prod) | Connection URL injected by Railway Postgres. |
 | `SAFEWAY_USERNAME` | Ordering only | Safeway account email. |
@@ -347,7 +348,13 @@ gunicorn 'grocery_butler.app:create_app()' --bind 0.0.0.0:5000
 FLASK_APP='grocery_butler.app:create_app()' flask run --debug
 ```
 
-Open <http://localhost:5000>.
+Open <http://localhost:5000>. `APP_ENV` is unset here, so a missing
+`FLASK_SECRET_KEY` doesn't block boot: the app falls back to a random
+per-process key and logs a warning. That's fine for a single local
+`flask run`/gunicorn worker, but sessions won't survive a restart or be
+shared across multiple workers — see
+[Fail-fast startup checks](#fail-fast-startup-checks) for the production
+behavior.
 
 ### Discord bot (local only — retired from production)
 
@@ -778,7 +785,9 @@ process to deploy alongside the web service.
 
 ### Required environment variables
 
-Set these in your Railway project settings:
+Set these in your Railway project settings. `APP_ENV=production` is baked
+into the `Dockerfile` and doesn't need to be set separately — it's what
+arms the fail-fast checks below.
 
 | Variable | Required | Description |
 |----------|----------|-------------|
@@ -790,6 +799,21 @@ Set these in your Railway project settings:
 | `SAFEWAY_PASSWORD` | Yes (ordering) | Safeway account password. |
 | `SAFEWAY_STORE_ID` | Yes (ordering) | Safeway store ID for product searches. |
 | `PORT` | Auto | Injected by Railway for the web process. |
+
+### Fail-fast startup checks
+
+The Docker image sets `APP_ENV=production` (see the `Dockerfile`), which
+arms startup checks in `create_app()` (issue #64):
+
+- Missing or empty `FLASK_SECRET_KEY` or `RUBOTPAUL_SHARED_SECRET` raises
+  `RuntimeError` and the process refuses to boot — a misconfigured deploy
+  crashes immediately instead of serving requests that later 401/500 or
+  silently generate an unstable session key.
+- Missing `ANTHROPIC_API_KEY` never blocks boot (in any mode); it logs a
+  startup warning since Claude-backed meal parsing degrades to
+  stub/saved-recipe paths without it.
+
+See `.env.example` for the full variable list and comments.
 
 ### Quick start
 

--- a/grocery_butler/app.py
+++ b/grocery_butler/app.py
@@ -37,6 +37,95 @@ from grocery_butler.recipe_store import RecipeStore
 logger = logging.getLogger(__name__)
 
 
+def _is_production() -> bool:
+    """Return whether the app is configured to run in production mode.
+
+    Production mode is opted into via the ``APP_ENV`` environment variable
+    (set to ``"production"`` in the Docker runtime image). The comparison
+    is case-insensitive so ``"Production"`` or ``"PRODUCTION"`` also count.
+
+    Returns:
+        True if ``APP_ENV`` is set to ``"production"`` (any case), else
+        False.
+    """
+    return os.environ.get("APP_ENV", "").lower() == "production"
+
+
+def _resolve_secret_key() -> str:
+    """Resolve the Flask session ``SECRET_KEY`` for the current environment.
+
+    ``FLASK_SECRET_KEY`` is used verbatim whenever it's set to a non-empty
+    value. When it's unset (or empty) in production, startup fails fast
+    with a ``RuntimeError`` rather than booting with an ephemeral key --
+    a random per-process key would silently break sessions across restarts
+    and across the multiple gunicorn worker processes production runs. In
+    dev/test mode the same gap is tolerated: a warning is logged and a
+    fresh random key is generated so local development keeps working
+    without any env setup.
+
+    Returns:
+        The resolved secret key string.
+
+    Raises:
+        RuntimeError: If running in production and ``FLASK_SECRET_KEY`` is
+            unset or empty.
+    """
+    secret_key = os.environ.get("FLASK_SECRET_KEY", "")
+    if secret_key:
+        return secret_key
+
+    if _is_production():
+        raise RuntimeError(
+            "FLASK_SECRET_KEY is not set; refusing to start in production. "
+            "A stable secret key is required so sessions survive restarts "
+            "and are shared consistently across gunicorn worker processes."
+        )
+
+    logger.warning(
+        "FLASK_SECRET_KEY is not set; generating a random key for this "
+        "process. Sessions will not survive restarts or be shared across "
+        "multiple workers. Set FLASK_SECRET_KEY for stable sessions."
+    )
+    return os.urandom(32).hex()
+
+
+def _require_rubotpaul_secret() -> None:
+    """Fail fast in production if the RubotPaul shared secret is missing.
+
+    Delegates to ``auth_middleware._shared_secret()``, which already
+    raises ``RuntimeError`` naming ``RUBOTPAUL_SHARED_SECRET`` when the
+    variable is unset or empty. This is a no-op outside production so dev
+    and test environments can boot without the shared secret configured;
+    unauthenticated requests to the API blueprint still 401 at request
+    time via ``require_bearer()``.
+
+    Raises:
+        RuntimeError: If running in production and
+            ``RUBOTPAUL_SHARED_SECRET`` is unset or empty.
+    """
+    if not _is_production():
+        return
+
+    from grocery_butler import auth_middleware
+
+    auth_middleware._shared_secret()
+
+
+def _warn_if_no_anthropic_key() -> None:
+    """Log a warning at startup if ``ANTHROPIC_API_KEY`` is not configured.
+
+    A missing key never blocks boot in any mode -- Claude-backed meal
+    parsing already degrades gracefully to stub/saved-recipe paths -- but
+    operators should be told loudly so the degraded behavior isn't a
+    surprise.
+    """
+    if not os.environ.get("ANTHROPIC_API_KEY", ""):
+        logger.warning(
+            "ANTHROPIC_API_KEY is not set; Claude-backed meal parsing will "
+            "degrade to stub/saved-recipe paths until it is configured."
+        )
+
+
 def _resolve_database_target(db_path: str | None) -> str:
     """Resolve the database path or connection URL to use for the app.
 
@@ -84,7 +173,7 @@ def create_app(db_path: str | None = None) -> Flask:
     )
     resolved = _resolve_database_target(db_path)
     app.config["DATABASE_PATH"] = resolved
-    app.config["SECRET_KEY"] = os.environ.get("FLASK_SECRET_KEY", os.urandom(32).hex())
+    app.config["SECRET_KEY"] = _resolve_secret_key()
 
     init_db(resolved)
 
@@ -100,11 +189,21 @@ def create_app(db_path: str | None = None) -> Flask:
 def _register_api(app: Flask) -> None:
     """Register the RubotPaul-facing /api/v1 JSON blueprint.
 
+    Validates production startup config (RubotPaul shared secret) and
+    warns about optional-but-recommended config (Anthropic API key)
+    before the blueprint is registered.
+
     Args:
         app: Flask application instance.
+
+    Raises:
+        RuntimeError: If running in production and
+            ``RUBOTPAUL_SHARED_SECRET`` is unset or empty.
     """
     from grocery_butler.api import api_v1
 
+    _require_rubotpaul_secret()
+    _warn_if_no_anthropic_key()
     app.register_blueprint(api_v1)
 
 

--- a/tests/test_startup_config.py
+++ b/tests/test_startup_config.py
@@ -1,0 +1,419 @@
+"""Tests for fail-fast production startup config validation (issue #64).
+
+``create_app()`` must refuse to start in production with missing secrets
+(``FLASK_SECRET_KEY``, ``RUBOTPAUL_SHARED_SECRET``) rather than silently
+booting with a random session key or deferring the auth failure to the
+first request. In dev/test mode (``APP_ENV`` unset or not "production")
+those same gaps are tolerated but loudly warned about. A missing
+``ANTHROPIC_API_KEY`` is warn-only in every mode since Claude-backed
+pipelines already degrade gracefully without it.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+
+import pytest
+
+from grocery_butler.app import create_app
+from grocery_butler.auth_middleware import SECRET_ENV_VAR
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ENV_EXAMPLE = REPO_ROOT / ".env.example"
+DOCKERFILE = REPO_ROOT / "Dockerfile"
+
+_STARTUP_ENV_VARS = (
+    "APP_ENV",
+    "FLASK_SECRET_KEY",
+    "RUBOTPAUL_SHARED_SECRET",
+    "ANTHROPIC_API_KEY",
+)
+
+
+def _clear_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Delete every startup-config env var so ambient env can't leak in.
+
+    A developer's real ``.env`` or shell environment must never influence
+    these tests, so each test clears the full set explicitly before
+    setting only the variables it cares about.
+
+    Args:
+        monkeypatch: Pytest fixture used to delete environment variables
+            for the duration of the current test.
+    """
+    for name in _STARTUP_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+
+def _env_example_has_key(key: str) -> bool:
+    """Return whether ``.env.example`` declares a line assigning ``key``.
+
+    Args:
+        key: Environment variable name to look for, e.g. ``"APP_ENV"``.
+
+    Returns:
+        True if a line of the form ``key=...`` is present in the file.
+    """
+    pattern = re.compile(rf"^{re.escape(key)}=")
+    return any(
+        pattern.match(line.strip()) for line in ENV_EXAMPLE.read_text().splitlines()
+    )
+
+
+def _warning_messages(
+    caplog: pytest.LogCaptureFixture, logger_name: str = "grocery_butler.app"
+) -> list[str]:
+    """Return formatted messages of WARNING+ records emitted by ``logger_name``.
+
+    Args:
+        caplog: Pytest fixture capturing log records for the current test.
+        logger_name: Logger name to filter records by.
+
+    Returns:
+        List of formatted (``getMessage()``) warning-or-above log messages.
+    """
+    return [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == logger_name and record.levelno >= logging.WARNING
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> str:
+    """Return a temporary database path for test isolation."""
+    return str(tmp_path / "test_startup.db")
+
+
+# ---------------------------------------------------------------------------
+# _is_production() helper
+# ---------------------------------------------------------------------------
+
+
+class TestIsProductionHelper:
+    """Tests for the ``_is_production`` startup helper in grocery_butler.app."""
+
+    def test_is_production_true_when_app_env_production(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """APP_ENV=production reports production mode."""
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("APP_ENV", "production")
+        from grocery_butler.app import _is_production
+
+        assert _is_production() is True
+
+    def test_is_production_true_case_insensitive(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """APP_ENV comparison ignores case, e.g. "Production" or "PRODUCTION"."""
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("APP_ENV", "PRODUCTION")
+        from grocery_butler.app import _is_production
+
+        assert _is_production() is True
+
+    def test_is_production_false_when_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An unset APP_ENV means dev/test mode, not production."""
+        _clear_env(monkeypatch)
+        from grocery_butler.app import _is_production
+
+        assert _is_production() is False
+
+    def test_is_production_false_when_other_value(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A non-production APP_ENV value (e.g. "staging") is not production."""
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("APP_ENV", "staging")
+        from grocery_butler.app import _is_production
+
+        assert _is_production() is False
+
+
+# ---------------------------------------------------------------------------
+# Production: missing FLASK_SECRET_KEY fails fast
+# ---------------------------------------------------------------------------
+
+
+class TestProductionMissingFlaskSecretKey:
+    """Production startup must fail fast when FLASK_SECRET_KEY is unset."""
+
+    def test_create_app_production_missing_flask_secret_key_raises(
+        self, monkeypatch: pytest.MonkeyPatch, db_path: str
+    ) -> None:
+        """Production with no FLASK_SECRET_KEY raises RuntimeError naming it."""
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv(SECRET_ENV_VAR, "shared-secret")
+
+        with pytest.raises(RuntimeError, match="FLASK_SECRET_KEY"):
+            create_app(db_path=db_path)
+
+    def test_create_app_production_empty_flask_secret_key_raises(
+        self, monkeypatch: pytest.MonkeyPatch, db_path: str
+    ) -> None:
+        """Production with an empty-string FLASK_SECRET_KEY also raises."""
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("FLASK_SECRET_KEY", "")
+        monkeypatch.setenv(SECRET_ENV_VAR, "shared-secret")
+
+        with pytest.raises(RuntimeError, match="FLASK_SECRET_KEY"):
+            create_app(db_path=db_path)
+
+
+# ---------------------------------------------------------------------------
+# Production: missing RUBOTPAUL_SHARED_SECRET fails fast
+# ---------------------------------------------------------------------------
+
+
+class TestProductionMissingSharedSecret:
+    """Production startup must fail fast when RUBOTPAUL_SHARED_SECRET is unset.
+
+    This is expected to surface the existing
+    ``auth_middleware._shared_secret()`` RuntimeError, not a new one, so the
+    match target is the same ``SECRET_ENV_VAR`` name that function already
+    raises against.
+    """
+
+    def test_create_app_production_missing_shared_secret_raises(
+        self, monkeypatch: pytest.MonkeyPatch, db_path: str
+    ) -> None:
+        """Production with FLASK_SECRET_KEY set but no shared secret raises."""
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("FLASK_SECRET_KEY", "prod-secret-value")
+
+        with pytest.raises(RuntimeError, match=SECRET_ENV_VAR):
+            create_app(db_path=db_path)
+
+    def test_create_app_production_empty_shared_secret_raises(
+        self, monkeypatch: pytest.MonkeyPatch, db_path: str
+    ) -> None:
+        """Production with an empty-string shared secret also raises."""
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("FLASK_SECRET_KEY", "prod-secret-value")
+        monkeypatch.setenv(SECRET_ENV_VAR, "")
+
+        with pytest.raises(RuntimeError, match=SECRET_ENV_VAR):
+            create_app(db_path=db_path)
+
+
+# ---------------------------------------------------------------------------
+# Dev/test mode: missing FLASK_SECRET_KEY is tolerated but warned about
+# ---------------------------------------------------------------------------
+
+
+class TestDevModeMissingFlaskSecretKey:
+    """Dev/test mode tolerates a missing FLASK_SECRET_KEY but warns loudly."""
+
+    def test_dev_mode_missing_flask_secret_key_boots_with_random_key(
+        self, monkeypatch: pytest.MonkeyPatch, db_path: str
+    ) -> None:
+        """No APP_ENV and no FLASK_SECRET_KEY still boots with a non-empty key."""
+        _clear_env(monkeypatch)
+
+        app = create_app(db_path=db_path)
+
+        assert app.config["SECRET_KEY"]
+
+    def test_dev_mode_missing_flask_secret_key_logs_warning(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        db_path: str,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A missing FLASK_SECRET_KEY logs a warning naming it and sessions."""
+        _clear_env(monkeypatch)
+        caplog.set_level(logging.WARNING, logger="grocery_butler.app")
+
+        create_app(db_path=db_path)
+
+        messages = _warning_messages(caplog)
+        assert any(
+            "FLASK_SECRET_KEY" in message and "session" in message.lower()
+            for message in messages
+        )
+
+
+# ---------------------------------------------------------------------------
+# Dev/test mode: missing RUBOTPAUL_SHARED_SECRET is tolerated at boot
+# ---------------------------------------------------------------------------
+
+
+class TestDevModeMissingSharedSecret:
+    """Dev/test mode boots without RUBOTPAUL_SHARED_SECRET; auth still 401s."""
+
+    def test_dev_mode_missing_shared_secret_registers_api_blueprint(
+        self, monkeypatch: pytest.MonkeyPatch, db_path: str
+    ) -> None:
+        """No shared secret in dev mode still creates the app with /api/v1."""
+        _clear_env(monkeypatch)
+
+        app = create_app(db_path=db_path)
+
+        assert "api_v1" in app.blueprints
+
+    def test_dev_mode_missing_shared_secret_unauthenticated_get_401(
+        self, monkeypatch: pytest.MonkeyPatch, db_path: str
+    ) -> None:
+        """An unauthenticated GET to /api/v1 still returns 401 without a secret."""
+        _clear_env(monkeypatch)
+        app = create_app(db_path=db_path)
+        client = app.test_client()
+
+        response = client.get("/api/v1/inventory")
+
+        assert response.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# FLASK_SECRET_KEY, when set, is used verbatim in any mode
+# ---------------------------------------------------------------------------
+
+
+class TestFlaskSecretKeyFromEnv:
+    """When FLASK_SECRET_KEY is set, config SECRET_KEY must match it exactly."""
+
+    def test_flask_secret_key_env_used_exactly_in_dev(
+        self, monkeypatch: pytest.MonkeyPatch, db_path: str
+    ) -> None:
+        """A set FLASK_SECRET_KEY becomes SECRET_KEY verbatim in dev mode."""
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("FLASK_SECRET_KEY", "dev-secret-value")
+
+        app = create_app(db_path=db_path)
+
+        assert app.config["SECRET_KEY"] == "dev-secret-value"
+
+    def test_flask_secret_key_env_used_exactly_in_production(
+        self, monkeypatch: pytest.MonkeyPatch, db_path: str
+    ) -> None:
+        """A set FLASK_SECRET_KEY becomes SECRET_KEY verbatim in production too."""
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("FLASK_SECRET_KEY", "prod-secret-value")
+        monkeypatch.setenv(SECRET_ENV_VAR, "shared-secret")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+        app = create_app(db_path=db_path)
+
+        assert app.config["SECRET_KEY"] == "prod-secret-value"
+
+
+# ---------------------------------------------------------------------------
+# ANTHROPIC_API_KEY is warn-only in every mode
+# ---------------------------------------------------------------------------
+
+
+class TestAnthropicApiKeyWarnOnly:
+    """A missing ANTHROPIC_API_KEY only warns at startup; it never blocks boot."""
+
+    def test_missing_anthropic_api_key_logs_startup_warning(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        db_path: str,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """No ANTHROPIC_API_KEY logs a prominent warning naming the var."""
+        _clear_env(monkeypatch)
+        caplog.set_level(logging.WARNING, logger="grocery_butler.app")
+
+        create_app(db_path=db_path)
+
+        messages = _warning_messages(caplog)
+        assert any("ANTHROPIC_API_KEY" in message for message in messages)
+
+    def test_present_anthropic_api_key_logs_no_warning(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        db_path: str,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A configured ANTHROPIC_API_KEY suppresses the startup warning."""
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-configured")
+        caplog.set_level(logging.WARNING, logger="grocery_butler.app")
+
+        create_app(db_path=db_path)
+
+        messages = _warning_messages(caplog)
+        assert not any("ANTHROPIC_API_KEY" in message for message in messages)
+
+
+# ---------------------------------------------------------------------------
+# Production with every required secret present succeeds
+# ---------------------------------------------------------------------------
+
+
+class TestProductionAllSecretsSetSucceeds:
+    """Production startup with every required secret set must succeed."""
+
+    def test_create_app_production_all_secrets_set_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch, db_path: str
+    ) -> None:
+        """create_app() returns normally when all prod secrets are present."""
+        _clear_env(monkeypatch)
+        monkeypatch.setenv("APP_ENV", "production")
+        monkeypatch.setenv("FLASK_SECRET_KEY", "prod-secret-value")
+        monkeypatch.setenv(SECRET_ENV_VAR, "shared-secret")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-configured")
+
+        app = create_app(db_path=db_path)
+
+        assert app.config["SECRET_KEY"] == "prod-secret-value"
+
+
+# ---------------------------------------------------------------------------
+# .env.example must document the vars the startup checks depend on
+# ---------------------------------------------------------------------------
+
+
+class TestEnvExampleGuardsProductionConfig:
+    """.env.example must document every var create_app()'s checks need."""
+
+    def test_env_example_documents_flask_secret_key(self) -> None:
+        """FLASK_SECRET_KEY must be documented for local/prod parity."""
+        assert _env_example_has_key("FLASK_SECRET_KEY")
+
+    def test_env_example_documents_database_url(self) -> None:
+        """DATABASE_URL must be documented alongside DATABASE_PATH."""
+        assert _env_example_has_key("DATABASE_URL")
+
+    def test_env_example_documents_app_env(self) -> None:
+        """APP_ENV must be documented so devs know how to opt into prod checks."""
+        assert _env_example_has_key("APP_ENV")
+
+    def test_env_example_still_documents_anthropic_api_key(self) -> None:
+        """The pre-existing ANTHROPIC_API_KEY line must not regress."""
+        assert _env_example_has_key("ANTHROPIC_API_KEY")
+
+    def test_env_example_still_documents_shared_secret(self) -> None:
+        """The pre-existing RUBOTPAUL_SHARED_SECRET line must not regress."""
+        assert _env_example_has_key("RUBOTPAUL_SHARED_SECRET")
+
+
+# ---------------------------------------------------------------------------
+# Dockerfile must default the runtime stage to production
+# ---------------------------------------------------------------------------
+
+
+class TestDockerfileSetsProductionAppEnv:
+    """The runtime image must default APP_ENV to production."""
+
+    def test_dockerfile_runtime_stage_sets_app_env_production(self) -> None:
+        """An ENV instruction must set APP_ENV=production in the runtime stage."""
+        pattern = re.compile(r"^ENV\s+.*\bAPP_ENV=production\b")
+        lines = DOCKERFILE.read_text().splitlines()
+        assert any(pattern.search(line.strip()) for line in lines)


### PR DESCRIPTION
## Summary

- **Fail fast in production**: `create_app()` now crashes at boot (`RuntimeError`) when `FLASK_SECRET_KEY` or `RUBOTPAUL_SHARED_SECRET` is unset/empty and `APP_ENV=production` (baked into the Dockerfile runtime stage), instead of silently minting a per-worker random session key (~50% session loss under 2+ gunicorn workers) or 500-ing on RubotPaul's first API call. Empty-string secrets are now treated the same as unset (fixes a latent gap in the old `os.environ.get(..., os.urandom(32).hex())` fallback).
- **Loud dev degradation**: without `APP_ENV=production`, a missing `FLASK_SECRET_KEY` still falls back to a random per-process key but logs a warning (sessions won't survive restarts/multiple workers), and a missing `ANTHROPIC_API_KEY` logs a prominent startup warning in all modes (meal parsing degrades to stub/saved-recipe paths). Request-time fail-closed auth is unchanged; the vendored `auth_middleware.py` is untouched.
- **Docs/config parity**: `.env.example` now covers `FLASK_SECRET_KEY`, `DATABASE_URL`, and `APP_ENV`; README documents the fail-fast startup checks, the `APP_ENV` signal, and the dev single-worker caveat.

## Test plan

- New `tests/test_startup_config.py` (23 tests, TDD red-first): production crash on missing/empty `FLASK_SECRET_KEY` and `RUBOTPAUL_SHARED_SECRET`; production boots with all secrets set; env `FLASK_SECRET_KEY` used verbatim in both modes (sessions stable across workers/restarts); dev boots with warning on missing key; dev `/api/v1` still 401s unauthenticated with no secret; `ANTHROPIC_API_KEY` warn-present/absent; guard tests pinning `.env.example` coverage and the Dockerfile's `ENV APP_ENV=production`.
- `./scripts/check-all.sh` exit 0: 1347 passed, 8 skipped (pre-existing Postgres-env skips), 95.74% branch coverage, mypy strict clean, ruff clean, bandit + pip-audit clean, complexity within limits.
- Security-specialist review PASS (no secret values logged, dev fails closed, no auth semantics changed); pre-push self-review CLEAN.

Notes: gunicorn runs the app factory without `--preload`, so a missing production secret crash-loops the workers rather than exiting the master once — acceptance criteria are still met (no request is ever served); a `--preload` follow-up may be worth a separate issue. The no-op `radon mi -a` maintainability gate observed during verification is already tracked in #92.

Closes #64
