### PR TITLE
fix(consolidator): merge quantities by unit dimension, stop silent each-coercion

### DIFF
--- a/grocery_butler/consolidator.py
+++ b/grocery_butler/consolidator.py
@@ -14,10 +14,11 @@ from typing import TYPE_CHECKING, Any
 from grocery_butler.claude_utils import extract_json_text
 from grocery_butler.models import IngredientCategory, ShoppingListItem, Unit, parse_unit
 from grocery_butler.prompt_loader import load_prompt
+from grocery_butler.units import convert, dimension_of
 
 if TYPE_CHECKING:
     from grocery_butler.config import Config
-    from grocery_butler.models import InventoryItem, ParsedMeal
+    from grocery_butler.models import Ingredient, InventoryItem, ParsedMeal
 
 logger = logging.getLogger(__name__)
 
@@ -190,8 +191,9 @@ class Consolidator:
     """Consolidates meal ingredients into a unified shopping list.
 
     Uses Claude API to intelligently merge quantities, handle unit
-    conversions, and exclude pantry staples. Falls back to pure-Python
-    dedup when no API client is available.
+    conversions, and exclude pantry staples. Falls back to a pure-Python,
+    dimension-aware merge (see :meth:`consolidate_simple`) when no API
+    client is available.
     """
 
     def __init__(
@@ -286,8 +288,14 @@ class Consolidator:
     ) -> list[ShoppingListItem]:
         """Pure-Python fallback consolidation without Claude.
 
-        Performs basic dedup and quantity summing. Used when the API
-        is unavailable or in tests.
+        Performs dimension-aware merging: ingredients sharing a name and a
+        compatible unit (same physical dimension -- mass, volume, or count)
+        have their quantities converted to a common unit and summed into a
+        single line item. Ingredients with incompatible units (e.g. a
+        packaging unit like "jar" vs. "can", or a dimensioned unit vs. a
+        packaging unit) are kept as separate line items rather than being
+        naively added together. Used when the API is unavailable or in
+        tests.
 
         Args:
             meals: List of parsed meals with ingredient lists.
@@ -295,7 +303,7 @@ class Consolidator:
             pantry_staples: Names of pantry staple ingredients.
 
         Returns:
-            Consolidated shopping list with basic merging.
+            Consolidated shopping list with unit-aware merging.
         """
         pantry_lower = {s.lower() for s in pantry_staples}
         merged = self._merge_meal_ingredients(meals, pantry_lower)
@@ -309,32 +317,87 @@ class Consolidator:
     # ------------------------------------------------------------------
 
     @staticmethod
+    def _ingredient_group_key(ingredient: str, unit: Unit) -> tuple[str, str]:
+        """Build the composite merge key for an ingredient/unit pairing.
+
+        Units with a fixed physical dimension (mass, volume, count) are
+        grouped by dimension so compatible units (e.g. cup and gallon) merge
+        into a single line item. Packaging/"other" units with no fixed
+        dimension are grouped by their exact unit instead, so incompatible
+        packaging (e.g. jar vs. can) stays split into separate line items.
+
+        Args:
+            ingredient: Raw ingredient name (not yet lowercased).
+            unit: The ingredient's parsed unit.
+
+        Returns:
+            A ``(ingredient_lower, group_token)`` tuple suitable for use as
+            a merge dict key.
+        """
+        dimension = dimension_of(unit)
+        if dimension is not None:
+            return (ingredient.lower(), f"dim:{dimension.value}")
+        return (ingredient.lower(), f"unit:{unit.value}")
+
+    @staticmethod
+    def _merge_quantity(entry: dict[str, object], item: Ingredient) -> None:
+        """Add an ingredient's quantity into an existing merge entry in place.
+
+        Converts ``item.quantity`` from ``item.unit`` into the entry's
+        canonical unit before summing, so dimensionally compatible units
+        (e.g. cups and gallons) combine correctly. If the units turn out to
+        be incomparable (``convert`` returns ``None`` -- unreachable in
+        normal orchestration since entries only share a group key when
+        their units are compatible, but guarded defensively), falls back to
+        adding the raw quantities unconverted.
+
+        Args:
+            entry: The existing merge entry to update in place. Expected to
+                hold ``"quantity"`` (a number) and ``"unit"`` (a ``Unit``).
+            item: The ingredient whose quantity is being merged in.
+
+        Returns:
+            None. ``entry["quantity"]`` is updated in place.
+        """
+        raw_qty = entry.get("quantity", 0.0)
+        current_qty = float(raw_qty) if isinstance(raw_qty, (int, float)) else 0.0
+
+        raw_unit = entry.get("unit")
+        canonical_unit = raw_unit if isinstance(raw_unit, Unit) else Unit.EACH
+
+        converted = convert(item.quantity, item.unit, canonical_unit)
+        addition = converted if converted is not None else item.quantity
+        entry["quantity"] = current_qty + addition
+
+    @staticmethod
     def _merge_meal_ingredients(
         meals: list[ParsedMeal],
         pantry_lower: set[str],
-    ) -> dict[str, dict[str, object]]:
+    ) -> dict[tuple[str, str], dict[str, object]]:
         """Merge ingredient quantities across meals, excluding pantry staples.
+
+        Ingredients are grouped by ``(ingredient_lower, group_token)`` via
+        :meth:`_ingredient_group_key` so unit conversion only ever combines
+        dimensionally compatible quantities; incompatible units for the same
+        ingredient are kept as separate line items.
 
         Args:
             meals: List of parsed meals.
             pantry_lower: Lowercased pantry staple names to exclude.
 
         Returns:
-            Dict keyed by ingredient name with merged data.
+            Dict keyed by ``(ingredient_lower, group_token)`` with merged
+            data.
         """
-        merged: dict[str, dict[str, object]] = {}
+        merged: dict[tuple[str, str], dict[str, object]] = {}
         for meal in meals:
             for item in meal.purchase_items:
-                key = item.ingredient.lower()
-                if key in pantry_lower:
+                if item.ingredient.lower() in pantry_lower:
                     continue
+                key = Consolidator._ingredient_group_key(item.ingredient, item.unit)
                 if key in merged:
                     entry = merged[key]
-                    raw_qty = entry.get("quantity", 0.0)
-                    current_qty = (
-                        float(raw_qty) if isinstance(raw_qty, (int, float)) else 0.0
-                    )
-                    entry["quantity"] = current_qty + item.quantity
+                    Consolidator._merge_quantity(entry, item)
                     raw_meals = entry.get("from_meals", [])
                     from_meals_list: list[str] = (
                         list(raw_meals) if isinstance(raw_meals, list) else []
@@ -354,12 +417,13 @@ class Consolidator:
 
     @staticmethod
     def _build_items_from_merged(
-        merged: dict[str, dict[str, object]],
+        merged: dict[tuple[str, str], dict[str, object]],
     ) -> list[ShoppingListItem]:
         """Convert merged ingredient dict into ShoppingListItem list.
 
         Args:
-            merged: Dict keyed by ingredient name with merged data.
+            merged: Dict keyed by ``(ingredient_lower, group_token)`` with
+                merged data.
 
         Returns:
             List of ShoppingListItem instances.

--- a/grocery_butler/models.py
+++ b/grocery_butler/models.py
@@ -7,10 +7,13 @@ including future Safeway models that aren't used yet.
 from __future__ import annotations
 
 import datetime as dt
+import logging
 from enum import StrEnum
 from typing import Any
 
 from pydantic import BaseModel, field_validator
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Enums
@@ -64,6 +67,8 @@ class Unit(StrEnum):
     ML = "ml"
     L = "l"
     GAL = "gal"
+    PINT = "pint"
+    QUART = "quart"
 
     # Weight
     OZ = "oz"
@@ -87,6 +92,7 @@ class Unit(StrEnum):
     BOTTLE = "bottle"
     PACKAGE = "package"
     BLOCK = "block"
+    STICK = "stick"
 
     # Other
     PINCH = "pinch"
@@ -120,6 +126,10 @@ _UNIT_ALIASES: dict[str, Unit] = {
     "liters": Unit.L,
     "gallon": Unit.GAL,
     "gallons": Unit.GAL,
+    "pints": Unit.PINT,
+    "pt": Unit.PINT,
+    "quarts": Unit.QUART,
+    "qt": Unit.QUART,
     # Count plurals
     "piece": Unit.EACH,
     "pieces": Unit.EACH,
@@ -136,6 +146,7 @@ _UNIT_ALIASES: dict[str, Unit] = {
     "packages": Unit.PACKAGE,
     "pkg": Unit.PACKAGE,
     "blocks": Unit.BLOCK,
+    "sticks": Unit.STICK,
 }
 
 
@@ -143,7 +154,10 @@ def parse_unit(raw: str) -> Unit:
     """Parse a raw unit string into a Unit enum member.
 
     Handles exact matches, aliases, and case-insensitive lookup.
-    Falls back to Unit.EACH for unrecognized strings.
+    Falls back to Unit.EACH for unrecognized strings, emitting a WARNING
+    log with the raw token so silent unit rewrites are detectable
+    (issue #69). Empty or blank input also falls back to Unit.EACH but
+    stays silent, since a missing unit is a legitimate default.
 
     Args:
         raw: Raw unit string from LLM output, database, or user input.
@@ -161,6 +175,7 @@ def parse_unit(raw: str) -> Unit:
     result = _UNIT_ALIASES.get(cleaned)
     if result is not None:
         return result
+    logger.warning("parse_unit: unknown unit %r; falling back to Unit.EACH", raw)
     return Unit.EACH
 
 

--- a/grocery_butler/units.py
+++ b/grocery_butler/units.py
@@ -55,6 +55,8 @@ _VOLUME_FACTORS_ML: dict[Unit, float] = {
     Unit.FL_OZ: 29.5735296,
     Unit.CUP: 236.588237,
     Unit.GAL: 3785.411784,
+    Unit.PINT: 473.176473,
+    Unit.QUART: 946.352946,
 }
 
 # Count units, expressed as each-per-unit.
@@ -63,10 +65,10 @@ _COUNT_FACTORS_EACH: dict[Unit, float] = {
     Unit.DOZEN: 12.0,
 }
 
-# Packaging/"other" units (bag, can, box, jar, bottle, package, block, pinch,
-# dash, to_taste, bunch, head, clove, slice) are deliberately absent: they
-# carry no fixed physical size, so they are non-convertible and classify as
-# dimensionless (``dimension_of`` returns ``None``).
+# Packaging/"other" units (bag, can, box, jar, bottle, package, block, stick,
+# pinch, dash, to_taste, bunch, head, clove, slice) are deliberately absent:
+# they carry no fixed physical size, so they are non-convertible and
+# classify as dimensionless (``dimension_of`` returns ``None``).
 
 _DIMENSION_TABLE: dict[Unit, tuple[Dimension, float]] = {
     **{unit: (Dimension.MASS, factor) for unit, factor in _MASS_FACTORS_G.items()},

--- a/tests/test_consolidator.py
+++ b/tests/test_consolidator.py
@@ -25,6 +25,7 @@ from grocery_butler.models import (
     InventoryStatus,
     ParsedMeal,
     ShoppingListItem,
+    Unit,
 )
 
 # ---------------------------------------------------------------------------
@@ -1062,18 +1063,27 @@ class TestMergeAndBuildHelpers:
         sample_tacos_meal: ParsedMeal,
         sample_tikka_meal: ParsedMeal,
     ):
-        """Test _merge_meal_ingredients deduplicates same ingredient."""
+        """Test _merge_meal_ingredients deduplicates same ingredient+unit group.
+
+        Post-fix, merged keys are composite ``(ingredient_lower, group_token)``
+        tuples rather than plain ingredient-name strings (issue #69).
+        """
         merged = Consolidator._merge_meal_ingredients(
             [sample_tacos_meal, sample_tikka_meal],
             set(),
         )
-        assert "lime" in merged
-        raw_qty = merged["lime"].get("quantity", 0.0)
+        key = ("lime", "dim:count")
+        assert key in merged
+        raw_qty = merged[key].get("quantity", 0.0)
         qty = float(raw_qty) if isinstance(raw_qty, (int, float)) else 0.0
         assert qty == 3.0
 
     def test_merge_excludes_pantry(self, sample_tacos_meal: ParsedMeal):
-        """Test pantry items excluded from merged result."""
+        """Test pantry items excluded from merged result via composite key.
+
+        Post-fix, membership must be checked via the ingredient-name element
+        of the composite ``(ingredient_lower, group_token)`` key (issue #69).
+        """
         # "olive oil" is in purchase_items but we pass it as pantry
         meal = ParsedMeal(
             name="Test",
@@ -1100,8 +1110,8 @@ class TestMergeAndBuildHelpers:
             [meal],
             {"olive oil"},
         )
-        assert "olive oil" not in merged
-        assert "chicken" in merged
+        assert not any(k[0] == "olive oil" for k in merged)
+        assert any(k[0] == "chicken" for k in merged)
 
     def test_build_items_from_merged(self):
         """Test _build_items_from_merged produces ShoppingListItem list."""
@@ -1124,3 +1134,340 @@ class TestMergeAndBuildHelpers:
         result = Consolidator._build_restock_items(sample_restock_queue)
         assert len(result) == 2
         assert all("restock" in i.from_meals for i in result)
+
+
+# ---------------------------------------------------------------------------
+# Unit-aware merge tests (issue #69: dimensional-quantity consolidation bug)
+#
+# Current buggy behavior: _merge_meal_ingredients sums raw quantities across
+# ALL units for a given ingredient name and keeps whichever unit was seen
+# first, producing nonsensical totals (e.g. "milk 1 cup + 1 gal" -> "2 cup").
+# These tests assert the post-fix, dimension-aware behavior and are expected
+# to FAIL against the current implementation.
+# ---------------------------------------------------------------------------
+
+
+class TestConsolidateSimpleUnitAwareMerging:
+    """Tests for dimension-aware quantity merging (issue #69 regression)."""
+
+    def test_volume_units_converted_and_summed(self) -> None:
+        """Test milk 1 cup + 1 gal merges to 17 cups (not naive sum of 2)."""
+        meal_a = ParsedMeal(
+            name="Cereal",
+            servings=2,
+            known_recipe=True,
+            needs_confirmation=False,
+            purchase_items=[
+                Ingredient(
+                    ingredient="milk",
+                    quantity=1.0,
+                    unit="cup",
+                    category=IngredientCategory.DAIRY,
+                ),
+            ],
+            pantry_items=[],
+        )
+        meal_b = ParsedMeal(
+            name="Milkshake",
+            servings=2,
+            known_recipe=True,
+            needs_confirmation=False,
+            purchase_items=[
+                Ingredient(
+                    ingredient="milk",
+                    quantity=1.0,
+                    unit="gal",
+                    category=IngredientCategory.DAIRY,
+                ),
+            ],
+            pantry_items=[],
+        )
+        consolidator = Consolidator()
+        result = consolidator.consolidate_simple([meal_a, meal_b], [], [])
+        milk_items = [i for i in result if i.ingredient == "milk"]
+        assert len(milk_items) == 1
+        assert milk_items[0].quantity == pytest.approx(17.0)
+        assert milk_items[0].unit == Unit.CUP
+
+    def test_mass_units_converted_and_summed(self) -> None:
+        """Test chicken 1 lb + 8 oz merges to 1.5 lb (canonical first-seen unit)."""
+        meal_a = ParsedMeal(
+            name="Grilled Chicken",
+            servings=2,
+            known_recipe=True,
+            needs_confirmation=False,
+            purchase_items=[
+                Ingredient(
+                    ingredient="chicken",
+                    quantity=1.0,
+                    unit="lb",
+                    category=IngredientCategory.MEAT,
+                ),
+            ],
+            pantry_items=[],
+        )
+        meal_b = ParsedMeal(
+            name="Chicken Soup",
+            servings=2,
+            known_recipe=True,
+            needs_confirmation=False,
+            purchase_items=[
+                Ingredient(
+                    ingredient="chicken",
+                    quantity=8.0,
+                    unit="oz",
+                    category=IngredientCategory.MEAT,
+                ),
+            ],
+            pantry_items=[],
+        )
+        consolidator = Consolidator()
+        result = consolidator.consolidate_simple([meal_a, meal_b], [], [])
+        chicken_items = [i for i in result if i.ingredient == "chicken"]
+        assert len(chicken_items) == 1
+        assert chicken_items[0].quantity == pytest.approx(1.5)
+        assert chicken_items[0].unit == Unit.LB
+
+    def test_count_units_converted_and_summed(self) -> None:
+        """Test eggs 1 dozen + 6 each merges to 1.5 dozen (first-seen unit)."""
+        meal_a = ParsedMeal(
+            name="Omelette",
+            servings=2,
+            known_recipe=True,
+            needs_confirmation=False,
+            purchase_items=[
+                Ingredient(
+                    ingredient="eggs",
+                    quantity=1.0,
+                    unit="dozen",
+                    category=IngredientCategory.DAIRY,
+                ),
+            ],
+            pantry_items=[],
+        )
+        meal_b = ParsedMeal(
+            name="Baking",
+            servings=2,
+            known_recipe=True,
+            needs_confirmation=False,
+            purchase_items=[
+                Ingredient(
+                    ingredient="eggs",
+                    quantity=6.0,
+                    unit="each",
+                    category=IngredientCategory.DAIRY,
+                ),
+            ],
+            pantry_items=[],
+        )
+        consolidator = Consolidator()
+        result = consolidator.consolidate_simple([meal_a, meal_b], [], [])
+        egg_items = [i for i in result if i.ingredient == "eggs"]
+        assert len(egg_items) == 1
+        assert egg_items[0].quantity == pytest.approx(1.5)
+        assert egg_items[0].unit == Unit.DOZEN
+
+    def test_packaging_same_unit_merges(self) -> None:
+        """Test sauce 1 jar + 1 jar merges into a single 2-jar line item.
+
+        This is a same-unit merge that should hold both before and after
+        the fix -- included as a regression guard alongside the new
+        dimension-aware split behavior.
+        """
+        meal_a = ParsedMeal(
+            name="Pasta Night",
+            servings=2,
+            known_recipe=True,
+            needs_confirmation=False,
+            purchase_items=[
+                Ingredient(
+                    ingredient="sauce",
+                    quantity=1.0,
+                    unit="jar",
+                    category=IngredientCategory.PANTRY_DRY,
+                ),
+            ],
+            pantry_items=[],
+        )
+        meal_b = ParsedMeal(
+            name="Pizza Night",
+            servings=2,
+            known_recipe=True,
+            needs_confirmation=False,
+            purchase_items=[
+                Ingredient(
+                    ingredient="sauce",
+                    quantity=1.0,
+                    unit="jar",
+                    category=IngredientCategory.PANTRY_DRY,
+                ),
+            ],
+            pantry_items=[],
+        )
+        consolidator = Consolidator()
+        result = consolidator.consolidate_simple([meal_a, meal_b], [], [])
+        sauce_items = [i for i in result if i.ingredient == "sauce"]
+        assert len(sauce_items) == 1
+        assert sauce_items[0].quantity == 2.0
+        assert sauce_items[0].unit == Unit.JAR
+
+    def test_packaging_different_units_stay_separate(self) -> None:
+        """Test sauce 1 jar + 1 can stay as two distinct line items."""
+        meal_a = ParsedMeal(
+            name="Pasta Night",
+            servings=2,
+            known_recipe=True,
+            needs_confirmation=False,
+            purchase_items=[
+                Ingredient(
+                    ingredient="sauce",
+                    quantity=1.0,
+                    unit="jar",
+                    category=IngredientCategory.PANTRY_DRY,
+                ),
+            ],
+            pantry_items=[],
+        )
+        meal_b = ParsedMeal(
+            name="Soup Night",
+            servings=2,
+            known_recipe=True,
+            needs_confirmation=False,
+            purchase_items=[
+                Ingredient(
+                    ingredient="sauce",
+                    quantity=1.0,
+                    unit="can",
+                    category=IngredientCategory.PANTRY_DRY,
+                ),
+            ],
+            pantry_items=[],
+        )
+        consolidator = Consolidator()
+        result = consolidator.consolidate_simple([meal_a, meal_b], [], [])
+        sauce_items = [i for i in result if i.ingredient == "sauce"]
+        assert len(sauce_items) == 2
+
+    def test_dimensioned_vs_packaging_unit_stays_separate(self) -> None:
+        """Test milk 1 cup + milk 1 jar stay as two distinct line items."""
+        meal_a = ParsedMeal(
+            name="Cereal",
+            servings=2,
+            known_recipe=True,
+            needs_confirmation=False,
+            purchase_items=[
+                Ingredient(
+                    ingredient="milk",
+                    quantity=1.0,
+                    unit="cup",
+                    category=IngredientCategory.DAIRY,
+                ),
+            ],
+            pantry_items=[],
+        )
+        meal_b = ParsedMeal(
+            name="Sauce Base",
+            servings=2,
+            known_recipe=True,
+            needs_confirmation=False,
+            purchase_items=[
+                Ingredient(
+                    ingredient="milk",
+                    quantity=1.0,
+                    unit="jar",
+                    category=IngredientCategory.DAIRY,
+                ),
+            ],
+            pantry_items=[],
+        )
+        consolidator = Consolidator()
+        result = consolidator.consolidate_simple([meal_a, meal_b], [], [])
+        milk_items = [i for i in result if i.ingredient == "milk"]
+        assert len(milk_items) == 2
+
+    def test_from_meals_tracked_per_split_line(self) -> None:
+        """Test from_meals is scoped per split line, not merged globally.
+
+        Meal A contributes milk in cups, meal B contributes milk in jars.
+        Post-fix these are two distinct line items, each with only its
+        contributing meal in ``from_meals``.
+        """
+        meal_a = ParsedMeal(
+            name="Cereal",
+            servings=2,
+            known_recipe=True,
+            needs_confirmation=False,
+            purchase_items=[
+                Ingredient(
+                    ingredient="milk",
+                    quantity=1.0,
+                    unit="cup",
+                    category=IngredientCategory.DAIRY,
+                ),
+            ],
+            pantry_items=[],
+        )
+        meal_b = ParsedMeal(
+            name="Sauce Base",
+            servings=2,
+            known_recipe=True,
+            needs_confirmation=False,
+            purchase_items=[
+                Ingredient(
+                    ingredient="milk",
+                    quantity=1.0,
+                    unit="jar",
+                    category=IngredientCategory.DAIRY,
+                ),
+            ],
+            pantry_items=[],
+        )
+        consolidator = Consolidator()
+        result = consolidator.consolidate_simple([meal_a, meal_b], [], [])
+        cup_items = [i for i in result if i.ingredient == "milk" and i.unit == Unit.CUP]
+        jar_items = [i for i in result if i.ingredient == "milk" and i.unit == Unit.JAR]
+        assert len(cup_items) == 1
+        assert len(jar_items) == 1
+        assert cup_items[0].from_meals == ["Cereal"]
+        assert jar_items[0].from_meals == ["Sauce Base"]
+
+
+class TestMergeHelperDirect:
+    """Direct tests for the planned unit-aware merge helper methods.
+
+    ``_ingredient_group_key`` and ``_merge_quantity`` do not exist yet on
+    the current ``Consolidator`` implementation, so these tests are
+    expected to fail with ``AttributeError`` until issue #69 is fixed.
+    """
+
+    def test_ingredient_group_key_dimensioned_unit(self) -> None:
+        """Test _ingredient_group_key groups dimensioned units by dimension."""
+        assert Consolidator._ingredient_group_key("Milk", Unit.CUP) == (
+            "milk",
+            "dim:volume",
+        )
+
+    def test_ingredient_group_key_packaging_unit(self) -> None:
+        """Test _ingredient_group_key groups packaging units by exact unit."""
+        assert Consolidator._ingredient_group_key("Sauce", Unit.JAR) == (
+            "sauce",
+            "unit:jar",
+        )
+
+    def test_merge_quantity_incomparable_units_falls_back_to_raw_sum(self) -> None:
+        """Test _merge_quantity falls back to raw addition when convert() is None."""
+        entry: dict[str, object] = {
+            "ingredient": "mystery",
+            "quantity": 1.0,
+            "unit": Unit.CUP,
+            "category": "other",
+            "from_meals": ["Meal A"],
+        }
+        item = Ingredient(
+            ingredient="mystery",
+            quantity=2.0,
+            unit="bag",
+            category=IngredientCategory.OTHER,
+        )
+        Consolidator._merge_quantity(entry, item)
+        assert entry["quantity"] == pytest.approx(3.0)

--- a/tests/test_migrate_unit_enum.py
+++ b/tests/test_migrate_unit_enum.py
@@ -285,6 +285,46 @@ class TestMigrate:
 
 
 # ---------------------------------------------------------------------------
+# Regression tests: pint/stick units must not be rewritten (issue #69)
+#
+# Current bug: the ``Unit`` enum lacks ``PINT``/``QUART``/``STICK`` members,
+# so ``parse_unit`` (used internally by the migration) silently falls back
+# to ``Unit.EACH`` for these valid-but-unsupported tokens. That means a
+# stored "pint" or "stick" unit gets incorrectly rewritten to "each" the
+# first time this migration runs -- silent, lossy data corruption. Post-fix,
+# these units are first-class Unit members, so the migration must treat
+# them as already-normalized and leave them untouched.
+# ---------------------------------------------------------------------------
+
+
+class TestMigrateUnitEnumNewUnits:
+    """Regression tests: pint/stick units must not be rewritten (issue #69)."""
+
+    def test_pint_unit_not_rewritten(self, tmp_path: Path) -> None:
+        """Test a stored 'pint' recipe ingredient unit is left unchanged."""
+        db_path = str(tmp_path / "test.db")
+        init_db(db_path)
+        recipe_id = _seed_recipe(db_path)
+        row_id = _seed_recipe_ingredient(db_path, recipe_id, "pint")
+
+        count = _migrate_recipe_ingredients(db_path)
+
+        assert count == 0
+        assert _fetch_recipe_ingredient_unit(db_path, row_id) == "pint"
+
+    def test_stick_unit_not_rewritten(self, tmp_path: Path) -> None:
+        """Test a stored 'stick' household_inventory default_unit is unchanged."""
+        db_path = str(tmp_path / "test.db")
+        init_db(db_path)
+        row_id = _seed_inventory_item(db_path, "butter", "stick")
+
+        count = _migrate_household_inventory(db_path)
+
+        assert count == 0
+        assert _fetch_inventory_default_unit(db_path, row_id) == "stick"
+
+
+# ---------------------------------------------------------------------------
 # Tests for CLI entry point
 # ---------------------------------------------------------------------------
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 import pytest
 from pydantic import ValidationError
 
@@ -148,7 +150,12 @@ class TestUnit:
         assert Unit.LB == "lb"
 
     def test_known_members_exist(self) -> None:
-        """Test all expected unit members are defined."""
+        """Test all expected unit members are defined.
+
+        Includes pint/quart/stick, added for issue #69 (Unit enum lacked
+        these units, forcing recipes that used them through the silent
+        parse_unit -> EACH fallback).
+        """
         expected = {
             "tsp",
             "tbsp",
@@ -157,6 +164,8 @@ class TestUnit:
             "ml",
             "l",
             "gal",
+            "pint",
+            "quart",
             "oz",
             "lb",
             "g",
@@ -174,6 +183,7 @@ class TestUnit:
             "bottle",
             "package",
             "block",
+            "stick",
             "pinch",
             "dash",
             "to_taste",
@@ -243,6 +253,57 @@ class TestParseUnit:
         """Test unrecognized strings default to EACH."""
         assert parse_unit("foobar") == Unit.EACH
         assert parse_unit("xyz123") == Unit.EACH
+
+
+class TestParseUnitNewUnits:
+    """Tests for parse_unit support of pint/quart/stick units (issue #69)."""
+
+    def test_pint_and_aliases(self) -> None:
+        """Test 'pint', 'pt', and 'pints' all resolve to Unit.PINT."""
+        assert parse_unit("pint") == Unit.PINT
+        assert parse_unit("pt") == Unit.PINT
+        assert parse_unit("pints") == Unit.PINT
+
+    def test_quart_and_aliases(self) -> None:
+        """Test 'quart', 'qt', and 'quarts' all resolve to Unit.QUART."""
+        assert parse_unit("quart") == Unit.QUART
+        assert parse_unit("qt") == Unit.QUART
+        assert parse_unit("quarts") == Unit.QUART
+
+    def test_stick_and_aliases(self) -> None:
+        """Test 'stick' and 'sticks' both resolve to Unit.STICK."""
+        assert parse_unit("stick") == Unit.STICK
+        assert parse_unit("sticks") == Unit.STICK
+
+
+class TestParseUnitWarningLogging:
+    """Tests for parse_unit's WARNING log on unknown unit fallback (issue #69).
+
+    Currently ``parse_unit`` silently falls back to ``Unit.EACH`` for any
+    unrecognized token, with no logging at all -- masking data-quality
+    problems from LLM output or user input. Post-fix, an unrecognized
+    non-blank token must log a WARNING containing the raw token, while a
+    blank/empty token continues to fall back silently.
+    """
+
+    def test_unknown_unit_logs_warning_with_raw_token(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Test an unrecognized unit token logs a WARNING containing the token."""
+        with caplog.at_level(logging.WARNING, logger="grocery_butler.models"):
+            result = parse_unit("zorbml")
+        assert result == Unit.EACH
+        assert len(caplog.records) == 1
+        assert "zorbml" in caplog.text
+
+    def test_empty_string_emits_no_warning(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Test blank input falls back to EACH silently, with no WARNING logged."""
+        with caplog.at_level(logging.WARNING, logger="grocery_butler.models"):
+            result = parse_unit("")
+        assert result == Unit.EACH
+        assert len(caplog.records) == 0
 
 
 class TestCoerceUnit:

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -47,6 +47,28 @@ class TestDimensionOf:
         assert dimension_of(unit) is None
 
 
+class TestDimensionOfNewUnits:
+    """Tests for dimension_of classification of pint/quart/stick (issue #69).
+
+    ``Unit.PINT``/``Unit.QUART``/``Unit.STICK`` don't exist on the current
+    ``Unit`` enum yet, so referencing them raises ``AttributeError`` --
+    written as plain (non-parametrized) test bodies so a missing attribute
+    only fails its own test, not collection of this whole module.
+    """
+
+    def test_pint_is_volume(self) -> None:
+        """Test Unit.PINT classifies as Dimension.VOLUME."""
+        assert dimension_of(Unit.PINT) == Dimension.VOLUME
+
+    def test_quart_is_volume(self) -> None:
+        """Test Unit.QUART classifies as Dimension.VOLUME."""
+        assert dimension_of(Unit.QUART) == Dimension.VOLUME
+
+    def test_stick_is_dimensionless(self) -> None:
+        """Test Unit.STICK (packaging) classifies as None (no fixed dimension)."""
+        assert dimension_of(Unit.STICK) is None
+
+
 # ------------------------------------------------------------------
 # Tests: convert
 # ------------------------------------------------------------------
@@ -128,6 +150,27 @@ class TestConvert:
         assert convert(1.0, Unit.G, Unit.BAG) is None
 
 
+class TestConvertNewUnits:
+    """Tests for convert() involving pint/quart (issue #69).
+
+    ``_VOLUME_FACTORS_ML`` lacks entries for ``Unit.PINT``/``Unit.QUART`` on
+    the current implementation, so these conversions currently return
+    ``None`` instead of the expected converted value.
+    """
+
+    def test_pint_to_quart(self) -> None:
+        """Test 2 pints convert to approximately 1 quart."""
+        assert convert(2.0, Unit.PINT, Unit.QUART) == pytest.approx(1.0)
+
+    def test_quart_to_liter(self) -> None:
+        """Test 1 quart converts to approximately 0.946352946 liters."""
+        assert convert(1.0, Unit.QUART, Unit.L) == pytest.approx(0.946352946)
+
+    def test_gallon_to_quart(self) -> None:
+        """Test 1 gallon converts to exactly 4 quarts."""
+        assert convert(1.0, Unit.GAL, Unit.QUART) == pytest.approx(4.0)
+
+
 # ------------------------------------------------------------------
 # Tests: parse_size
 # ------------------------------------------------------------------
@@ -181,3 +224,15 @@ class TestParseSize:
     def test_leading_whitespace(self) -> None:
         """Test size with leading whitespace is still parsed."""
         assert parse_size("  16 oz") == (16.0, Unit.OZ)
+
+
+class TestParseSizeNewUnits:
+    """Tests for parse_size() recognizing pint/quart tokens (issue #69)."""
+
+    def test_parses_pint(self) -> None:
+        """Test '1 pint' parses to (1.0, Unit.PINT)."""
+        assert parse_size("1 pint") == (1.0, Unit.PINT)
+
+    def test_parses_quart_abbreviation(self) -> None:
+        """Test '2 qt' parses to (2.0, Unit.QUART)."""
+        assert parse_size("2 qt") == (2.0, Unit.QUART)


### PR DESCRIPTION
## Summary

- `consolidate_simple` now merges shopping-list quantities by `(ingredient, unit dimension)` instead of ingredient name alone: compatible units are converted to the first-seen canonical unit via `grocery_butler.units.convert` and summed (milk 1 cup + 1 gal now yields 17.0 cup, not 2.0 cup), while incompatible/packaging units are kept as separate line items with accurate per-line `from_meals` provenance.
- `parse_unit` now emits a WARNING with the raw token whenever it falls back to `Unit.EACH` for an unrecognized unit (blank input stays a silent default), so silent unit rewrites are detectable instead of destroying data at write time.
- Adds `Unit.PINT` and `Unit.QUART` (volume, with ml conversion factors in `units.py`) and `Unit.STICK` (packaging, deliberately non-convertible), plus `pints`/`pt`/`quarts`/`qt`/`sticks` aliases — "1 pint heavy cream" no longer persists as "1 each heavy cream", and `db.migrate_unit_enum` no longer rewrites stored `pint`/`stick` values.

## Test plan

- New RED-first tests reproducing the issue verbatim: milk 1 cup + 1 gal -> one item at 17.0 cup; mass (1 lb + 8 oz -> 1.5 lb) and count (1 dozen + 6 each -> 1.5 dozen) conversions; packaging same-unit merge, different-unit split, dimensioned-vs-packaging split, and per-split-line `from_meals`; direct tests of the new `_ingredient_group_key` / `_merge_quantity` helpers including the incomparable-unit fallback branch.
- New unit tests for PINT/QUART/STICK across `parse_unit` (incl. `caplog` warning assertions), `dimension_of`, `convert`, and `parse_size`; migration regression tests that `pint`/`stick` rows are no longer rewritten to `each`.
- Full suite: 1468 passed, 10 skipped (Postgres-only, `TEST_DATABASE_URL` unset).
- `./scripts/check-all.sh` exits 0 (ruff lint+format, mypy strict, bandit + pip-audit, radon/xenon complexity, tests, coverage 95.9% vs 90% threshold, interrogate docstrings).

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)
