### PR TITLE
fix: meal parser 500s on malformed Claude output (unknown category, null confidence)

### DIFF
--- a/grocery_butler/consolidator.py
+++ b/grocery_butler/consolidator.py
@@ -12,7 +12,13 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from grocery_butler.claude_utils import extract_json_text
-from grocery_butler.models import IngredientCategory, ShoppingListItem, Unit, parse_unit
+from grocery_butler.models import (
+    IngredientCategory,
+    ShoppingListItem,
+    Unit,
+    coerce_category,
+    parse_unit,
+)
 from grocery_butler.prompt_loader import load_prompt
 
 if TYPE_CHECKING:
@@ -98,11 +104,7 @@ def _parse_shopping_item(data: dict[str, object]) -> ShoppingListItem:
         [str(m) for m in raw_from_meals] if isinstance(raw_from_meals, list) else []
     )
 
-    raw_category = str(data.get("category", "other"))
-    try:
-        category = IngredientCategory(raw_category)
-    except ValueError:
-        category = IngredientCategory.OTHER
+    category = coerce_category(data.get("category", "other"))
 
     return ShoppingListItem(
         ingredient=str(data.get("ingredient", "")),

--- a/grocery_butler/meal_parser.py
+++ b/grocery_butler/meal_parser.py
@@ -12,7 +12,12 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from grocery_butler.claude_utils import extract_json_text
-from grocery_butler.models import Ingredient, IngredientCategory, ParsedMeal, parse_unit
+from grocery_butler.models import (
+    Ingredient,
+    ParsedMeal,
+    coerce_category,
+    parse_unit,
+)
 from grocery_butler.prompt_loader import load_prompt
 from grocery_butler.recipe_store import RecipeStore, normalize_recipe_name
 
@@ -59,7 +64,7 @@ def _parse_ingredient(data: dict[str, object]) -> Ingredient:
         ingredient=str(data.get("ingredient", "")),
         quantity=quantity,
         unit=parse_unit(str(data.get("unit", ""))),
-        category=IngredientCategory(str(data.get("category", "other"))),
+        category=coerce_category(data.get("category", "other")),
         notes=str(data.get("notes", "")),
         is_pantry_item=bool(data.get("is_pantry_item", False)),
     )
@@ -272,7 +277,10 @@ class MealParser:
             return None
 
         match_name = data.get("match")
-        confidence = float(data.get("confidence", 0))
+        raw_confidence = data.get("confidence", 0)
+        confidence = (
+            float(raw_confidence) if isinstance(raw_confidence, (int, float)) else 0.0
+        )
 
         if match_name is None or confidence < _MATCH_CONFIDENCE_THRESHOLD:
             return None

--- a/grocery_butler/models.py
+++ b/grocery_butler/models.py
@@ -7,10 +7,13 @@ including future Safeway models that aren't used yet.
 from __future__ import annotations
 
 import datetime as dt
+import logging
 from enum import StrEnum
 from typing import Any
 
 from pydantic import BaseModel, field_validator
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Enums
@@ -162,6 +165,48 @@ def parse_unit(raw: str) -> Unit:
     if result is not None:
         return result
     return Unit.EACH
+
+
+def coerce_category(raw: object) -> IngredientCategory:
+    """Coerce a raw value into an IngredientCategory, defaulting to OTHER.
+
+    Handles exact matches (case-insensitive), existing enum members, and
+    ``None``/empty values. Unrecognized strings degrade to
+    ``IngredientCategory.OTHER`` with a warning logged; ``None`` and empty
+    strings degrade silently since they represent "no data" rather than
+    "bad data".
+
+    Args:
+        raw: Raw category value from LLM output, database, or user input.
+
+    Returns:
+        Matching IngredientCategory enum member, or OTHER if unrecognized.
+    """
+    if isinstance(raw, IngredientCategory):
+        return raw
+    text = "" if raw is None else str(raw).strip().lower()
+    if not text:
+        return IngredientCategory.OTHER
+    try:
+        return IngredientCategory(text)
+    except ValueError:
+        logger.warning("Unknown ingredient category %r; using OTHER", raw)
+        return IngredientCategory.OTHER
+
+
+def coerce_category_optional(raw: object) -> IngredientCategory | None:
+    """Coerce a raw value into an IngredientCategory, preserving None.
+
+    Args:
+        raw: Raw category value, or None.
+
+    Returns:
+        Matching IngredientCategory enum member, None if input was None,
+        or OTHER if the input was a non-None, unrecognized value.
+    """
+    if raw is None:
+        return None
+    return coerce_category(raw)
 
 
 def _coerce_unit(v: object) -> Unit:

--- a/grocery_butler/pantry_manager.py
+++ b/grocery_butler/pantry_manager.py
@@ -16,7 +16,12 @@ from datetime import UTC, datetime
 from typing import Any, Protocol
 
 from grocery_butler.db import get_connection, init_db
-from grocery_butler.models import InventoryItem, InventoryStatus, InventoryUpdate
+from grocery_butler.models import (
+    InventoryItem,
+    InventoryStatus,
+    InventoryUpdate,
+    coerce_category_optional,
+)
 from grocery_butler.prompt_loader import load_prompt
 
 logger = logging.getLogger(__name__)
@@ -348,7 +353,7 @@ def _row_to_item(row: Any) -> InventoryItem:
     return InventoryItem(
         ingredient=row["ingredient"],
         display_name=row["display_name"],
-        category=row["category"],
+        category=coerce_category_optional(row["category"]),
         status=row["status"],
         current_quantity=row["current_quantity"],
         current_unit=row["current_unit"],

--- a/tests/test_meal_parser.py
+++ b/tests/test_meal_parser.py
@@ -968,6 +968,160 @@ class TestRetryOnApiError:
         assert results[0].purchase_items == []
 
 
+class TestMalformedCategoryDegradation:
+    """Tests for graceful degradation on malformed category data (Issue #68).
+
+    Claude's JSON output occasionally contains an ``category`` value that
+    is not one of the known ``IngredientCategory`` members (e.g. "spices")
+    or is ``null``. Today ``_parse_ingredient`` calls
+    ``IngredientCategory(str(data.get("category", "other")))`` directly,
+    which raises ``ValueError`` and escapes
+    ``_parse_decomposition_response``'s try/except, producing a 500 on
+    ``POST /api/v1/meals/parse``. These tests should drive
+    ``_parse_ingredient`` to use ``coerce_category`` instead.
+    """
+
+    def test_parse_ingredient_unknown_category_returns_other(self):
+        """Test _parse_ingredient degrades an unknown category to OTHER."""
+        data: dict[str, object] = {
+            "ingredient": "cumin",
+            "quantity": 1.0,
+            "unit": "tsp",
+            "category": "spices",
+        }
+        result = _parse_ingredient(data)
+        assert result.category == IngredientCategory.OTHER
+
+    def test_decompose_meal_unknown_category_degrades_to_other(
+        self, store: RecipeStore, mock_client: MagicMock
+    ):
+        """Test an unknown purchase-item category doesn't crash decomposition."""
+        decomp_json = json.dumps(
+            [
+                {
+                    "name": "Taco Night",
+                    "servings": 4,
+                    "known_recipe": False,
+                    "needs_confirmation": True,
+                    "purchase_items": [
+                        {
+                            "ingredient": "cumin",
+                            "quantity": 1,
+                            "unit": "tsp",
+                            "category": "spices",
+                        },
+                    ],
+                    "pantry_items": [],
+                }
+            ]
+        )
+        mock_client.messages.create.return_value = _make_claude_response(decomp_json)
+        parser = MealParser(store, anthropic_client=mock_client)
+
+        results = parser.parse_meals(["Taco Night"])
+
+        assert len(results) == 1
+        meal = results[0]
+        assert isinstance(meal, ParsedMeal)
+        assert len(meal.purchase_items) == 1
+        assert meal.purchase_items[0].category == IngredientCategory.OTHER
+
+    def test_decompose_meal_null_category_degrades_to_other(
+        self, store: RecipeStore, mock_client: MagicMock
+    ):
+        """Test a null purchase-item category doesn't crash decomposition."""
+        decomp_json = json.dumps(
+            [
+                {
+                    "name": "Taco Night",
+                    "servings": 4,
+                    "known_recipe": False,
+                    "needs_confirmation": True,
+                    "purchase_items": [
+                        {
+                            "ingredient": "cumin",
+                            "quantity": 1,
+                            "unit": "tsp",
+                            "category": None,
+                        },
+                    ],
+                    "pantry_items": [],
+                }
+            ]
+        )
+        mock_client.messages.create.return_value = _make_claude_response(decomp_json)
+        parser = MealParser(store, anthropic_client=mock_client)
+
+        results = parser.parse_meals(["Taco Night"])
+
+        assert len(results) == 1
+        meal = results[0]
+        assert isinstance(meal, ParsedMeal)
+        assert len(meal.purchase_items) == 1
+        assert meal.purchase_items[0].category == IngredientCategory.OTHER
+
+
+class TestFuzzyMatchMalformedConfidence:
+    """Tests for graceful degradation on malformed confidence data (Issue #68).
+
+    Claude's fuzzy-match JSON occasionally has a ``confidence`` value that
+    is not numeric (``null`` or a string like ``"high"``). Today
+    ``_parse_fuzzy_match_response`` calls
+    ``float(data.get("confidence", 0))`` directly, which raises
+    ``TypeError`` on ``None`` and ``ValueError`` on non-numeric strings.
+    These tests should drive the fix to use the repo's isinstance-numeric
+    idiom (non-numeric -> 0.0, which falls below the 0.6 threshold).
+    """
+
+    def test_fuzzy_match_null_confidence_returns_none(
+        self, store: RecipeStore, sample_meal: ParsedMeal, mock_client: MagicMock
+    ):
+        """Test a null confidence value does not raise and yields no match."""
+        store.save_recipe(sample_meal)
+        match_response = json.dumps({"match": "Chicken Tacos", "confidence": None})
+        decomp_response = _valid_decomposition_json(name="Chicken Tacos But Weird")
+        mock_client.messages.create.side_effect = [
+            _make_claude_response(match_response),
+            _make_claude_response(decomp_response),
+        ]
+        parser = MealParser(store, anthropic_client=mock_client)
+
+        results = parser.parse_meals(["chicken tacos but weird"])
+
+        assert results[0].needs_confirmation is True
+
+    def test_fuzzy_match_string_confidence_returns_none(
+        self, store: RecipeStore, sample_meal: ParsedMeal, mock_client: MagicMock
+    ):
+        """Test a non-numeric confidence value does not raise and no-matches."""
+        store.save_recipe(sample_meal)
+        match_response = json.dumps({"match": "Chicken Tacos", "confidence": "high"})
+        decomp_response = _valid_decomposition_json(name="Chicken Tacos But Weird")
+        mock_client.messages.create.side_effect = [
+            _make_claude_response(match_response),
+            _make_claude_response(decomp_response),
+        ]
+        parser = MealParser(store, anthropic_client=mock_client)
+
+        results = parser.parse_meals(["chicken tacos but weird"])
+
+        assert results[0].needs_confirmation is True
+
+    def test_fuzzy_match_valid_confidence_still_matches(
+        self, store: RecipeStore, sample_meal: ParsedMeal, mock_client: MagicMock
+    ):
+        """Regression guard: a valid numeric confidence still matches."""
+        store.save_recipe(sample_meal)
+        match_response = json.dumps({"match": "Chicken Tacos", "confidence": 0.9})
+        mock_client.messages.create.return_value = _make_claude_response(match_response)
+        parser = MealParser(store, anthropic_client=mock_client)
+
+        results = parser.parse_meals(["tacos with chicken"])
+
+        assert results[0].name == "Chicken Tacos"
+        assert results[0].known_recipe is True
+
+
 class TestFuzzyMatchWithNoClient:
     """Tests for fuzzy matching behavior without a client."""
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 from pydantic import ValidationError
 
@@ -29,6 +31,8 @@ from grocery_butler.models import (
     Unit,
     _coerce_unit,
     _coerce_unit_optional,
+    coerce_category,
+    coerce_category_optional,
     parse_unit,
 )
 
@@ -283,6 +287,58 @@ class TestCoerceUnitOptional:
     def test_exact_string_normalized(self) -> None:
         """Test exact unit strings are resolved."""
         assert _coerce_unit_optional("gal") == Unit.GAL
+
+
+class TestCoerceCategory:
+    """Tests for the coerce_category module-level helper (Issue #68)."""
+
+    def test_known_value_returns_enum(self) -> None:
+        """Test a known category string maps to its enum member."""
+        assert coerce_category("produce") == IngredientCategory.PRODUCE
+
+    def test_unknown_value_returns_other(self) -> None:
+        """Test an unrecognized category string degrades to OTHER."""
+        assert coerce_category("spices") == IngredientCategory.OTHER
+
+    def test_unknown_value_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Test an unrecognized category string logs a WARNING mentioning it."""
+        with caplog.at_level(logging.WARNING, logger="grocery_butler.models"):
+            coerce_category("spices")
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert "spices" in warnings[0].message
+
+    def test_none_returns_other(self) -> None:
+        """Test None input degrades to OTHER."""
+        assert coerce_category(None) == IngredientCategory.OTHER
+
+    def test_empty_string_returns_other_silently(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Test an empty string degrades to OTHER without logging a WARNING."""
+        with caplog.at_level(logging.WARNING, logger="grocery_butler.models"):
+            result = coerce_category("")
+
+        assert result == IngredientCategory.OTHER
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings == []
+
+    def test_existing_enum_passthrough(self) -> None:
+        """Test an existing IngredientCategory member passes through unchanged."""
+        assert coerce_category(IngredientCategory.MEAT) == IngredientCategory.MEAT
+
+
+class TestCoerceCategoryOptional:
+    """Tests for the coerce_category_optional module-level helper (Issue #68)."""
+
+    def test_none_returns_none(self) -> None:
+        """Test None input is preserved as None (not coerced to OTHER)."""
+        assert coerce_category_optional(None) is None
+
+    def test_invalid_returns_other(self) -> None:
+        """Test an invalid category string degrades to OTHER."""
+        assert coerce_category_optional("legacy_snacks") == IngredientCategory.OTHER
 
 
 class TestUnitValidatorOnModels:

--- a/tests/test_pantry_manager.py
+++ b/tests/test_pantry_manager.py
@@ -20,6 +20,7 @@ from grocery_butler.pantry_manager import (
     PantryManager,
     _format_inventory_context,
     _parse_claude_response,
+    _row_to_item,
 )
 
 # ---------------------------------------------------------------------------
@@ -779,6 +780,60 @@ class TestParseInventoryIntent:
         messages = call_args.kwargs["messages"]
         prompt_text = messages[0]["content"]
         assert "Milk" in prompt_text
+
+
+# ---------------------------------------------------------------------------
+# TestRowToItem
+# ---------------------------------------------------------------------------
+
+
+class TestRowToItem:
+    """Tests for the _row_to_item helper (Issue #68).
+
+    Legacy or malformed ``category`` values stored in the database (e.g.
+    from an older schema, or a category IngredientCategory has since
+    dropped) must not crash inventory reads with a pydantic
+    ``ValidationError``. ``_row_to_item`` should degrade unknown category
+    strings to ``OTHER`` while preserving ``None`` as ``None``.
+    """
+
+    def test_invalid_category_falls_back_to_other(self) -> None:
+        """Test an unrecognized category string degrades to OTHER."""
+        row = {
+            "ingredient": "legacy stuff",
+            "display_name": "Legacy Stuff",
+            "category": "legacy_snacks",
+            "status": "on_hand",
+            "current_quantity": None,
+            "current_unit": None,
+            "default_quantity": None,
+            "default_unit": None,
+            "default_search_term": None,
+            "notes": None,
+        }
+
+        item = _row_to_item(row)
+
+        assert item.category == IngredientCategory.OTHER
+
+    def test_null_category_preserved_as_none(self) -> None:
+        """Regression guard: a null category row stays None (not OTHER)."""
+        row = {
+            "ingredient": "mystery spice",
+            "display_name": "Mystery Spice",
+            "category": None,
+            "status": "on_hand",
+            "current_quantity": None,
+            "current_unit": None,
+            "default_quantity": None,
+            "default_unit": None,
+            "default_search_term": None,
+            "notes": None,
+        }
+
+        item = _row_to_item(row)
+
+        assert item.category is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Fixes two 500s on `POST /api/v1/meals/parse` from malformed-but-JSON-valid Claude output: unknown ingredient category (e.g. `"spices"`) raised an uncaught `ValueError` in `_parse_ingredient`, and `{"confidence": null}` (or a non-numeric string) raised `TypeError`/`ValueError` in `_parse_fuzzy_match_response`.
- Adds `coerce_category` / `coerce_category_optional` helpers in `models.py` (mirroring the existing `parse_unit` fallback pattern): unknown values degrade to `IngredientCategory.OTHER` with a warning log, `None`/empty degrade silently, and `None` is preserved by the optional variant. `pantry_manager._row_to_item` now uses the optional variant so a legacy/invalid DB category no longer 500s `GET /api/v1/inventory`.
- Refactors `consolidator._parse_shopping_item`'s hand-rolled try/except category fallback onto the shared helper (DRY; consolidator now also logs the warning).

Scope note: this PR intentionally does not touch `app.py`/route logic (owned by the concurrent #66 lane) and adds no Pydantic field validators — the fix is surgical, at the exact call sites named in the issue.

## Test plan

- New failing-first tests (TDD, all reproduced the original crashes before the fix):
  - `tests/test_models.py::TestCoerceCategory` / `TestCoerceCategoryOptional` — known/unknown/None/empty/enum-passthrough behavior plus warning-log presence/absence.
  - `tests/test_meal_parser.py::TestMalformedCategoryDegradation` — `"spices"` and `null` categories through `parse_meals` end-to-end (previously `ValueError`).
  - `tests/test_meal_parser.py::TestFuzzyMatchMalformedConfidence` — `null` and `"high"` confidence (previously `TypeError`/`ValueError`), plus a valid-confidence regression guard.
  - `tests/test_pantry_manager.py::TestRowToItem` — invalid DB category degrades to `OTHER` (previously `ValidationError`); `None` category preserved as `None`.
- `./scripts/check-all.sh` exit 0: 1457 passed, 8 skipped (Postgres-only), coverage 95.86% (threshold 90%), ruff/mypy/bandit/complexity all clean; interrogate docstring coverage 99.5% (threshold 95%).

Closes #68
