### PR TITLE
fix(cart): include selected substitutions in order submission and totals

### DIFF
--- a/grocery_butler/cart_builder.py
+++ b/grocery_butler/cart_builder.py
@@ -104,6 +104,13 @@ class CartBuilder:
     ) -> CartSummary:
         """Build a complete cart from shopping list items.
 
+        Selected substitutions (out-of-stock items with an
+        auto-selected alternative) are converted into priced,
+        ``needs_review=True`` cart items so they are included in the
+        submitted order rather than silently dropped (issue #70). They
+        also remain listed in ``substituted_items`` as a display and
+        provenance record.
+
         Args:
             items: Shopping list items to add to cart.
             restock_items: Optional restock queue items.
@@ -136,6 +143,13 @@ class CartBuilder:
                     cart_items.append(result)
             elif isinstance(result, SubstitutionResult):
                 substituted.append(result)
+
+        for sub in substituted:
+            substitute_item = _substitution_to_cart_item(
+                sub, self._max_quantity_per_item
+            )
+            if substitute_item is not None:
+                cart_items.append(substitute_item)
 
         fulfillment_options = self._get_fulfillment_options()
         recommended = _recommend_fulfillment(fulfillment_options)
@@ -377,6 +391,45 @@ def _parse_fulfillment_response(
             )
         )
     return options
+
+
+def _substitution_to_cart_item(
+    result: SubstitutionResult,
+    cap: int,
+) -> CartItem | None:
+    """Convert a selected substitution into a priced, review-flagged item.
+
+    A substitution is a machine decision (the best available alternative,
+    auto-selected by :meth:`CartBuilder._handle_out_of_stock`) and must be
+    confirmed by a human before the order is submitted. Per the
+    chief-architect's ruling on issue #70, the resulting ``CartItem`` is
+    always flagged ``needs_review=True`` with ``review_reason="substitution"``,
+    regardless of whether the quantity calculation itself needed review.
+
+    Args:
+        result: A ``SubstitutionResult`` produced while processing an
+            out-of-stock shopping list item.
+        cap: Maximum quantity to order without flagging for review, passed
+            through to the underlying quantity calculation.
+
+    Returns:
+        A ``CartItem`` for the selected substitute product, or ``None``
+        when ``result.selected`` is unset (no alternative was chosen).
+    """
+    if result.selected is None:
+        return None
+
+    product = result.selected.product
+    decision = _calculate_quantity(result.original_item, product, cap=cap)
+    cost = round(product.price * decision.quantity, 2)
+    return CartItem(
+        shopping_list_item=result.original_item,
+        safeway_product=product,
+        quantity_to_order=decision.quantity,
+        estimated_cost=cost,
+        needs_review=True,
+        review_reason="substitution",
+    )
 
 
 def _default_fulfillment_options() -> list[FulfillmentOption]:

--- a/grocery_butler/models.py
+++ b/grocery_butler/models.py
@@ -383,12 +383,14 @@ class CartItem(BaseModel):
         safeway_product: The matched Safeway product.
         quantity_to_order: Number of product units to order.
         estimated_cost: Estimated cost for ``quantity_to_order`` units.
-        needs_review: Whether the quantity calculation needs human review
-            (e.g. an unparseable product size, incomparable units, or a
-            quantity capped by the per-item maximum).
+        needs_review: Whether the item needs human review (e.g. an
+            unparseable product size, incomparable units, a quantity
+            capped by the per-item maximum, or an auto-selected
+            substitution).
         review_reason: Machine-readable reason code for ``needs_review``
-            (``"unparseable_size"``, ``"incomparable_units"``, or
-            ``"quantity_capped"``), or ``""`` when no review is needed.
+            (``"unparseable_size"``, ``"incomparable_units"``,
+            ``"quantity_capped"``, or ``"substitution"``), or ``""``
+            when no review is needed.
     """
 
     shopping_list_item: ShoppingListItem

--- a/tests/e2e/test_ordering.py
+++ b/tests/e2e/test_ordering.py
@@ -82,11 +82,17 @@ def test_order_preview_substitution_reflected_in_response(
     no_claude: None,
     safeway_mock: SafewayMockState,
 ) -> None:
-    """An out-of-stock primary product surfaces a substitute in the preview.
+    """An out-of-stock primary product surfaces a priced substitute.
 
-    Bug #70 (open) blocks driving a substituted cart through
-    submit -> confirm, so this test stops at preview and does not
-    exercise ``/order/submit`` with a substituted item.
+    Regression guard for issue #70: previously the selected substitute
+    was tracked only in ``substituted_items`` and never converted into
+    a priced ``CartItem``, so it was silently dropped from the
+    submitted order. Per the chief-architect's ruling, the selected
+    substitute must now also appear in ``cart["items"]``, correctly
+    priced and always flagged ``needs_review`` with
+    ``review_reason="substitution"`` (a human must confirm every
+    substitution), while ``substituted_items`` continues to carry the
+    same provenance record as before.
     """
     headers = signed_headers()
     safeway_mock.oos_once.add("bell pepper")
@@ -107,7 +113,16 @@ def test_order_preview_substitution_reflected_in_response(
     )
     assert response.status_code == 200
     cart = response.get_json()["cart"]
-    assert cart["items"] == []
+
+    assert len(cart["items"]) == 1
+    substitute_item = cart["items"][0]
+    assert substitute_item["safeway_product"]["product_id"] == "upc-bell-pepper-alt"
+    assert substitute_item["quantity_to_order"] == 1
+    assert substitute_item["estimated_cost"] == 1.49
+    assert substitute_item["needs_review"] is True
+    assert substitute_item["review_reason"] == "substitution"
+    assert cart["subtotal"] == 1.49
+
     assert len(cart["substituted_items"]) == 1
     substitution = cart["substituted_items"][0]
     assert substitution["status"] == "alternatives_found"

--- a/tests/test_cart_builder.py
+++ b/tests/test_cart_builder.py
@@ -780,3 +780,241 @@ class TestBuildCart:
         assert cart_item.quantity_to_order == 3
         assert cart_item.needs_review is True
         assert cart_item.review_reason == "quantity_capped"
+
+
+# ------------------------------------------------------------------
+# Tests: CartBuilder.build_cart substitution pricing (issue #70)
+# ------------------------------------------------------------------
+#
+# Regression guards for issue #70: build_cart routed out-of-stock items
+# into substituted_items with the best alternative auto-selected, but
+# never converted that selected substitute into a priced CartItem, so
+# it was silently dropped from the submitted order (never priced into
+# the subtotal, never serialized into the order payload). Per the
+# chief-architect's ruling, a selected substitution must become a
+# CartItem in cart.items, always flagged needs_review=True with
+# review_reason="substitution" (a human must confirm substitutions),
+# while still appearing in substituted_items as a display/provenance
+# record. A SubstitutionResult with no selected alternative must remain
+# display-only.
+
+
+def _make_alt_substitution_result(alt_product: SafewayProduct) -> SubstitutionResult:
+    """Build a SubstitutionResult with one alternative, pre-selection.
+
+    Mirrors what SubstitutionService.find_substitutions would return
+    before CartBuilder._handle_out_of_stock sets ``selected`` to the
+    first alternative.
+
+    Args:
+        alt_product: The alternative product to offer as a substitute.
+
+    Returns:
+        SubstitutionResult with one alternative and ``selected`` unset
+        (CartBuilder sets ``selected`` internally).
+    """
+    alt_option = SubstitutionOption(
+        product=alt_product,
+        suitability=SubstitutionSuitability.GOOD,
+        reasoning="Similar cut",
+    )
+    return SubstitutionResult(
+        status="alternatives_found",
+        original_item=_make_item(),
+        alternatives=[alt_option],
+        message="Found 1 alternative(s)",
+    )
+
+
+class TestBuildCartSubstitutionPricing:
+    """Tests for CartBuilder.build_cart pricing selected substitutions."""
+
+    def _make_builder(
+        self,
+        sub_result: SubstitutionResult,
+        oos_product: SafewayProduct | None = None,
+        fulfillment_response: dict | None = None,
+    ) -> CartBuilder:
+        """Create a CartBuilder wired for an out-of-stock + substitution flow.
+
+        Args:
+            sub_result: SubstitutionResult the mocked substitution service
+                returns for the out-of-stock item.
+            oos_product: The primary out-of-stock product returned by
+                search/selection. Defaults to a standard OOS product.
+            fulfillment_response: Fulfillment API response for the mocked
+                Safeway client.
+
+        Returns:
+            CartBuilder with mocked search, selector, substitution, and
+            client services.
+        """
+        oos = oos_product or _make_product(in_stock=False)
+        item = _make_item()
+
+        mock_search = MagicMock()
+        mock_search.search_or_cached.return_value = [oos]
+
+        mock_selector = MagicMock()
+        mock_selector.select_product.return_value = _MockSelectionResult(
+            item=item,
+            product=oos,
+            reasoning="Test selection",
+        )
+
+        mock_substitution = MagicMock()
+        mock_substitution.find_substitutions.return_value = sub_result
+
+        mock_client = MagicMock()
+        mock_client.store_id = "1234"
+        mock_client.get.return_value = fulfillment_response or {}
+
+        return CartBuilder(
+            search_service=mock_search,
+            product_selector=mock_selector,
+            substitution_service=mock_substitution,
+            safeway_client=mock_client,
+        )
+
+    def test_selected_substitution_added_to_cart_items(self) -> None:
+        """Test a selected substitution is converted into a CartItem.
+
+        Regression guard for issue #70: the selected substitute must
+        appear in ``cart.items`` with the substitute product, correct
+        quantity, and correctly priced cost — not silently dropped.
+        """
+        alt_product = _make_product(
+            product_id="ALT1",
+            name="Organic Chicken Thighs",
+            price=10.99,
+            size="1 lb",
+        )
+        sub_result = _make_alt_substitution_result(alt_product)
+        builder = self._make_builder(sub_result)
+
+        cart = builder.build_cart([_make_item()])
+
+        assert len(cart.items) == 1
+        substitute_item = cart.items[0]
+        assert substitute_item.safeway_product.product_id == "ALT1"
+        assert substitute_item.quantity_to_order == 2
+        assert substitute_item.estimated_cost == round(10.99 * 2, 2)
+
+    def test_substitution_priced_into_subtotal(self) -> None:
+        """Test the substitute's cost is included in cart.subtotal."""
+        alt_product = _make_product(
+            product_id="ALT1",
+            name="Organic Chicken Thighs",
+            price=10.99,
+            size="1 lb",
+        )
+        sub_result = _make_alt_substitution_result(alt_product)
+        builder = self._make_builder(sub_result)
+
+        cart = builder.build_cart([_make_item()])
+
+        assert cart.subtotal == round(10.99 * 2, 2)
+
+    def test_substitution_flagged_for_review(self) -> None:
+        """Test the substitute CartItem is always flagged for review.
+
+        Per the chief-architect's ruling, a human must confirm every
+        substitution before it is submitted, regardless of whether the
+        quantity math itself needed review.
+        """
+        alt_product = _make_product(
+            product_id="ALT1",
+            name="Organic Chicken Thighs",
+            price=10.99,
+            size="1 lb",
+        )
+        sub_result = _make_alt_substitution_result(alt_product)
+        builder = self._make_builder(sub_result)
+
+        cart = builder.build_cart([_make_item()])
+
+        assert len(cart.items) == 1
+        substitute_item = cart.items[0]
+        assert substitute_item.needs_review is True
+        assert substitute_item.review_reason == "substitution"
+
+    def test_estimated_total_includes_substitution(self) -> None:
+        """Test estimated_total includes the substitute's contribution.
+
+        The substitute's cost must flow through subtotal and into
+        estimated_total alongside the fulfillment fee, exactly like any
+        other priced cart item.
+        """
+        alt_product = _make_product(
+            product_id="ALT1",
+            name="Organic Chicken Thighs",
+            price=10.99,
+            size="1 lb",
+        )
+        sub_result = _make_alt_substitution_result(alt_product)
+        fulfillment_response = {
+            "fulfillmentOptions": [
+                {"type": "pickup", "available": False, "fee": 0.0, "windows": []},
+                {
+                    "type": "delivery",
+                    "available": True,
+                    "fee": 9.95,
+                    "windows": [],
+                },
+            ]
+        }
+        builder = self._make_builder(
+            sub_result, fulfillment_response=fulfillment_response
+        )
+
+        cart = builder.build_cart([_make_item()])
+
+        expected_subtotal = round(10.99 * 2, 2)
+        assert cart.recommended_fulfillment == FulfillmentType.DELIVERY
+        assert cart.estimated_total == round(expected_subtotal + 9.95, 2)
+
+    def test_substitution_still_listed_in_substituted_items(self) -> None:
+        """Test substituted_items still records the substitution (regression).
+
+        The provenance record in ``substituted_items`` must remain
+        populated exactly as before — pricing the substitute into
+        ``items`` must not remove it from the display list.
+        """
+        alt_product = _make_product(
+            product_id="ALT1",
+            name="Organic Chicken Thighs",
+            price=10.99,
+            size="1 lb",
+        )
+        sub_result = _make_alt_substitution_result(alt_product)
+        builder = self._make_builder(sub_result)
+
+        cart = builder.build_cart([_make_item()])
+
+        assert len(cart.substituted_items) == 1
+        recorded = cart.substituted_items[0]
+        assert recorded.selected is not None
+        assert recorded.selected.product.product_id == "ALT1"
+
+    def test_no_alternative_substitution_not_added_to_items(self) -> None:
+        """Test a substitution with no alternatives stays display-only.
+
+        When SubstitutionService finds no alternatives, ``selected``
+        stays ``None`` and nothing should be added to ``items`` or
+        priced into ``subtotal`` — only ``substituted_items`` records
+        the failed substitution attempt.
+        """
+        no_alt_result = SubstitutionResult(
+            status="no_alternatives",
+            original_item=_make_item(),
+            alternatives=[],
+            message="No alternatives",
+        )
+        builder = self._make_builder(no_alt_result)
+
+        cart = builder.build_cart([_make_item()])
+
+        assert cart.items == []
+        assert cart.subtotal == 0.0
+        assert len(cart.substituted_items) == 1
+        assert cart.substituted_items[0].selected is None

--- a/tests/test_order_service.py
+++ b/tests/test_order_service.py
@@ -190,6 +190,30 @@ class TestBuildOrderPayload:
         assert "P001" in product_ids
         assert "R1" in product_ids
 
+    def test_includes_substitute_item(self) -> None:
+        """Test a substitute-style CartItem in cart.items reaches the payload.
+
+        Contract guard for issue #70: once CartBuilder converts a
+        selected substitution into a CartItem (needs_review=True,
+        review_reason="substitution") and appends it to ``cart.items``,
+        ``_build_order_payload`` must serialize it exactly like any
+        other cart item, using its current (cart-only) signature.
+        """
+        substitute = _make_cart_item(
+            ingredient="bell pepper",
+            product_id="ALT1",
+            price=1.49,
+            needs_review=True,
+            review_reason="substitution",
+        )
+        cart = _make_cart(items=[substitute])
+
+        result = _build_order_payload(cart)
+
+        product_ids = [i["productId"] for i in result["items"]]
+        assert "ALT1" in product_ids
+        assert result["estimatedTotal"] == cart.estimated_total
+
 
 # ------------------------------------------------------------------
 # Tests: _parse_order_response
@@ -598,6 +622,43 @@ class TestSubmitOrderReviewGate:
         result = service.submit_order(_make_cart())
 
         assert result.success is True
+        service._client.post.assert_called_once()
+
+    def test_blocks_unreviewed_substitution(self) -> None:
+        """Test a substitute CartItem blocks submission pending review.
+
+        Contract guard for issue #70: once CartBuilder appends a
+        selected substitution to ``cart.items`` with
+        ``review_reason="substitution"``, the existing issue #59 review
+        gate must block it exactly like any other flagged item unless
+        the caller explicitly opts in with ``allow_review_items=True``.
+        """
+        service = self._make_service(
+            api_response={
+                "orderId": "ORD-123",
+                "status": "confirmed",
+                "total": 1.49,
+            }
+        )
+        substitute = _make_cart_item(
+            ingredient="bell pepper",
+            product_id="ALT1",
+            price=1.49,
+            needs_review=True,
+            review_reason="substitution",
+        )
+        cart = _make_cart(items=[substitute])
+
+        blocked = service.submit_order(cart)
+
+        assert blocked.success is False
+        assert "substitution" in blocked.error_message.lower()
+        service._client.post.assert_not_called()
+
+        allowed = service.submit_order(cart, allow_review_items=True)
+
+        assert allowed.success is True
+        assert allowed.confirmation is not None
         service._client.post.assert_called_once()
 
 


### PR DESCRIPTION
## Summary

- Fixes the HIGH-severity bug where an approved substitution was previewed ("milk → Oat Milk") but neither priced into the total nor included in the submitted order: `CartBuilder.build_cart` now converts each `SubstitutionResult.selected` into a priced `CartItem` (new pure helper `_substitution_to_cart_item`) appended to `cart.items` before subtotal/`estimated_total` are computed, so `_build_order_payload`, `api._cart_total`, and the review gate all inherit the fix automatically — preview total now equals what is actually ordered.
- Substitute items are always flagged `needs_review=True` with `review_reason="substitution"`, so the existing issue-#59 review gate blocks submission until an explicit human override (`allow_review_items=True`). Substitutions with no selected alternative remain display-only, and `substituted_items` is retained as the display/provenance record.
- Deliberately zero changes to `order_service.py` / `safeway_pipeline.py` to avoid any conflict surface with in-flight PR #107 (issue #61 idempotency ledger); the issue-#60 `SAFEWAY_ORDER_SUBMISSION_ENABLED` preflight is untouched.

## Test plan

- New `TestBuildCartSubstitutionPricing` (6 tests) in `tests/test_cart_builder.py`: substitute added to `cart.items` with correct quantity/cost, priced into subtotal and `estimated_total`, flagged for review, still listed in `substituted_items`, and the no-alternative case stays display-only. Written first and verified RED against the old code.
- Contract guards in `tests/test_order_service.py`: `_build_order_payload` includes the substitute product and `estimatedTotal` matches; `submit_order` blocks an unreviewed substitution and proceeds with `allow_review_items=True`.
- Updated `tests/e2e/test_ordering.py::test_order_preview_substitution_reflected_in_response` to the new contract over the real HTTP pipeline.
- `./scripts/check-all.sh` exits 0: 1459 passed, coverage 95.84% (branch), mypy strict, ruff, bandit, pip-audit, complexity/MI, interrogate all green.
- Pre-push self-review (code-review-orchestrator) returned CLEAN.

## Follow-up (known, deliberately deferred)

A substituted *restock* item now lands in `cart.items` (correctly ordered and priced), but `_collect_restock_ingredients` only scans `restock_items`, so its pantry entry is never marked restocked after the order. `SubstitutionResult` carries no restock provenance; fixing that here was ruled scope creep. Needs a follow-up issue.

Closes #70
