### PR TITLE
fix(cache): cache the selected product with real size/stock and reverify at cart-build

### DIFF
--- a/grocery_butler/cart_builder.py
+++ b/grocery_butler/cart_builder.py
@@ -171,14 +171,7 @@ class CartBuilder:
             CartItem if successful, SubstitutionResult if substituted,
             or None if no product found.
         """
-        candidates = self._search.search_or_cached(item.search_term)
-        if not candidates:
-            logger.warning("No products found for '%s'", item.search_term)
-            return None
-
-        selection = self._selector.select_product(item, candidates)
-        product = selection.product
-
+        product = self._resolve_product(item)
         if product is None:
             return None
 
@@ -195,6 +188,60 @@ class CartBuilder:
             needs_review=decision.needs_review,
             review_reason=decision.review_reason,
         )
+
+    def _resolve_product(
+        self,
+        item: ShoppingListItem,
+    ) -> SafewayProduct | None:
+        """Resolve a shopping list item to a product via cache or search.
+
+        On a cache hit, the cached product is re-verified against a
+        fresh live search (see
+        :meth:`ProductSearchService.reverify_product`) so quantity and
+        stock decisions never rely on stale cached data. On a cache
+        miss, a full search-and-select flow runs instead.
+
+        Args:
+            item: The shopping list item to resolve.
+
+        Returns:
+            The resolved SafewayProduct, or None if unresolvable.
+        """
+        cached = self._search.get_cached_product(item.search_term)
+        if cached is not None:
+            return self._search.reverify_product(cached)
+        return self._search_and_select(item)
+
+    def _search_and_select(
+        self,
+        item: ShoppingListItem,
+    ) -> SafewayProduct | None:
+        """Search for and select a product on a cache miss.
+
+        Performs a live search, hands the candidates to the product
+        selector, and -- when a selection is made -- caches the
+        selected product (not merely the top raw search hit) so future
+        lookups hit the cache with the right product.
+
+        Args:
+            item: The shopping list item to search for.
+
+        Returns:
+            The selected SafewayProduct, or None if no products were
+            found or none was selected.
+        """
+        candidates = self._search.search_products(item.search_term)
+        if not candidates:
+            logger.warning("No products found for '%s'", item.search_term)
+            return None
+
+        selection = self._selector.select_product(item, candidates)
+        product = selection.product
+        if product is None:
+            return None
+
+        self._search.save_mapping(item.search_term, product)
+        return product
 
     def _handle_out_of_stock(
         self,

--- a/grocery_butler/db/migrations/007_product_mapping_stock_size.sql
+++ b/grocery_butler/db/migrations/007_product_mapping_stock_size.sql
@@ -1,0 +1,11 @@
+-- Migration 007: product_mapping size/stock columns (SQLite).
+-- Issue #71: ProductSearchService used to rehydrate cached rows with a
+-- hardcoded size="" and a default in_stock=True because product_mapping
+-- never stored the real values, pinning cached quantity calculations to 1
+-- (unparseable_size) and preventing the substitution flow from ever
+-- triggering for cached items. These columns let save_mapping/pin_mapping
+-- persist the real product size and stock status so cache hits can be
+-- re-verified and rehydrated accurately.
+
+ALTER TABLE product_mapping ADD COLUMN safeway_product_size TEXT;
+ALTER TABLE product_mapping ADD COLUMN safeway_in_stock BOOLEAN DEFAULT TRUE;

--- a/grocery_butler/db/migrations/007_product_mapping_stock_size_pg.sql
+++ b/grocery_butler/db/migrations/007_product_mapping_stock_size_pg.sql
@@ -1,0 +1,11 @@
+-- Migration 007: product_mapping size/stock columns (PostgreSQL).
+-- Issue #71: ProductSearchService used to rehydrate cached rows with a
+-- hardcoded size="" and a default in_stock=True because product_mapping
+-- never stored the real values, pinning cached quantity calculations to 1
+-- (unparseable_size) and preventing the substitution flow from ever
+-- triggering for cached items. These columns let save_mapping/pin_mapping
+-- persist the real product size and stock status so cache hits can be
+-- re-verified and rehydrated accurately.
+
+ALTER TABLE product_mapping ADD COLUMN IF NOT EXISTS safeway_product_size TEXT;
+ALTER TABLE product_mapping ADD COLUMN IF NOT EXISTS safeway_in_stock BOOLEAN DEFAULT TRUE;

--- a/grocery_butler/db/schema.sql
+++ b/grocery_butler/db/schema.sql
@@ -85,6 +85,8 @@ CREATE TABLE IF NOT EXISTS product_mapping (
     safeway_product_id TEXT NOT NULL,
     safeway_product_name TEXT NOT NULL,
     safeway_price REAL,
+    safeway_product_size TEXT,
+    safeway_in_stock BOOLEAN DEFAULT TRUE,
     last_used TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     times_selected INTEGER DEFAULT 1,
     is_pinned BOOLEAN DEFAULT FALSE

--- a/grocery_butler/db/schema_pg.sql
+++ b/grocery_butler/db/schema_pg.sql
@@ -85,6 +85,8 @@ CREATE TABLE IF NOT EXISTS product_mapping (
     safeway_product_id TEXT NOT NULL,
     safeway_product_name TEXT NOT NULL,
     safeway_price DOUBLE PRECISION,
+    safeway_product_size TEXT,
+    safeway_in_stock BOOLEAN DEFAULT TRUE,
     last_used TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     times_selected INTEGER DEFAULT 1,
     is_pinned BOOLEAN DEFAULT FALSE

--- a/grocery_butler/product_search.py
+++ b/grocery_butler/product_search.py
@@ -5,11 +5,22 @@ Searches the Nimbus API for grocery products, caches results in the
 instances.  Pinned mappings bypass the API entirely.
 
 Cache strategy:
+- ``get_cached_product`` returns a pinned or non-stale cached mapping
+  (touching ``times_selected``/``last_used``) without ever performing a
+  live search; a stale or absent mapping returns ``None`` so the caller
+  falls back to a fresh search and selection.
+- ``save_mapping``/``pin_mapping`` persist the *selected* product (name,
+  price, size, and stock status) so the cache reflects what the user
+  actually chose, not merely the top raw search hit.
+- ``reverify_product`` re-runs a live search for a cache hit's
+  ingredient description and reconciles the cached ``product_id``
+  against the fresh candidates, returning up-to-date price/size/stock
+  (or marking the product out-of-stock if it no longer appears, so the
+  substitution flow can trigger). A search failure falls back to the
+  cached product unchanged.
 - Mappings older than ``CACHE_MAX_AGE_DAYS`` are considered stale and
   re-fetched on the next search.
 - Pinned mappings never expire.
-- ``times_selected`` and ``last_used`` are updated each time a cached
-  mapping is returned.
 """
 
 from __future__ import annotations
@@ -129,32 +140,72 @@ class ProductSearchService:
 
         return _parse_search_results(data)
 
-    def search_or_cached(
+    def get_cached_product(
         self,
         search_term: str,
-    ) -> list[SafewayProduct]:
-        """Return cached results or perform a fresh search.
+    ) -> CachedMapping | None:
+        """Return a usable cached mapping for *search_term*, if any.
 
-        If a pinned mapping exists, returns only that product. If a
-        non-expired cached mapping exists, returns it (and refreshes
-        ``last_used``). Otherwise performs a live search and caches
-        the top result.
+        A pinned mapping is always usable; a non-pinned mapping is
+        usable if it is not yet stale (see ``CACHE_MAX_AGE_DAYS``). In
+        either case, the mapping is "touched" (``times_selected``
+        incremented and ``last_used`` refreshed) before being returned.
+
+        This never performs a live search; callers should fall back to
+        :meth:`search_products` (and, for cache hits, re-verify via
+        :meth:`reverify_product`) when this returns ``None``.
 
         Args:
             search_term: The ingredient search term.
 
         Returns:
-            List of SafewayProduct results (possibly a single pinned item).
+            The usable cached mapping, or ``None`` if no cached mapping
+            exists or the only one found is stale and not pinned.
         """
         cached = self.get_cached_mapping(search_term)
-        if cached is not None and (cached.is_pinned or not self._is_stale(cached)):
-            self._touch_mapping(cached.mapping_id)
-            return [cached.product]
+        if cached is None:
+            return None
+        if not (cached.is_pinned or not self._is_stale(cached)):
+            return None
 
-        products = self.search_products(search_term)
-        if products:
-            self.save_mapping(search_term, products[0])
-        return products
+        self._touch_mapping(cached.mapping_id)
+        return cached
+
+    def reverify_product(self, cached: CachedMapping) -> SafewayProduct:
+        """Re-verify a cached product against a fresh live search.
+
+        Cached price/size/stock can go stale between visits, so a cache
+        hit re-runs a live search for the mapping's ingredient
+        description and looks for a fresh candidate whose
+        ``product_id`` matches the cached product. When found, the
+        fresh candidate (with current price, size, and stock) is
+        returned. When no fresh candidate matches -- the product has
+        been delisted or is otherwise absent from results -- the cached
+        product is returned with ``in_stock`` forced to ``False`` so
+        the substitution flow can trigger. If the live search itself
+        fails, the cached product is returned unchanged (a transient
+        API outage should not be treated as an out-of-stock signal).
+
+        Args:
+            cached: The cached mapping to re-verify.
+
+        Returns:
+            The re-verified SafewayProduct.
+        """
+        try:
+            fresh = self.search_products(cached.ingredient_description)
+        except ProductSearchError:
+            logger.warning(
+                "Re-verification search failed for '%s'; using cached product",
+                cached.ingredient_description,
+            )
+            return cached.product
+
+        for candidate in fresh:
+            if candidate.product_id == cached.product.product_id:
+                return candidate
+
+        return cached.product.model_copy(update={"in_stock": False})
 
     # ------------------------------------------------------------------
     # Cache operations
@@ -176,7 +227,8 @@ class ProductSearchService:
         try:
             row = conn.execute(
                 "SELECT id, ingredient_description, safeway_product_id,"
-                " safeway_product_name, safeway_price, last_used,"
+                " safeway_product_name, safeway_price, safeway_product_size,"
+                " safeway_in_stock, last_used,"
                 " times_selected, is_pinned"
                 " FROM product_mapping"
                 " WHERE ingredient_description = ?"
@@ -223,21 +275,26 @@ class ProductSearchService:
                     "UPDATE product_mapping"
                     " SET times_selected = times_selected + 1,"
                     " last_used = CURRENT_TIMESTAMP,"
-                    " safeway_price = ?"
+                    " safeway_price = ?,"
+                    " safeway_product_size = ?,"
+                    " safeway_in_stock = ?"
                     " WHERE id = ?",
-                    (product.price, row_id),
+                    (product.price, product.size, product.in_stock, row_id),
                 )
             else:
                 cursor = conn.execute(
                     "INSERT INTO product_mapping"
                     " (ingredient_description, safeway_product_id,"
-                    "  safeway_product_name, safeway_price)"
-                    " VALUES (?, ?, ?, ?)",
+                    "  safeway_product_name, safeway_price,"
+                    "  safeway_product_size, safeway_in_stock)"
+                    " VALUES (?, ?, ?, ?, ?, ?)",
                     (
                         search_term,
                         product.product_id,
                         product.name,
                         product.price,
+                        product.size,
+                        product.in_stock,
                     ),
                 )
                 row_id = cursor.lastrowid
@@ -288,21 +345,26 @@ class ProductSearchService:
                     "UPDATE product_mapping"
                     " SET is_pinned = TRUE,"
                     " last_used = CURRENT_TIMESTAMP,"
-                    " safeway_price = ?"
+                    " safeway_price = ?,"
+                    " safeway_product_size = ?,"
+                    " safeway_in_stock = ?"
                     " WHERE id = ?",
-                    (product.price, row_id),
+                    (product.price, product.size, product.in_stock, row_id),
                 )
             else:
                 cursor = conn.execute(
                     "INSERT INTO product_mapping"
                     " (ingredient_description, safeway_product_id,"
-                    "  safeway_product_name, safeway_price, is_pinned)"
-                    " VALUES (?, ?, ?, ?, TRUE)",
+                    "  safeway_product_name, safeway_price,"
+                    "  safeway_product_size, safeway_in_stock, is_pinned)"
+                    " VALUES (?, ?, ?, ?, ?, ?, TRUE)",
                     (
                         search_term,
                         product.product_id,
                         product.name,
                         product.price,
+                        product.size,
+                        product.in_stock,
                     ),
                 )
                 row_id = cursor.lastrowid
@@ -498,6 +560,7 @@ def _row_to_cached_mapping(row: DictRow) -> CachedMapping:
     else:
         last_used = datetime.now(tz=UTC)
 
+    in_stock_value = row["safeway_in_stock"]
     return CachedMapping(
         mapping_id=row["id"],
         ingredient_description=row["ingredient_description"],
@@ -505,7 +568,8 @@ def _row_to_cached_mapping(row: DictRow) -> CachedMapping:
             product_id=row["safeway_product_id"],
             name=row["safeway_product_name"],
             price=row["safeway_price"] or 0.0,
-            size="",
+            size=row["safeway_product_size"] or "",
+            in_stock=True if in_stock_value is None else bool(in_stock_value),
         ),
         is_pinned=bool(row["is_pinned"]),
         times_selected=row["times_selected"],

--- a/tests/test_cart_builder.py
+++ b/tests/test_cart_builder.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 from grocery_butler.cart_builder import (
@@ -27,6 +28,7 @@ from grocery_butler.models import (
     SubstitutionResult,
     SubstitutionSuitability,
 )
+from grocery_butler.product_search import CachedMapping
 
 # ------------------------------------------------------------------
 # Fixtures
@@ -514,7 +516,8 @@ class TestBuildCart:
             CartBuilder with mocked services.
         """
         mock_search = MagicMock()
-        mock_search.search_or_cached.return_value = search_results or []
+        mock_search.get_cached_product.return_value = None
+        mock_search.search_products.return_value = search_results or []
 
         mock_selector = MagicMock()
         item = _make_item()
@@ -606,7 +609,8 @@ class TestBuildCart:
         )
 
         mock_search = MagicMock()
-        mock_search.search_or_cached.return_value = [oos_product]
+        mock_search.get_cached_product.return_value = None
+        mock_search.search_products.return_value = [oos_product]
 
         mock_selector = MagicMock()
         mock_selector.select_product.return_value = _MockSelectionResult(
@@ -751,7 +755,8 @@ class TestBuildCart:
         """
         product = _make_product(price=1.0, size="1 lb")
         mock_search = MagicMock()
-        mock_search.search_or_cached.return_value = [product]
+        mock_search.get_cached_product.return_value = None
+        mock_search.search_products.return_value = [product]
 
         item = _make_item(quantity=100.0, unit="lb")
         mock_selector = MagicMock()
@@ -780,3 +785,235 @@ class TestBuildCart:
         assert cart_item.quantity_to_order == 3
         assert cart_item.needs_review is True
         assert cart_item.review_reason == "quantity_capped"
+
+
+# ------------------------------------------------------------------
+# Tests: CartBuilder cache-hit / cache-miss flow (issue #71)
+# ------------------------------------------------------------------
+#
+# Regression guards for issue #71: the old ``search_or_cached`` cached
+# ``products[0]`` -- the raw pre-selection top hit, not what the selector
+# actually chose -- and rehydrated cache rows with a hardcoded size=""
+# and a default in_stock=True. Consequences: quantity was pinned to 1
+# (unparseable_size) and the substitution flow never triggered for
+# cached items. The fixed flow splits the miss path
+# (search_products -> selector.select_product -> save_mapping(selected))
+# from the hit path (get_cached_product -> reverify_product), and a hit
+# never calls search_products or select_product.
+
+
+def _make_cached_mapping(product: SafewayProduct) -> CachedMapping:
+    """Build a CachedMapping wrapping *product* for cache-hit tests.
+
+    Args:
+        product: The cached SafewayProduct.
+
+    Returns:
+        A CachedMapping resembling what
+        ``ProductSearchService.get_cached_product`` returns on a hit.
+    """
+    return CachedMapping(
+        mapping_id=1,
+        ingredient_description="boneless chicken thighs",
+        product=product,
+        is_pinned=False,
+        times_selected=1,
+        last_used=datetime.now(tz=UTC),
+    )
+
+
+class TestCartBuilderCacheFlow:
+    """Tests for the cache-hit/cache-miss split in CartBuilder._process_item."""
+
+    def _make_dependencies(
+        self,
+    ) -> tuple[MagicMock, MagicMock, MagicMock, MagicMock]:
+        """Create fresh mocks for search, selector, substitution, and client.
+
+        Returns:
+            Tuple of (mock_search, mock_selector, mock_substitution,
+            mock_client).
+        """
+        mock_search = MagicMock()
+        mock_selector = MagicMock()
+        mock_substitution = MagicMock()
+        mock_client = MagicMock()
+        mock_client.store_id = "1234"
+        mock_client.get.return_value = {}
+        return mock_search, mock_selector, mock_substitution, mock_client
+
+    def test_cache_miss_saves_selected_product(self) -> None:
+        """Test a cache miss saves the SELECTED candidate, not candidates[0].
+
+        Regression guard for issue #71: the old code cached
+        ``products[0]`` regardless of which candidate the selector
+        actually chose.
+        """
+        item = _make_item()
+        candidates = [
+            _make_product(product_id="P001"),
+            _make_product(product_id="P002"),
+            _make_product(product_id="P003"),
+        ]
+        mock_search, mock_selector, mock_substitution, mock_client = (
+            self._make_dependencies()
+        )
+        mock_search.get_cached_product.return_value = None
+        mock_search.search_products.return_value = candidates
+        mock_selector.select_product.return_value = _MockSelectionResult(
+            item=item, product=candidates[1], reasoning="Best match"
+        )
+
+        builder = CartBuilder(
+            search_service=mock_search,
+            product_selector=mock_selector,
+            substitution_service=mock_substitution,
+            safeway_client=mock_client,
+        )
+        builder.build_cart([item])
+
+        mock_search.save_mapping.assert_called_once_with(
+            item.search_term, candidates[1]
+        )
+
+    def test_cache_hit_skips_search_and_select(self) -> None:
+        """Test a cache hit bypasses search_products and select_product."""
+        item = _make_item()
+        cached_product = _make_product(product_id="CACHED1", size="2 lb")
+        reverified = _make_product(product_id="CACHED1", size="2 lb")
+        cached = _make_cached_mapping(cached_product)
+
+        mock_search, mock_selector, mock_substitution, mock_client = (
+            self._make_dependencies()
+        )
+        mock_search.get_cached_product.return_value = cached
+        mock_search.reverify_product.return_value = reverified
+
+        builder = CartBuilder(
+            search_service=mock_search,
+            product_selector=mock_selector,
+            substitution_service=mock_substitution,
+            safeway_client=mock_client,
+        )
+        result = builder.build_cart([item])
+
+        mock_selector.select_product.assert_not_called()
+        mock_search.search_products.assert_not_called()
+        mock_search.reverify_product.assert_called_once_with(cached)
+        assert len(result.items) == 1
+        assert result.items[0].safeway_product.product_id == "CACHED1"
+
+    def test_cache_hit_uses_reverified_size_for_quantity(self) -> None:
+        """Test quantity calc uses the reverified product's size, not cached.
+
+        Regression guard for issue #71: the cached row's hardcoded
+        size="" used to force ``unparseable_size`` and a quantity of 1
+        for every cache hit, regardless of the item's actual needs.
+        """
+        item = _make_item(quantity=4.0, unit="lb")
+        cached_product = _make_product(product_id="CACHED1", size="1 lb")
+        reverified = _make_product(product_id="CACHED1", size="2 lb")
+        cached = _make_cached_mapping(cached_product)
+
+        mock_search, mock_selector, mock_substitution, mock_client = (
+            self._make_dependencies()
+        )
+        mock_search.get_cached_product.return_value = cached
+        mock_search.reverify_product.return_value = reverified
+
+        builder = CartBuilder(
+            search_service=mock_search,
+            product_selector=mock_selector,
+            substitution_service=mock_substitution,
+            safeway_client=mock_client,
+        )
+        result = builder.build_cart([item])
+
+        assert len(result.items) == 1
+        cart_item = result.items[0]
+        assert cart_item.quantity_to_order == 2
+        assert cart_item.needs_review is False
+
+    def test_cache_hit_out_of_stock_triggers_substitution(self) -> None:
+        """Test an out-of-stock reverified product triggers substitution.
+
+        Regression guard for issue #71: the cached row's default
+        in_stock=True used to prevent the substitution flow from ever
+        triggering for cached items.
+        """
+        item = _make_item()
+        cached_product = _make_product(product_id="CACHED1", in_stock=True)
+        reverified = _make_product(product_id="CACHED1", in_stock=False)
+        cached = _make_cached_mapping(cached_product)
+
+        sub_result = SubstitutionResult(
+            status="no_alternatives",
+            original_item=item,
+            message="No alternatives",
+        )
+        mock_search, mock_selector, mock_substitution, mock_client = (
+            self._make_dependencies()
+        )
+        mock_search.get_cached_product.return_value = cached
+        mock_search.reverify_product.return_value = reverified
+        mock_substitution.find_substitutions.return_value = sub_result
+
+        builder = CartBuilder(
+            search_service=mock_search,
+            product_selector=mock_selector,
+            substitution_service=mock_substitution,
+            safeway_client=mock_client,
+        )
+        result = builder.build_cart([item])
+
+        mock_substitution.find_substitutions.assert_called_once()
+        assert result.substituted_items == [sub_result]
+
+    def test_cache_hit_cost_uses_reverified_price(self) -> None:
+        """Test estimated_cost uses the reverified price, not the cached price."""
+        item = _make_item(quantity=1.0, unit="lb")
+        cached_product = _make_product(product_id="CACHED1", price=3.99, size="1 lb")
+        reverified = _make_product(product_id="CACHED1", price=5.49, size="1 lb")
+        cached = _make_cached_mapping(cached_product)
+
+        mock_search, mock_selector, mock_substitution, mock_client = (
+            self._make_dependencies()
+        )
+        mock_search.get_cached_product.return_value = cached
+        mock_search.reverify_product.return_value = reverified
+
+        builder = CartBuilder(
+            search_service=mock_search,
+            product_selector=mock_selector,
+            substitution_service=mock_substitution,
+            safeway_client=mock_client,
+        )
+        result = builder.build_cart([item])
+
+        assert len(result.items) == 1
+        assert result.items[0].estimated_cost == 5.49
+
+    def test_no_product_selected_returns_failed(self) -> None:
+        """Test a cache miss with no selected product fails without saving."""
+        item = _make_item()
+        candidates = [_make_product(product_id="P001")]
+
+        mock_search, mock_selector, mock_substitution, mock_client = (
+            self._make_dependencies()
+        )
+        mock_search.get_cached_product.return_value = None
+        mock_search.search_products.return_value = candidates
+        mock_selector.select_product.return_value = _MockSelectionResult(
+            item=item, product=None, reasoning="No good match"
+        )
+
+        builder = CartBuilder(
+            search_service=mock_search,
+            product_selector=mock_selector,
+            substitution_service=mock_substitution,
+            safeway_client=mock_client,
+        )
+        result = builder.build_cart([item])
+
+        assert len(result.failed_items) == 1
+        mock_search.save_mapping.assert_not_called()

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -470,6 +470,37 @@ class TestMigrate:
 # ---------------------------------------------------------------------------
 
 
+class TestMigration007ProductMappingStockSize:
+    """Tests for migration 007 (product_mapping size/stock columns).
+
+    Issue #71: ``ProductSearchService`` used to rehydrate cached rows
+    with a hardcoded ``size=""`` and a default ``in_stock=True`` because
+    the ``product_mapping`` table never stored the real values. This
+    migration adds the two columns so the fix has somewhere to persist
+    them.
+    """
+
+    def test_migration_007_adds_product_mapping_columns(self, db_path: str) -> None:
+        """Test migrate() adds safeway_product_size/safeway_in_stock columns.
+
+        Running migrate() a second time afterwards must apply zero
+        additional migrations (idempotency).
+        """
+        migrate(db_path)
+
+        conn = get_connection(db_path)
+        try:
+            cursor = conn.execute("PRAGMA table_info(product_mapping)")
+            columns = {row["name"] for row in cursor.fetchall()}
+        finally:
+            conn.close()
+
+        assert "safeway_product_size" in columns
+        assert "safeway_in_stock" in columns
+
+        assert migrate(db_path) == 0
+
+
 class TestCLI:
     """Tests for the CLI entry point."""
 

--- a/tests/test_product_search.py
+++ b/tests/test_product_search.py
@@ -509,94 +509,226 @@ class TestCacheOperations:
         assert cached is not None
         assert cached.times_selected == 2
 
+    # ------------------------------------------------------------------
+    # Regression guards for issue #71: cached rows must persist the real
+    # product size and stock status instead of being rehydrated with a
+    # hardcoded size="" and a default in_stock=True. Those defaults used
+    # to pin quantity calculations to 1 (unparseable_size) and prevented
+    # the substitution flow from ever triggering for cached items.
+    # ------------------------------------------------------------------
 
-# ------------------------------------------------------------------
-# Tests: search_or_cached
-# ------------------------------------------------------------------
+    def test_save_persists_size(self, db_path: str) -> None:
+        """Test save_mapping persists the product's real size."""
+        service = self._make_service(db_path)
+        product = SafewayProduct(
+            product_id="UPC010", name="Whole Milk", price=4.99, size="1 gal"
+        )
 
+        service.save_mapping("whole milk", product)
+        cached = service.get_cached_mapping("whole milk")
 
-class TestSearchOrCached:
-    """Tests for ProductSearchService.search_or_cached."""
+        assert cached is not None
+        assert cached.product.size == "1 gal"
 
-    @patch("grocery_butler.safeway_client.time.sleep")
-    def test_returns_pinned_without_search(
-        self, mock_sleep: object, db_path: str
+    def test_save_persists_stock(self, db_path: str) -> None:
+        """Test save_mapping persists an out-of-stock product's flag."""
+        service = self._make_service(db_path)
+        product = SafewayProduct(
+            product_id="UPC011",
+            name="Sold Out Milk",
+            price=4.99,
+            size="1 gal",
+            in_stock=False,
+        )
+
+        service.save_mapping("whole milk", product)
+        cached = service.get_cached_mapping("whole milk")
+
+        assert cached is not None
+        assert cached.product.in_stock is False
+
+    def test_pin_persists_size_and_stock(self, db_path: str) -> None:
+        """Test pin_mapping persists size and in_stock like save_mapping."""
+        service = self._make_service(db_path)
+        product = SafewayProduct(
+            product_id="UPC012",
+            name="Pinned Milk",
+            price=5.49,
+            size="2 gal",
+            in_stock=False,
+        )
+
+        service.pin_mapping("whole milk", product)
+        cached = service.get_cached_mapping("whole milk")
+
+        assert cached is not None
+        assert cached.product.size == "2 gal"
+        assert cached.product.in_stock is False
+
+    def test_save_update_path_reflects_latest_size_stock_price(
+        self, db_path: str
     ) -> None:
-        """Test that pinned mappings bypass API search."""
+        """Test saving the same product twice updates size/stock/price.
+
+        The UPDATE branch of save_mapping (same search term + product_id
+        already cached) must refresh size and in_stock alongside price,
+        not just price.
+        """
+        service = self._make_service(db_path)
+        original = SafewayProduct(
+            product_id="UPC013",
+            name="Whole Milk",
+            price=4.99,
+            size="1 gal",
+            in_stock=True,
+        )
+        updated = SafewayProduct(
+            product_id="UPC013",
+            name="Whole Milk",
+            price=5.49,
+            size="0.5 gal",
+            in_stock=False,
+        )
+
+        service.save_mapping("whole milk", original)
+        service.save_mapping("whole milk", updated)
+        cached = service.get_cached_mapping("whole milk")
+
+        assert cached is not None
+        assert cached.product.price == 5.49
+        assert cached.product.size == "0.5 gal"
+        assert cached.product.in_stock is False
+
+    def test_pin_update_path_reflects_latest_size_stock_price(
+        self, db_path: str
+    ) -> None:
+        """Test re-pinning an already-cached product refreshes size/stock/price.
+
+        The UPDATE branch of pin_mapping (same search term + product_id
+        already cached) must refresh size and in_stock alongside price,
+        mirroring the save_mapping update path.
+        """
+        service = self._make_service(db_path)
+        original = SafewayProduct(
+            product_id="UPC014",
+            name="Whole Milk",
+            price=4.99,
+            size="1 gal",
+            in_stock=True,
+        )
+        updated = SafewayProduct(
+            product_id="UPC014",
+            name="Whole Milk",
+            price=5.79,
+            size="0.5 gal",
+            in_stock=False,
+        )
+
+        service.save_mapping("whole milk", original)
+        service.pin_mapping("whole milk", updated)
+        cached = service.get_cached_mapping("whole milk")
+
+        assert cached is not None
+        assert cached.is_pinned is True
+        assert cached.product.price == 5.79
+        assert cached.product.size == "0.5 gal"
+        assert cached.product.in_stock is False
+
+    def test_legacy_row_without_size_stock_columns_rehydrates_defaults(
+        self, db_path: str
+    ) -> None:
+        """Test rows lacking real size/stock data rehydrate to safe defaults.
+
+        Regression guard for issue #71: rows written before migration 007
+        have NULL ``safeway_product_size``/``safeway_in_stock``. Those
+        must rehydrate to ``size == ""`` and ``in_stock is True`` rather
+        than raising.
+        """
+        service = self._make_service(db_path)
+        conn = service._connect()
+        try:
+            conn.execute(
+                "INSERT INTO product_mapping"
+                " (ingredient_description, safeway_product_id,"
+                "  safeway_product_name, safeway_price)"
+                " VALUES (?, ?, ?, ?)",
+                ("legacy item", "LEGACY1", "Legacy Product", 2.99),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        cached = service.get_cached_mapping("legacy item")
+
+        assert cached is not None
+        assert cached.product.size == ""
+        assert cached.product.in_stock is True
+
+
+# ------------------------------------------------------------------
+# Tests: get_cached_product
+# ------------------------------------------------------------------
+
+
+class TestGetCachedProduct:
+    """Tests for ProductSearchService.get_cached_product (issue #71).
+
+    Replaces the cache-hit half of the removed ``search_or_cached``: a
+    pinned or fresh mapping is returned (touching times_selected /
+    last_used) without ever performing a live search; a stale or absent
+    mapping returns None so the caller can fall back to a fresh search.
+    """
+
+    def _make_service(self, db_path: str) -> ProductSearchService:
+        """Create a service with a dummy client for cache-only tests.
+
+        Args:
+            db_path: Database path.
+
+        Returns:
+            ProductSearchService instance.
+        """
         transport = _MockTransport([])
         http = httpx.Client(transport=transport)
         client = SafewayClient("user", "pass", "1234", http_client=http)
-        service = ProductSearchService(client, db_path)
+        return ProductSearchService(client, db_path)
 
+    def test_returns_pinned_without_search(self, db_path: str) -> None:
+        """Test pinned mappings are returned without calling search_products."""
+        service = self._make_service(db_path)
         product = SafewayProduct(
             product_id="PIN1", name="Pinned Milk", price=4.99, size="1 gal"
         )
         service.pin_mapping("milk", product)
 
-        results = service.search_or_cached("milk")
+        with patch.object(service, "search_products") as mock_search:
+            result = service.get_cached_product("milk")
 
-        assert len(results) == 1
-        assert results[0].product_id == "PIN1"
+        mock_search.assert_not_called()
+        assert result is not None
+        assert result.product.product_id == "PIN1"
 
-    @patch("grocery_butler.safeway_client.time.sleep")
-    def test_returns_fresh_cache(self, mock_sleep: object, db_path: str) -> None:
-        """Test that fresh cached mappings are returned without searching."""
-        transport = _MockTransport([])
-        http = httpx.Client(transport=transport)
-        client = SafewayClient("user", "pass", "1234", http_client=http)
-        service = ProductSearchService(client, db_path)
-
+    def test_returns_fresh_cache(self, db_path: str) -> None:
+        """Test a fresh (non-stale, non-pinned) mapping is returned."""
+        service = self._make_service(db_path)
         product = SafewayProduct(
             product_id="CACHE1", name="Cached Milk", price=4.99, size="1 gal"
         )
         service.save_mapping("milk", product)
 
-        results = service.search_or_cached("milk")
+        result = service.get_cached_product("milk")
 
-        assert len(results) == 1
-        assert results[0].product_id == "CACHE1"
+        assert result is not None
+        assert result.product.product_id == "CACHE1"
 
-    @patch("grocery_butler.safeway_client.time.sleep")
-    def test_searches_when_no_cache(self, mock_sleep: object, db_path: str) -> None:
-        """Test that search is performed when no cache exists."""
-        response_data = _make_search_response(
-            [
-                _make_nimbus_product(upc="NEW1", name="Fresh Milk", price=3.99),
-            ]
-        )
-        client, _transport = _make_authenticated_client(
-            [
-                httpx.Response(200, json=response_data),
-            ]
-        )
-        service = ProductSearchService(client, db_path)
+    def test_absent_returns_none(self, db_path: str) -> None:
+        """Test an uncached search term returns None."""
+        service = self._make_service(db_path)
+        assert service.get_cached_product("not cached") is None
 
-        results = service.search_or_cached("milk")
-
-        assert len(results) == 1
-        assert results[0].product_id == "NEW1"
-        # Should also be cached now
-        cached = service.get_cached_mapping("milk")
-        assert cached is not None
-        assert cached.product.product_id == "NEW1"
-        client.close()
-
-    @patch("grocery_butler.safeway_client.time.sleep")
-    def test_searches_when_cache_stale(self, mock_sleep: object, db_path: str) -> None:
-        """Test that stale cache triggers a fresh search."""
-        response_data = _make_search_response(
-            [
-                _make_nimbus_product(upc="FRESH1", name="Fresh Milk"),
-            ]
-        )
-        client, _transport = _make_authenticated_client(
-            [
-                httpx.Response(200, json=response_data),
-            ]
-        )
-        service = ProductSearchService(client, db_path)
-
-        # Save a mapping, then make it stale
+    def test_stale_returns_none(self, db_path: str) -> None:
+        """Test a stale, unpinned mapping is not returned."""
+        service = self._make_service(db_path)
         product = SafewayProduct(
             product_id="OLD1", name="Old Milk", price=3.99, size="1 gal"
         )
@@ -613,11 +745,146 @@ class TestSearchOrCached:
         finally:
             conn.close()
 
-        results = service.search_or_cached("milk")
+        assert service.get_cached_product("milk") is None
 
-        assert len(results) == 1
-        assert results[0].product_id == "FRESH1"
+    def test_hit_touches_mapping(self, db_path: str) -> None:
+        """Test a cache hit increments times_selected via _touch_mapping."""
+        service = self._make_service(db_path)
+        product = SafewayProduct(
+            product_id="CACHE1", name="Cached Milk", price=4.99, size="1 gal"
+        )
+        service.save_mapping("milk", product)
+
+        service.get_cached_product("milk")
+
+        cached = service.get_cached_mapping("milk")
+        assert cached is not None
+        assert cached.times_selected == 2
+
+
+# ------------------------------------------------------------------
+# Tests: reverify_product
+# ------------------------------------------------------------------
+
+
+class TestReverifyProduct:
+    """Tests for ProductSearchService.reverify_product (issue #71).
+
+    A cache hit must not trust the stale cached price/size/stock: it
+    re-runs a live search for the mapping's ingredient description and
+    reconciles the cached product_id against the fresh candidates.
+    """
+
+    def _make_service_no_transport(self, db_path: str) -> ProductSearchService:
+        """Create a service whose client would error on any HTTP call.
+
+        Args:
+            db_path: Database path.
+
+        Returns:
+            ProductSearchService instance.
+        """
+        transport = _MockTransport([])
+        http = httpx.Client(transport=transport)
+        client = SafewayClient("user", "pass", "1234", http_client=http)
+        return ProductSearchService(client, db_path)
+
+    def _cached(self, **overrides: Any) -> CachedMapping:
+        """Build a CachedMapping for reverify_product scenarios.
+
+        Args:
+            overrides: SafewayProduct field overrides.
+
+        Returns:
+            A CachedMapping wrapping the (possibly overridden) product.
+        """
+        product_kwargs: dict[str, Any] = {
+            "product_id": "P1",
+            "name": "Chicken Thighs",
+            "price": 3.99,
+            "size": "1 lb",
+            "in_stock": True,
+        }
+        product_kwargs.update(overrides)
+        return CachedMapping(
+            mapping_id=1,
+            ingredient_description="chicken thighs",
+            product=SafewayProduct(**product_kwargs),
+            is_pinned=False,
+            times_selected=1,
+            last_used=datetime.now(tz=UTC),
+        )
+
+    @patch("grocery_butler.safeway_client.time.sleep")
+    def test_matching_candidate_returns_fresh_values(
+        self, mock_sleep: object, db_path: str
+    ) -> None:
+        """Test a matching product_id in fresh search results wins.
+
+        Fresh price/size/stock must replace the cached values.
+        """
+        cached = self._cached()
+        response_data = _make_search_response(
+            [
+                _make_nimbus_product(
+                    upc="P1", name="Chicken Thighs", price=5.49, size="2 lb"
+                ),
+            ]
+        )
+        client, _transport = _make_authenticated_client(
+            [httpx.Response(200, json=response_data)]
+        )
+        service = ProductSearchService(client, db_path)
+
+        result = service.reverify_product(cached)
+
+        assert result.product_id == "P1"
+        assert result.price == 5.49
+        assert result.size == "2 lb"
+        assert result.in_stock is True
         client.close()
+
+    @patch("grocery_butler.safeway_client.time.sleep")
+    def test_no_matching_candidate_marks_out_of_stock(
+        self, mock_sleep: object, db_path: str
+    ) -> None:
+        """Test no product_id match marks the cached product out of stock.
+
+        Regression guard for issue #71: this is the substitution-trigger
+        path for cached items whose Safeway product has since vanished
+        from search results (delisted or out of stock).
+        """
+        cached = self._cached()
+        response_data = _make_search_response(
+            [
+                _make_nimbus_product(upc="OTHER1", name="Different Product"),
+            ]
+        )
+        client, _transport = _make_authenticated_client(
+            [httpx.Response(200, json=response_data)]
+        )
+        service = ProductSearchService(client, db_path)
+
+        result = service.reverify_product(cached)
+
+        assert result.product_id == "P1"
+        assert result.price == 3.99
+        assert result.size == "1 lb"
+        assert result.in_stock is False
+        client.close()
+
+    def test_search_error_returns_cached_product_unchanged(self, db_path: str) -> None:
+        """Test a search failure falls back to the cached product untouched."""
+        cached = self._cached()
+        service = self._make_service_no_transport(db_path)
+
+        with patch.object(
+            service, "search_products", side_effect=ProductSearchError("down")
+        ):
+            result = service.reverify_product(cached)
+
+        assert result == cached.product
+        assert result.in_stock is True
 
 
 # ------------------------------------------------------------------
@@ -667,7 +934,12 @@ class TestRowToCachedMapping:
     """Tests for _row_to_cached_mapping."""
 
     def test_converts_row(self, db_path: str) -> None:
-        """Test converting a database row to CachedMapping."""
+        """Test converting a database row to CachedMapping.
+
+        Covers the real (post-migration-007) row shape: size and stock
+        columns are populated and must be selected and rehydrated
+        alongside the existing fields (issue #71).
+        """
         from grocery_butler.db import get_connection, init_db
 
         init_db(db_path)
@@ -676,15 +948,16 @@ class TestRowToCachedMapping:
             conn.execute(
                 "INSERT INTO product_mapping"
                 " (ingredient_description, safeway_product_id,"
-                "  safeway_product_name, safeway_price, is_pinned)"
-                " VALUES (?, ?, ?, ?, ?)",
-                ("milk", "UPC1", "Test Milk", 3.99, True),
+                "  safeway_product_name, safeway_price, safeway_product_size,"
+                "  safeway_in_stock, is_pinned)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?)",
+                ("milk", "UPC1", "Test Milk", 3.99, "1 gal", False, True),
             )
             conn.commit()
             row = conn.execute(
                 "SELECT id, ingredient_description, safeway_product_id,"
-                " safeway_product_name, safeway_price, last_used,"
-                " times_selected, is_pinned"
+                " safeway_product_name, safeway_price, safeway_product_size,"
+                " safeway_in_stock, last_used, times_selected, is_pinned"
                 " FROM product_mapping LIMIT 1"
             ).fetchone()
             assert row is not None
@@ -696,6 +969,8 @@ class TestRowToCachedMapping:
             assert result.product.product_id == "UPC1"
             assert result.product.name == "Test Milk"
             assert result.product.price == 3.99
+            assert result.product.size == "1 gal"
+            assert result.product.in_stock is False
             assert result.is_pinned is True
             assert result.times_selected == 1
         finally:


### PR DESCRIPTION
## Summary

- Fixes the degraded product-mapping cache: `save_mapping`/`pin_mapping` now persist the product's real `size` and `in_stock` (new `safeway_product_size`/`safeway_in_stock` columns via migration 007, sqlite + pg, with legacy-NULL rehydration guards), instead of rehydrating every cached row with `size=""` / `in_stock=True` / week-old price.
- The cache now stores the **selected** product: `CartBuilder` searches, runs the Claude selector, and caches `selection.product` on a miss; on a hit it skips search+select entirely (`get_cached_product`) and the buggy `search_or_cached` is removed.
- Cached products are **re-verified at cart-build time** (`reverify_product`): fresh price/size/stock are fetched per item; a product that has vanished from search results is marked out of stock so the substitution flow can trigger; on API failure it degrades gracefully to the cached values.

Design note for reviewers: re-verification runs on every cache hit (including pinned mappings) — the cache's savings is skipping the per-item Claude selection call, not the search HTTP call. This is the deliberate cost of correct price/stock per the issue's acceptance criteria. Migration number 006 is intentionally skipped (claimed by PR #107); the migration runner tolerates gaps.

## Test plan

- TDD: 19 tests written first and confirmed RED against the old code, reproducing all three degradations (size=""→quantity pinned to 1, in_stock always True→substitution never triggers, stale price→wrong totals), then turned GREEN by the fix.
- New/updated coverage: `TestCacheOperations` size/stock persistence (insert + update paths for both save and pin), legacy-NULL row rehydration, `TestGetCachedProduct` (pinned/fresh/absent/stale/touch), `TestReverifyProduct` (fresh match, vanished→out-of-stock, API-error fallback), `TestCartBuilderCacheFlow` (selected-product caching, hit skips search+select, reverified size drives quantity, out-of-stock triggers substitution, reverified price drives cost), migration 007 column + idempotency test.
- `./scripts/check-all.sh` → exit 0, 7/7 checks green; full suite 1483 passed, 10 skipped (Postgres-only, no server); coverage 95.87% (>=90% gate).
- Gate 2.5 self-review (code-review-orchestrator): CLEAN.

Closes #71
