### PR TITLE
fix(cart): surface failed fulfillment queries instead of fabricating options

### DIFF
--- a/grocery_butler/api.py
+++ b/grocery_butler/api.py
@@ -482,6 +482,32 @@ def _render_review_section(cart: CartSummary) -> str:
     return f" Needs review: {named}."
 
 
+def _render_fulfillment_section(cart: CartSummary) -> str:
+    """Render a staged-message clause warning about unverified fulfillment.
+
+    Mirrors :func:`_render_review_section` but for the fulfillment gate
+    (Issue #72): when Safeway's fulfillment options could not be
+    confirmed while building the cart, the human must see that warning
+    before ever replying "confirm" — per the issue #59 precedent, that
+    visibility is what makes a later confirm count as an explicit
+    override of the fulfillment gate.
+
+    Args:
+        cart: The cart being staged for confirmation.
+
+    Returns:
+        Empty string for a cart with verified fulfillment, otherwise a
+        sentence warning that fulfillment could not be confirmed.
+    """
+    if not cart.fulfillment_unverified:
+        return ""
+    return (
+        " Fulfillment options could not be confirmed with Safeway "
+        "(unverified) — pickup/delivery availability and fees are not "
+        "final."
+    )
+
+
 @api_v1.post("/order/submit")
 def post_order_submit() -> Response:
     """Stage a Safeway order for confirmation. Never submits directly."""
@@ -495,12 +521,13 @@ def post_order_submit() -> Response:
     )
     item_count = len(cart.items) + len(cart.restock_items)
     review_section = _render_review_section(cart)
+    fulfillment_section = _render_fulfillment_section(cart)
     return jsonify(
         status="pending_confirmation",
         action_id=action_id,
         message=(
             f"Staged Safeway order ({item_count} items, ${total})."
-            f"{review_section} Reply 'confirm' to submit."
+            f"{review_section}{fulfillment_section} Reply 'confirm' to submit."
         ),
     )
 
@@ -636,13 +663,18 @@ def _confirm_order_submit(
         # The staged message (post_order_submit) already named every
         # flagged item and its reason code, so replying "confirm" IS the
         # human's explicit override of the review gate (chief-architect
-        # ruling, issue #59 round 3). The action_id doubles as the
-        # idempotency key so the duplicate-order ledger and Safeway's
-        # clientOrderId correlate with the staged action (Issue #61).
+        # ruling, issue #59 round 3). The staged message also already
+        # warned when fulfillment could not be confirmed with Safeway, so
+        # this same "confirm" is likewise the explicit human override of
+        # the fulfillment gate (issue #59 precedent, issue #72). The
+        # action_id doubles as the idempotency key so the duplicate-order
+        # ledger and Safeway's clientOrderId correlate with the staged
+        # action (Issue #61).
         result = pipeline.submit_cart(
             cart,
             idempotency_key=action.action_id,
             allow_review_items=True,
+            allow_unverified_fulfillment=True,
         )
     except SafewayPipelineError as exc:
         return jsonify(error=f"order submission failed: {exc}"), 502

--- a/grocery_butler/bot.py
+++ b/grocery_butler/bot.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
         InventoryItem,
         ParsedMeal,
         ShoppingListItem,
+        SubstitutionResult,
     )
     from grocery_butler.order_service import OrderResult
     from grocery_butler.safeway_pipeline import SafewayPipeline
@@ -296,9 +297,16 @@ class _OrderConfirmView(discord.ui.View):
             # The rendered preview (_format_cart_summary) already showed
             # the user every flagged item and its reason code, so this
             # button press IS the explicit human override of the review
-            # gate (chief-architect ruling, issue #59 round 3).
+            # gate (chief-architect ruling, issue #59 round 3). The preview
+            # also already warned when fulfillment could not be confirmed
+            # with Safeway (via _format_fulfillment_warning), so this same
+            # confirm press is likewise the explicit human override of the
+            # fulfillment gate (issue #59 precedent, issue #72).
             order_result = await asyncio.to_thread(
-                self._pipeline.submit_cart, self._cart, allow_review_items=True
+                self._pipeline.submit_cart,
+                self._cart,
+                allow_review_items=True,
+                allow_unverified_fulfillment=True,
             )
             msg = _format_order_result(order_result)
             await interaction.followup.send(msg)
@@ -371,6 +379,68 @@ def _format_cart_item_line(ci: CartItem) -> str:
     )
 
 
+def _format_substituted_section(
+    substituted_items: list[SubstitutionResult],
+) -> list[str]:
+    """Format the "Substituted" section lines of a cart summary.
+
+    Args:
+        substituted_items: Substitution results to format.
+
+    Returns:
+        Formatted lines for this section, or an empty list when there
+        are no substituted items.
+    """
+    if not substituted_items:
+        return []
+    lines = [f"\nSubstituted ({len(substituted_items)}):"]
+    for sub in substituted_items:
+        orig = sub.original_item.ingredient
+        alt = sub.selected.product.name if sub.selected else "?"
+        lines.append(f"  {orig} -> {alt}")
+    return lines
+
+
+def _format_failed_section(failed_items: list[ShoppingListItem]) -> list[str]:
+    """Format the "Failed" section lines of a cart summary.
+
+    Args:
+        failed_items: Shopping list items no product could be found for.
+
+    Returns:
+        Formatted lines for this section, or an empty list when there
+        are no failed items.
+    """
+    if not failed_items:
+        return []
+    lines = [f"\nFailed ({len(failed_items)}):"]
+    lines.extend(f"  - {item.ingredient}" for item in failed_items)
+    return lines
+
+
+def _format_fulfillment_warning(cart: CartSummary) -> list[str]:
+    """Format the unverified-fulfillment warning line, if applicable.
+
+    Regression guard for issue #72: when Safeway's fulfillment options
+    could not be confirmed while building the cart, the human must see
+    this warning before ever pressing Confirm.
+
+    Args:
+        cart: Cart summary to inspect.
+
+    Returns:
+        A single-element list with the warning line, or an empty list
+        when the cart's fulfillment was verified.
+    """
+    if not cart.fulfillment_unverified:
+        return []
+    return [
+        "\nWARNING: fulfillment options could not be confirmed with "
+        "Safeway (unverified) — pickup/delivery availability and fees "
+        "below are not final."
+    ]
+
+
 def _format_cart_summary(cart: CartSummary) -> str:
     """Format a CartSummary for Discord display.
 
@@ -390,17 +460,9 @@ def _format_cart_summary(cart: CartSummary) -> str:
         lines.append(f"\nRestock ({len(cart.restock_items)}):")
         lines.extend(_format_cart_item_line(ci) for ci in cart.restock_items)
 
-    if cart.substituted_items:
-        lines.append(f"\nSubstituted ({len(cart.substituted_items)}):")
-        for sub in cart.substituted_items:
-            orig = sub.original_item.ingredient
-            alt = sub.selected.product.name if sub.selected else "?"
-            lines.append(f"  {orig} -> {alt}")
-
-    if cart.failed_items:
-        lines.append(f"\nFailed ({len(cart.failed_items)}):")
-        for item in cart.failed_items:
-            lines.append(f"  - {item.ingredient}")
+    lines.extend(_format_substituted_section(cart.substituted_items))
+    lines.extend(_format_failed_section(cart.failed_items))
+    lines.extend(_format_fulfillment_warning(cart))
 
     lines.append(f"\nSubtotal: ${cart.subtotal:.2f}")
     lines.append(f"Fulfillment: {cart.recommended_fulfillment.value}")

--- a/grocery_butler/cart_builder.py
+++ b/grocery_butler/cart_builder.py
@@ -137,7 +137,7 @@ class CartBuilder:
             elif isinstance(result, SubstitutionResult):
                 substituted.append(result)
 
-        fulfillment_options = self._get_fulfillment_options()
+        fulfillment_options, unverified = self._get_fulfillment_options()
         recommended = _recommend_fulfillment(fulfillment_options)
         subtotal = _calculate_subtotal(cart_items, restock_cart)
         fee = _get_fulfillment_fee(fulfillment_options, recommended)
@@ -152,6 +152,7 @@ class CartBuilder:
             fulfillment_options=fulfillment_options,
             recommended_fulfillment=recommended,
             estimated_total=estimated_total,
+            fulfillment_unverified=unverified,
         )
 
     # ------------------------------------------------------------------
@@ -215,21 +216,29 @@ class CartBuilder:
             result.selected = result.alternatives[0]
         return result
 
-    def _get_fulfillment_options(self) -> list[FulfillmentOption]:
+    def _get_fulfillment_options(self) -> tuple[list[FulfillmentOption], bool]:
         """Query available fulfillment options from Safeway.
 
+        Issue #72 (HIGH): a fetch failure must never be papered over with
+        fabricated pickup/delivery options presented as real availability
+        and fees. On failure this returns an empty options list and flags
+        the result as unverified so callers can warn the human and
+        require an explicit override before submitting.
+
         Returns:
-            List of available fulfillment options.
+            A tuple of (fulfillment options, unverified). ``unverified``
+            is True when the fetch failed, in which case the options
+            list is empty; False (with the parsed options) on success.
         """
         try:
             store_id = self._client.store_id
             response = self._client.get(
                 f"/abs/pub/web/stores/{store_id}/fulfillment",
             )
-            return _parse_fulfillment_response(response)
+            return _parse_fulfillment_response(response), False
         except Exception:
             logger.exception("Failed to fetch fulfillment options")
-            return _default_fulfillment_options()
+            return [], True
 
 
 # ------------------------------------------------------------------
@@ -377,25 +386,3 @@ def _parse_fulfillment_response(
             )
         )
     return options
-
-
-def _default_fulfillment_options() -> list[FulfillmentOption]:
-    """Return default fulfillment options when API is unavailable.
-
-    Returns:
-        Pickup and delivery with default values.
-    """
-    return [
-        FulfillmentOption(
-            type=FulfillmentType.PICKUP,
-            available=True,
-            fee=0.0,
-            windows=[],
-        ),
-        FulfillmentOption(
-            type=FulfillmentType.DELIVERY,
-            available=True,
-            fee=9.95,
-            windows=[],
-        ),
-    ]

--- a/grocery_butler/cli.py
+++ b/grocery_butler/cli.py
@@ -596,6 +596,14 @@ def _format_cart_summary(cart: CartSummary) -> str:
             lines.append(f"  {orig} -> {alt}")
         lines.append("")
 
+    if cart.fulfillment_unverified:
+        lines.append(
+            "WARNING: fulfillment options could not be confirmed with "
+            "Safeway (unverified) — pickup/delivery availability and "
+            "fees below are not final."
+        )
+        lines.append("")
+
     lines.append(f"Subtotal:  ${cart.subtotal:.2f}")
     lines.append(f"Fulfillment: {cart.recommended_fulfillment.value}")
     lines.append(f"Est. Total: ${cart.estimated_total:.2f}")

--- a/grocery_butler/models.py
+++ b/grocery_butler/models.py
@@ -455,7 +455,28 @@ class FulfillmentOption(BaseModel):
 
 
 class CartSummary(BaseModel):
-    """Complete cart ready for order submission."""
+    """Complete cart ready for order submission.
+
+    Attributes:
+        items: Regular cart items.
+        failed_items: Shopping list items no product could be found for.
+        substituted_items: Out-of-stock items with substitution results.
+        skipped_items: Items explicitly skipped by the caller.
+        restock_items: Restock-queue cart items.
+        subtotal: Sum of all item costs before fulfillment fees.
+        fulfillment_options: Fulfillment options fetched from Safeway, or
+            an empty list when the fetch failed (see
+            ``fulfillment_unverified``).
+        recommended_fulfillment: The recommended fulfillment type.
+        estimated_total: Subtotal plus the recommended fulfillment fee.
+        fulfillment_unverified: True when Safeway's fulfillment options
+            could not be fetched, so ``fulfillment_options`` is empty and
+            ``estimated_total`` excludes any fulfillment fee (issue #72).
+            Callers must warn the human and require an explicit override
+            before submitting an order built from such a cart -- never
+            treat the absence of a fee as confirmation that fulfillment
+            is free. Defaults to False (verified).
+    """
 
     items: list[CartItem]
     failed_items: list[ShoppingListItem]
@@ -466,6 +487,7 @@ class CartSummary(BaseModel):
     fulfillment_options: list[FulfillmentOption]
     recommended_fulfillment: FulfillmentType
     estimated_total: float
+    fulfillment_unverified: bool = False
 
 
 class PendingActionStatus(StrEnum):

--- a/grocery_butler/order_service.py
+++ b/grocery_butler/order_service.py
@@ -140,6 +140,7 @@ class OrderService:
         idempotency_key: str | None = None,
         *,
         allow_review_items: bool = False,
+        allow_unverified_fulfillment: bool = False,
     ) -> OrderResult:
         """Submit a cart to Safeway and update inventory.
 
@@ -147,6 +148,10 @@ class OrderService:
         by unit-aware quantity math (see :attr:`CartItem.needs_review`).
         Flagged items block submission unless ``allow_review_items`` is
         set, which represents an explicit human override after review.
+        The cart is also checked for unverified fulfillment (Issue #72):
+        if Safeway's fulfillment options could not be fetched when the
+        cart was built, submission blocks unless
+        ``allow_unverified_fulfillment`` is set.
 
         Sends a ``clientOrderId`` (the given ``idempotency_key``, or a
         freshly generated UUID4 if none is given) with the order so
@@ -164,6 +169,10 @@ class OrderService:
             allow_review_items: If True, bypass the review gate and
                 submit even if items are flagged as ``needs_review``.
                 Defaults to False (safe/blocking).
+            allow_unverified_fulfillment: If True, bypass the fulfillment
+                gate and submit even if ``cart.fulfillment_unverified``
+                is True (Issue #72 explicit human override). Defaults to
+                False (safe/blocking).
 
         Returns:
             OrderResult with confirmation or error details. If order
@@ -171,7 +180,11 @@ class OrderService:
             with :data:`ORDER_SUBMISSION_DISABLED_MESSAGE` before any
             other validation or API call.
         """
-        blocked = self._preflight_block(cart, allow_review_items=allow_review_items)
+        blocked = self._preflight_block(
+            cart,
+            allow_review_items=allow_review_items,
+            allow_unverified_fulfillment=allow_unverified_fulfillment,
+        )
         if blocked is not None:
             return blocked
 
@@ -263,18 +276,22 @@ class OrderService:
         cart: CartSummary,
         *,
         allow_review_items: bool,
+        allow_unverified_fulfillment: bool,
     ) -> OrderResult | None:
         """Run the pre-flight gates that block a submission before any I/O.
 
         Gates run in a deliberate order: the Issue #60 descope gate
         short-circuits first (before any other validation), then the
-        Issue #59 review gate (unless overridden), then the empty-cart
-        check — all before any HTTP call or ledger write.
+        Issue #59 review gate (unless overridden), then the Issue #72
+        fulfillment gate (unless overridden), then the empty-cart check
+        — all before any HTTP call or ledger write.
 
         Args:
             cart: The built cart summary to validate.
             allow_review_items: If True, skip the review gate (explicit
                 human override).
+            allow_unverified_fulfillment: If True, skip the fulfillment
+                gate (explicit human override, Issue #72).
 
         Returns:
             A failed OrderResult describing the first gate that blocks
@@ -288,6 +305,11 @@ class OrderService:
 
         if not allow_review_items:
             blocked = review_block_result(cart)
+            if blocked is not None:
+                return blocked
+
+        if not allow_unverified_fulfillment:
+            blocked = fulfillment_block_result(cart)
             if blocked is not None:
                 return blocked
 
@@ -479,6 +501,45 @@ def _format_review_block_message(flagged: list[CartItem]) -> str:
         "Order blocked pending review: the following items need "
         f"manual review before ordering: {named}. Re-submit with "
         "allow_review_items=True after confirming quantities."
+    )
+
+
+def fulfillment_block_result(cart: CartSummary) -> OrderResult | None:
+    """Return the blocking result for a cart with unverified fulfillment.
+
+    Shared by :meth:`OrderService.submit_order` and the pipeline's
+    duplicate-order guard so the fulfillment gate (Issue #72) is
+    enforced once, consistently, *before* any ledger write or HTTP call
+    — a fulfillment-blocked attempt must never record a duplicate-guard
+    ledger row, because it never reaches Safeway (Issue #61).
+
+    Issue #72 (HIGH): when Safeway's fulfillment options could not be
+    fetched while building the cart, ``CartBuilder`` previously
+    substituted fabricated defaults (free pickup, $9.95 delivery, both
+    marked available) instead of surfacing the failure — presenting
+    invented availability and fees as if fulfillment had been confirmed.
+    The fix flags such a cart ``fulfillment_unverified`` and this
+    function blocks it here, honestly, before any money moves.
+
+    Args:
+        cart: Cart summary to inspect for ``fulfillment_unverified``.
+
+    Returns:
+        A failed :class:`OrderResult` explaining that fulfillment could
+        not be confirmed with Safeway, or None when nothing blocks
+        submission.
+    """
+    if not cart.fulfillment_unverified:
+        return None
+    return OrderResult(
+        success=False,
+        error_message=(
+            "Order blocked — fulfillment options could not be confirmed "
+            "with Safeway, so pickup/delivery availability and fees are "
+            "unverified. Re-submit with "
+            "allow_unverified_fulfillment=True after confirming "
+            "fulfillment manually."
+        ),
     )
 
 

--- a/grocery_butler/safeway_pipeline.py
+++ b/grocery_butler/safeway_pipeline.py
@@ -16,6 +16,7 @@ from grocery_butler.order_service import (
     OrderOutcome,
     OrderResult,
     OrderService,
+    fulfillment_block_result,
     review_block_result,
 )
 from grocery_butler.order_submissions import (
@@ -190,6 +191,7 @@ class SafewayPipeline:
         idempotency_key: str | None = None,
         *,
         allow_review_items: bool = False,
+        allow_unverified_fulfillment: bool = False,
     ) -> OrderResult:
         """Submit a pre-built cart to Safeway.
 
@@ -203,6 +205,10 @@ class SafewayPipeline:
             allow_review_items: If True, bypass the review gate for
                 items flagged as ``needs_review`` (explicit human
                 override). Defaults to False (safe/blocking).
+            allow_unverified_fulfillment: If True, bypass the
+                fulfillment gate for a cart whose fulfillment options
+                could not be confirmed with Safeway (explicit human
+                override, Issue #72). Defaults to False (safe/blocking).
 
         Returns:
             OrderResult with confirmation or error details.
@@ -216,7 +222,10 @@ class SafewayPipeline:
             raise OrderSubmissionDisabledError(ORDER_SUBMISSION_DISABLED_MESSAGE)
         self._authenticate()
         return self._submit_guarded(
-            cart, idempotency_key, allow_review_items=allow_review_items
+            cart,
+            idempotency_key,
+            allow_review_items=allow_review_items,
+            allow_unverified_fulfillment=allow_unverified_fulfillment,
         )
 
     def close(self) -> None:
@@ -242,6 +251,7 @@ class SafewayPipeline:
         idempotency_key: str | None,
         *,
         allow_review_items: bool = False,
+        allow_unverified_fulfillment: bool = False,
     ) -> OrderResult:
         """Submit a cart through the duplicate-order guard (Issue #61).
 
@@ -249,12 +259,14 @@ class SafewayPipeline:
         :class:`~grocery_butler.order_service.OrderService` (which
         rejects it with its existing "cart is empty" error). A cart with
         items flagged ``needs_review`` is blocked next (Issue #59) —
-        unless ``allow_review_items`` overrides — *before* any ledger
-        write, so a review-blocked attempt (which never reaches Safeway)
-        can never leave behind a ledger row that would spuriously mark
-        the post-review resubmission a duplicate. Otherwise, the attempt
-        is atomically recorded in the ledger — or rejected as a
-        duplicate — via a single call to
+        unless ``allow_review_items`` overrides — followed by a cart
+        flagged ``fulfillment_unverified`` (Issue #72) — unless
+        ``allow_unverified_fulfillment`` overrides — both *before* any
+        ledger write, so a gate-blocked attempt (which never reaches
+        Safeway) can never leave behind a ledger row that would
+        spuriously mark a post-override resubmission a duplicate.
+        Otherwise, the attempt is atomically recorded in the ledger — or
+        rejected as a duplicate — via a single call to
         ``OrderSubmissionStore.try_record_attempt`` (fail-closed, and
         race-safe: a security review found the prior
         ``find_recent_blocking`` + ``record_attempt`` pair vulnerable
@@ -267,6 +279,10 @@ class SafewayPipeline:
             allow_review_items: If True, bypass the review gate for
                 flagged items (explicit human override). Defaults to
                 False (safe/blocking).
+            allow_unverified_fulfillment: If True, bypass the
+                fulfillment gate for a cart whose fulfillment options
+                could not be confirmed with Safeway (explicit human
+                override, Issue #72). Defaults to False (safe/blocking).
 
         Returns:
             OrderResult with confirmation, error, or DUPLICATE details.
@@ -276,6 +292,11 @@ class SafewayPipeline:
 
         if not allow_review_items:
             blocked = review_block_result(cart)
+            if blocked is not None:
+                return blocked
+
+        if not allow_unverified_fulfillment:
+            blocked = fulfillment_block_result(cart)
             if blocked is not None:
                 return blocked
 
@@ -305,6 +326,7 @@ class SafewayPipeline:
             cart,
             idempotency_key=key,
             allow_review_items=allow_review_items,
+            allow_unverified_fulfillment=allow_unverified_fulfillment,
         )
 
         self._finalize_submission(submission_id, result)

--- a/tests/test_api_destructive.py
+++ b/tests/test_api_destructive.py
@@ -187,6 +187,18 @@ def _make_cart_with_flagged_item() -> CartSummary:
     )
 
 
+def _make_cart_with_unverified_fulfillment() -> CartSummary:
+    """Return a CartSummary flagged fulfillment_unverified=True (issue #72).
+
+    Mirrors ``_make_cart_with_flagged_item`` but for the fulfillment
+    gate: exercises the staged-message warning and the confirm-time
+    override for a cart whose fulfillment options could not be confirmed
+    with Safeway.
+    """
+    cart = _make_cart({"pasta": 3.50, "sauce": 4.25})
+    return cart.model_copy(update={"fulfillment_unverified": True})
+
+
 def _order_body(costs: dict[str, float] | None = None) -> dict[str, Any]:
     """Return a valid /order/submit request body."""
     cart = _make_cart(costs or {"pasta": 3.50, "sauce": 4.25})
@@ -397,6 +409,27 @@ class TestOrderSubmitStaging:
         assert response.status_code == 200
         message = response.get_json()["message"]
         assert "review" not in message.lower()
+
+    def test_staged_message_includes_unverified_fulfillment_clause(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """The staged message must warn about unverified fulfillment (issue #72).
+
+        Mirrors the needs-review clause: the human must see that
+        fulfillment was never actually confirmed with Safeway before
+        replying "confirm", since that confirm is the explicit override
+        of the fulfillment gate (issue #59 precedent).
+        """
+        cart = _make_cart_with_unverified_fulfillment()
+        response = client.post(
+            "/api/v1/order/submit",
+            json={"cart": cart.model_dump(mode="json")},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        message = response.get_json()["message"].lower()
+        assert "fulfillment" in message
+        assert "unverified" in message or "unconfirmed" in message
 
 
 # ---------------------------------------------------------------------------
@@ -611,6 +644,39 @@ class TestActionsConfirm:
         pipeline.submit_cart.assert_called_once()
         _, kwargs = pipeline.submit_cart.call_args
         assert kwargs.get("allow_review_items") is True
+
+    def test_confirm_order_forwards_allow_unverified_fulfillment_override(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """Confirming a staged order must override the fulfillment gate.
+
+        Issue #72: the staged message (post_order_submit) already warned
+        that fulfillment was unconfirmed before the human replied
+        "confirm", so that confirm IS the explicit human override
+        (mirrors the issue #59 review-gate precedent). The confirm
+        executor must call ``pipeline.submit_cart`` with
+        ``allow_unverified_fulfillment=True``.
+        """
+        body = {
+            "cart": _make_cart_with_unverified_fulfillment().model_dump(mode="json")
+        }
+        action_id = _stage_via_api(client, auth_headers, "/api/v1/order/submit", body)
+
+        pipeline = MagicMock()
+        pipeline.submit_cart.return_value = _successful_order_result()
+        with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
+            response = client.post(
+                "/api/v1/actions/confirm",
+                json={"action_id": action_id},
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 200
+        pipeline.submit_cart.assert_called_once()
+        _, kwargs = pipeline.submit_cart.call_args
+        assert kwargs.get("allow_unverified_fulfillment") is True
 
     def test_failed_order_submission_returns_502(
         self,

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -1989,6 +1989,47 @@ class TestFormatCartSummaryBot:
         assert "Organic Chicken Thighs" in result
         assert "?" not in result
 
+    def test_format_unverified_fulfillment_shows_warning(self) -> None:
+        """Test an unverified-fulfillment cart shows a visible warning.
+
+        Regression guard for issue #72: when Safeway's fulfillment fetch
+        failed, the cart previously presented fabricated pickup/delivery
+        options as if they were real, with no indication anything was
+        wrong. The Discord preview must now warn the human that
+        fulfillment could not be confirmed before they ever press
+        Confirm.
+        """
+        from grocery_butler.models import CartSummary, FulfillmentType
+
+        cart = CartSummary(
+            items=[],
+            failed_items=[],
+            substituted_items=[],
+            skipped_items=[],
+            restock_items=[],
+            subtotal=0.0,
+            fulfillment_options=[],
+            recommended_fulfillment=FulfillmentType.PICKUP,
+            estimated_total=0.0,
+            fulfillment_unverified=True,
+        )
+
+        result = _format_cart_summary(cart)
+
+        lowered = result.lower()
+        assert "fulfillment" in lowered
+        assert "unverified" in lowered or "unconfirmed" in lowered
+
+    def test_format_verified_fulfillment_shows_no_warning(self) -> None:
+        """Test a normal (verified) cart shows no unverified-fulfillment warning."""
+        cart = _make_cart_summary()
+
+        result = _format_cart_summary(cart)
+
+        lowered = result.lower()
+        assert "unverified" not in lowered
+        assert "unconfirmed" not in lowered
+
 
 class TestFormatOrderResult:
     """Tests for _format_order_result in bot module."""
@@ -2366,7 +2407,9 @@ class TestOrderConfirmView:
         press is itself the human approval, so it must always forward
         ``allow_review_items=True`` -- the user already saw the flagged
         items and their reason codes in the preview rendered by
-        ``_format_cart_summary`` before pressing Confirm.
+        ``_format_cart_summary`` before pressing Confirm. The same
+        preview also renders the fulfillment warning (issue #72), so
+        confirm must likewise forward ``allow_unverified_fulfillment=True``.
         """
         cart = _make_cart_summary()
         order_result = _make_order_result(success=True, order_id="ORD-99")
@@ -2380,19 +2423,22 @@ class TestOrderConfirmView:
         mock_interaction.followup.send.assert_called_once()
         call_args = str(mock_interaction.followup.send.call_args)
         assert "ORD-99" in call_args
-        mock_pipeline.submit_cart.assert_called_once_with(cart, allow_review_items=True)
+        mock_pipeline.submit_cart.assert_called_once_with(
+            cart, allow_review_items=True, allow_unverified_fulfillment=True
+        )
         mock_pipeline.close.assert_called_once()
         assert view.is_finished() is True
 
     @pytest.mark.asyncio()
     async def test_confirm_forwards_allow_review_items_override(self, mock_interaction):
-        """Test confirm always passes allow_review_items=True to submit_cart.
+        """Test confirm always passes the review and fulfillment overrides.
 
         Dedicated regression guard (separate from the result-reporting
-        test above) for the exact kwarg the confirm button must forward,
+        test above) for the exact kwargs the confirm button must forward,
         per the chief-architect's ruling: the human already reviewed the
-        flagged items and reasons in the rendered preview, so pressing
-        Confirm is the explicit override.
+        flagged items/reasons and any fulfillment warning in the rendered
+        preview, so pressing Confirm is the explicit override of both
+        gates.
         """
         cart = _make_cart_summary()
         mock_pipeline = MagicMock()
@@ -2404,6 +2450,32 @@ class TestOrderConfirmView:
         mock_pipeline.submit_cart.assert_called_once()
         _, kwargs = mock_pipeline.submit_cart.call_args
         assert kwargs.get("allow_review_items") is True
+        assert kwargs.get("allow_unverified_fulfillment") is True
+
+    @pytest.mark.asyncio()
+    async def test_confirm_forwards_allow_unverified_fulfillment_override(
+        self, mock_interaction
+    ):
+        """Test confirming a fulfillment-unverified cart is not a dead end.
+
+        Issue #72 round-2 review finding: the preview shown before the
+        Confirm button already displays the fulfillment warning (via
+        ``_format_fulfillment_warning``), so a user who saw that warning
+        and pressed Confirm must have the override forwarded to
+        ``submit_cart`` rather than being bounced back with an error
+        about a flag Discord users have no way to set.
+        """
+        cart = _make_cart_summary()
+        cart = cart.model_copy(update={"fulfillment_unverified": True})
+        mock_pipeline = MagicMock()
+        mock_pipeline.submit_cart.return_value = _make_order_result(success=True)
+
+        view = _OrderConfirmView(mock_pipeline, cart)
+        await type(view).confirm(view, mock_interaction, MagicMock())
+
+        mock_pipeline.submit_cart.assert_called_once()
+        _, kwargs = mock_pipeline.submit_cart.call_args
+        assert kwargs.get("allow_unverified_fulfillment") is True
 
     @pytest.mark.asyncio()
     async def test_confirm_submission_failure_reports_and_closes(

--- a/tests/test_cart_builder.py
+++ b/tests/test_cart_builder.py
@@ -11,7 +11,6 @@ from grocery_butler.cart_builder import (
     QuantityDecision,
     _calculate_quantity,
     _calculate_subtotal,
-    _default_fulfillment_options,
     _get_fulfillment_fee,
     _parse_fulfillment_response,
     _recommend_fulfillment,
@@ -467,29 +466,6 @@ class TestParseFulfillmentResponse:
 
 
 # ------------------------------------------------------------------
-# Tests: _default_fulfillment_options
-# ------------------------------------------------------------------
-
-
-class TestDefaultFulfillmentOptions:
-    """Tests for _default_fulfillment_options."""
-
-    def test_returns_two_options(self) -> None:
-        """Test defaults include pickup and delivery."""
-        result = _default_fulfillment_options()
-        assert len(result) == 2
-        types = {o.type for o in result}
-        assert FulfillmentType.PICKUP in types
-        assert FulfillmentType.DELIVERY in types
-
-    def test_pickup_is_free(self) -> None:
-        """Test default pickup fee is 0."""
-        result = _default_fulfillment_options()
-        pickup = next(o for o in result if o.type == FulfillmentType.PICKUP)
-        assert pickup.fee == 0.0
-
-
-# ------------------------------------------------------------------
 # Tests: CartBuilder.build_cart
 # ------------------------------------------------------------------
 
@@ -686,8 +662,22 @@ class TestBuildCart:
 
         assert result.estimated_total == 10.0
 
-    def test_fulfillment_api_failure_uses_defaults(self) -> None:
-        """Test default fulfillment options on API failure."""
+    def test_fulfillment_api_failure_marks_cart_unverified_no_fabricated_options(
+        self,
+    ) -> None:
+        """Test a fulfillment-fetch failure marks the cart unverified (issue #72).
+
+        Regression guard for issue #72 (HIGH): previously any exception
+        raised while fetching fulfillment options was swallowed by
+        ``_get_fulfillment_options`` and replaced with fabricated
+        defaults (free pickup, $9.95 delivery, both marked
+        ``available=True``) via the now-deleted
+        ``_default_fulfillment_options`` helper -- presenting invented
+        availability and fees as real. On failure, ``build_cart`` must
+        instead return an empty ``fulfillment_options`` list and flag
+        ``fulfillment_unverified=True`` so callers know fulfillment was
+        never actually confirmed with Safeway.
+        """
         product = _make_product(price=5.0, size="1 lb")
         builder = self._make_builder(
             search_results=[product],
@@ -696,8 +686,60 @@ class TestBuildCart:
         builder._client.get.side_effect = Exception("API down")
         result = builder.build_cart([_make_item(quantity=1.0)])
 
-        assert len(result.fulfillment_options) == 2
+        assert result.fulfillment_options == []
+        assert result.fulfillment_unverified is True
+
+    def test_fulfillment_api_failure_estimated_total_has_no_fabricated_fee(
+        self,
+    ) -> None:
+        """Test a fulfillment-fetch failure never adds the fabricated $9.95 fee.
+
+        With no fulfillment options available, ``_recommend_fulfillment``
+        falls back to ``PICKUP`` and ``_get_fulfillment_fee`` returns
+        ``0.0``, so the estimated total on an unverified cart must equal
+        the subtotal exactly -- never the subtotal plus an invented
+        delivery fee (issue #72). ``fulfillment_options`` recommending
+        free pickup alone can't distinguish this fix from the old
+        fabricated-defaults behavior (which also recommended free
+        pickup), so this also asserts the options list is empty --
+        i.e. no fabricated delivery option carrying the $9.95 fee is
+        present anywhere in it.
+        """
+        product = _make_product(price=5.0, size="1 lb")
+        builder = self._make_builder(
+            search_results=[product],
+            selection_product=product,
+        )
+        builder._client.get.side_effect = Exception("API down")
+        result = builder.build_cart([_make_item(quantity=1.0)])
+
+        assert result.estimated_total == result.subtotal
         assert result.recommended_fulfillment == FulfillmentType.PICKUP
+        assert result.fulfillment_options == []
+
+    def test_fulfillment_api_success_marks_cart_verified(self) -> None:
+        """Test a successful fulfillment fetch leaves the cart verified.
+
+        On the happy path -- fulfillment options fetched without error --
+        ``fulfillment_unverified`` must be ``False`` and the parsed
+        options from the API response must be used as before (issue #72).
+        """
+        product = _make_product(price=5.0, size="1 lb")
+        fulfillment = {
+            "fulfillmentOptions": [
+                {"type": "pickup", "available": True, "fee": 0.0, "windows": []},
+            ]
+        }
+        builder = self._make_builder(
+            search_results=[product],
+            selection_product=product,
+            fulfillment_response=fulfillment,
+        )
+        result = builder.build_cart([_make_item(quantity=1.0)])
+
+        assert result.fulfillment_unverified is False
+        assert len(result.fulfillment_options) == 1
+        assert result.fulfillment_options[0].type == FulfillmentType.PICKUP
 
     def test_empty_cart(self) -> None:
         """Test building cart with no items."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1932,4 +1932,55 @@ class TestFormatCartSummary:
         result = _format_cart_summary(cart)
         assert "Substituted" in result
         assert "Organic Chicken Thighs" in result
-        assert "?" not in result
+
+    def test_format_unverified_fulfillment_shows_warning(self) -> None:
+        """Test an unverified-fulfillment cart preview shows a warning.
+
+        Regression guard for issue #72: when Safeway's fulfillment fetch
+        failed, the cart previously presented fabricated pickup/delivery
+        options as if they were real, with no indication anything was
+        wrong. The CLI preview must now warn the human that fulfillment
+        could not be confirmed before they submit the order.
+        """
+        from grocery_butler.models import CartSummary, FulfillmentType
+
+        cart = CartSummary(
+            items=[],
+            failed_items=[],
+            substituted_items=[],
+            skipped_items=[],
+            restock_items=[],
+            subtotal=0.0,
+            fulfillment_options=[],
+            recommended_fulfillment=FulfillmentType.PICKUP,
+            estimated_total=0.0,
+            fulfillment_unverified=True,
+        )
+
+        result = _format_cart_summary(cart)
+
+        lowered = result.lower()
+        assert "fulfillment" in lowered
+        assert "unverified" in lowered or "unconfirmed" in lowered
+
+    def test_format_verified_fulfillment_shows_no_warning(self) -> None:
+        """Test a normal (verified) cart preview shows no unverified warning."""
+        from grocery_butler.models import CartSummary, FulfillmentType
+
+        cart = CartSummary(
+            items=[],
+            failed_items=[],
+            substituted_items=[],
+            skipped_items=[],
+            restock_items=[],
+            subtotal=0.0,
+            fulfillment_options=[],
+            recommended_fulfillment=FulfillmentType.PICKUP,
+            estimated_total=0.0,
+        )
+
+        result = _format_cart_summary(cart)
+
+        lowered = result.lower()
+        assert "unverified" not in lowered
+        assert "unconfirmed" not in lowered

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -798,3 +798,50 @@ class TestCartSummary:
         )
         assert summary.subtotal == 0.0
         assert len(summary.items) == 0
+
+    def test_fulfillment_unverified_defaults_to_false(self) -> None:
+        """Test fulfillment_unverified defaults to False when omitted (issue #72).
+
+        Regression guard for issue #72: a cart with fulfillment options
+        that were actually fetched and parsed must not be flagged as
+        unverified by default.
+        """
+        summary = CartSummary(
+            items=[],
+            failed_items=[],
+            substituted_items=[],
+            skipped_items=[],
+            restock_items=[],
+            subtotal=0.0,
+            fulfillment_options=[],
+            recommended_fulfillment=FulfillmentType.PICKUP,
+            estimated_total=0.0,
+        )
+        assert summary.fulfillment_unverified is False
+
+    def test_fulfillment_unverified_round_trips_through_dump_and_validate(
+        self,
+    ) -> None:
+        """Test fulfillment_unverified survives a model_dump/model_validate round trip.
+
+        Issue #72: the API layer stages a cart via ``model_dump(mode="json")``
+        and later reconstructs it via ``model_validate`` when the human
+        confirms, so the flag must not be lost across that round trip.
+        """
+        summary = CartSummary(
+            items=[],
+            failed_items=[],
+            substituted_items=[],
+            skipped_items=[],
+            restock_items=[],
+            subtotal=0.0,
+            fulfillment_options=[],
+            recommended_fulfillment=FulfillmentType.PICKUP,
+            estimated_total=0.0,
+            fulfillment_unverified=True,
+        )
+        dumped = summary.model_dump(mode="json")
+        restored = CartSummary.model_validate(dumped)
+
+        assert dumped["fulfillment_unverified"] is True
+        assert restored.fulfillment_unverified is True

--- a/tests/test_order_service.py
+++ b/tests/test_order_service.py
@@ -109,12 +109,17 @@ def _make_cart_item(
 def _make_cart(
     items: list[CartItem] | None = None,
     restock_items: list[CartItem] | None = None,
+    *,
+    fulfillment_unverified: bool = False,
 ) -> CartSummary:
     """Create a test CartSummary.
 
     Args:
         items: Regular cart items.
         restock_items: Restock queue items.
+        fulfillment_unverified: Whether the cart's fulfillment options
+            failed to be confirmed with Safeway (issue #72). Defaults to
+            False (verified).
 
     Returns:
         CartSummary for testing.
@@ -139,6 +144,7 @@ def _make_cart(
         ],
         recommended_fulfillment=FulfillmentType.PICKUP,
         estimated_total=subtotal,
+        fulfillment_unverified=fulfillment_unverified,
     )
 
 
@@ -638,6 +644,156 @@ class TestSubmitOrderReviewGate:
         result = service.submit_order(_make_cart())
 
         assert result.success is True
+        service._client.post.assert_called_once()
+
+
+# ------------------------------------------------------------------
+# Tests: fulfillment_block_result and OrderService.submit_order
+# fulfillment gate (issue #72)
+# ------------------------------------------------------------------
+#
+# Issue #72 (HIGH): CartBuilder._get_fulfillment_options previously
+# swallowed any fetch failure and substituted fabricated defaults (free
+# pickup, $9.95 delivery, both marked available=True), presenting
+# invented availability and fees as real and letting orders proceed as
+# if fulfillment had been confirmed. The fix marks such a cart
+# fulfillment_unverified, and submit_order must block it before any HTTP
+# call unless the caller explicitly overrides with
+# allow_unverified_fulfillment=True.
+
+
+class TestFulfillmentBlockResult:
+    """Tests for order_service.fulfillment_block_result (issue #72)."""
+
+    def test_unverified_cart_returns_blocking_result(self) -> None:
+        """Test a fulfillment_unverified cart returns a failed OrderResult."""
+        from grocery_butler.order_service import fulfillment_block_result
+
+        cart = _make_cart(fulfillment_unverified=True)
+        result = fulfillment_block_result(cart)
+
+        assert result is not None
+        assert result.success is False
+        assert "fulfillment" in result.error_message.lower()
+
+    def test_verified_cart_returns_none(self) -> None:
+        """Test a verified cart (the default) returns None -- nothing blocks."""
+        from grocery_butler.order_service import fulfillment_block_result
+
+        cart = _make_cart(fulfillment_unverified=False)
+        assert fulfillment_block_result(cart) is None
+
+
+class TestSubmitOrderFulfillmentGate:
+    """Tests for OrderService.submit_order blocking unverified fulfillment."""
+
+    def _make_service(
+        self,
+        api_response: dict[str, Any] | None = None,
+    ) -> OrderService:
+        """Create an OrderService with mock dependencies.
+
+        Args:
+            api_response: Response the mocked client should return if the
+                order submission is allowed to proceed.
+
+        Returns:
+            OrderService with mocked client and pantry. Constructed with
+            ``submission_enabled=True`` because the fulfillment gate
+            under test sits behind the Issue #60 descope gate, which
+            blocks everything by default.
+        """
+        mock_client = MagicMock()
+        mock_client.post.return_value = api_response or {}
+        mock_pantry = MagicMock()
+        mock_pantry.mark_restocked.return_value = 0
+        return OrderService(mock_client, mock_pantry, submission_enabled=True)
+
+    def test_blocks_unverified_fulfillment_cart_before_any_post(self) -> None:
+        """Test an unverified-fulfillment cart blocks submission with no HTTP call."""
+        service = self._make_service()
+        cart = _make_cart(fulfillment_unverified=True)
+
+        result = service.submit_order(cart)
+
+        assert result.success is False
+        assert "fulfillment" in result.error_message.lower()
+        service._client.post.assert_not_called()
+
+    def test_allow_unverified_fulfillment_true_lets_it_proceed(self) -> None:
+        """Test allow_unverified_fulfillment=True is an explicit human override.
+
+        With the override set, submission must proceed exactly like the
+        unflagged happy path: the client is called and success is True.
+        """
+        service = self._make_service(
+            api_response={
+                "orderId": "ORD-123",
+                "status": "confirmed",
+                "total": 8.99,
+            }
+        )
+        cart = _make_cart(fulfillment_unverified=True)
+
+        result = service.submit_order(cart, allow_unverified_fulfillment=True)
+
+        assert result.success is True
+        service._client.post.assert_called_once()
+
+    def test_verified_cart_unaffected_by_default_kwarg(self) -> None:
+        """Test a normal (verified) cart submits normally with the new kwarg default.
+
+        Pins that the new ``allow_unverified_fulfillment`` keyword
+        argument defaults to False without changing behavior for a cart
+        whose fulfillment was actually confirmed.
+        """
+        service = self._make_service(
+            api_response={
+                "orderId": "ORD-456",
+                "status": "confirmed",
+                "total": 8.99,
+            }
+        )
+        result = service.submit_order(_make_cart())
+
+        assert result.success is True
+        service._client.post.assert_called_once()
+
+    def test_review_flagged_and_unverified_cart_needs_both_overrides(self) -> None:
+        """Test a cart that is both review-flagged and unverified needs both flags.
+
+        Overriding only one gate must not be enough to reach the client:
+        the human must explicitly clear both the review gate (issue #59)
+        and the fulfillment gate (issue #72) before real money moves.
+        """
+        flagged = _make_cart_item(
+            ingredient="flour",
+            needs_review=True,
+            review_reason="incomparable_units",
+        )
+        cart = _make_cart(items=[flagged], fulfillment_unverified=True)
+        service = self._make_service(
+            api_response={
+                "orderId": "ORD-789",
+                "status": "confirmed",
+                "total": 8.99,
+            }
+        )
+
+        only_review_override = service.submit_order(cart, allow_review_items=True)
+        assert only_review_override.success is False
+        service._client.post.assert_not_called()
+
+        only_fulfillment_override = service.submit_order(
+            cart, allow_unverified_fulfillment=True
+        )
+        assert only_fulfillment_override.success is False
+        service._client.post.assert_not_called()
+
+        both_overrides = service.submit_order(
+            cart, allow_review_items=True, allow_unverified_fulfillment=True
+        )
+        assert both_overrides.success is True
         service._client.post.assert_called_once()
 
 

--- a/tests/test_safeway_pipeline.py
+++ b/tests/test_safeway_pipeline.py
@@ -594,6 +594,121 @@ class TestSubmitCartReviewGate:
 
 
 # ---------------------------------------------------------------------------
+# Submit cart fulfillment-gate tests (issue #72)
+# ---------------------------------------------------------------------------
+#
+# Issue #72 (HIGH): CartBuilder._get_fulfillment_options previously
+# swallowed a fulfillment-fetch failure and substituted fabricated
+# defaults (free pickup, $9.95 delivery, both available=True), so orders
+# proceeded as if fulfillment had been confirmed. SafewayPipeline.submit_cart
+# and _submit_guarded must block a fulfillment_unverified cart before any
+# duplicate-ledger write, mirroring the review-gate placement (issue #59),
+# and must accept allow_unverified_fulfillment=True as the explicit human
+# override.
+
+
+class TestSubmitCartFulfillmentGate:
+    """Tests for SafewayPipeline.submit_cart blocking unverified fulfillment."""
+
+    @patch("grocery_butler.safeway_pipeline.RecipeStore")
+    @patch("grocery_butler.safeway_pipeline.ProductSearchService")
+    @patch("grocery_butler.safeway_pipeline.ProductSelector")
+    @patch("grocery_butler.safeway_pipeline.SubstitutionService")
+    @patch("grocery_butler.safeway_pipeline.SafewayClient")
+    @patch("grocery_butler.safeway_pipeline.PantryManager")
+    @patch("grocery_butler.safeway_pipeline.CartBuilder")
+    @patch("grocery_butler.safeway_pipeline.OrderService")
+    def test_submit_cart_blocks_unverified_fulfillment_before_ledger_write(
+        self,
+        mock_order_cls: MagicMock,
+        mock_cart_cls: MagicMock,
+        mock_pantry: MagicMock,
+        mock_client_cls: MagicMock,
+        mock_sub: MagicMock,
+        mock_selector: MagicMock,
+        mock_search: MagicMock,
+        mock_store: MagicMock,
+        safeway_config: Config,
+        mock_cart_summary: CartSummary,
+        tmp_path: Path,
+    ) -> None:
+        """Test an unverified-fulfillment cart is blocked before any ledger write.
+
+        Mirrors the review-gate placement (issue #59): a fulfillment-
+        unverified cart must be blocked in the pipeline itself, ahead of
+        the duplicate-order ledger (Issue #61), so a blocked attempt
+        (which never reaches Safeway) never leaves behind a ledger row
+        that would spuriously mark a post-override resubmission of the
+        same cart a duplicate.
+        """
+        from grocery_butler.order_submissions import DUPLICATE_WINDOW, cart_fingerprint
+
+        mock_client_cls.return_value.is_authenticated = True
+        unverified_cart = mock_cart_summary.model_copy(
+            update={"fulfillment_unverified": True}
+        )
+
+        pipeline = SafewayPipeline(safeway_config, str(tmp_path / "orders.db"))
+        result = pipeline.submit_cart(
+            unverified_cart, idempotency_key="key-fulfillment"
+        )
+
+        assert result.success is False
+        assert "fulfillment" in result.error_message.lower()
+        mock_order_cls.return_value.submit_order.assert_not_called()
+        row = pipeline._order_submissions._find_recent_blocking(
+            cart_fingerprint(unverified_cart), DUPLICATE_WINDOW
+        )
+        assert row is None
+
+    @patch("grocery_butler.safeway_pipeline.RecipeStore")
+    @patch("grocery_butler.safeway_pipeline.ProductSearchService")
+    @patch("grocery_butler.safeway_pipeline.ProductSelector")
+    @patch("grocery_butler.safeway_pipeline.SubstitutionService")
+    @patch("grocery_butler.safeway_pipeline.SafewayClient")
+    @patch("grocery_butler.safeway_pipeline.PantryManager")
+    @patch("grocery_butler.safeway_pipeline.CartBuilder")
+    @patch("grocery_butler.safeway_pipeline.OrderService")
+    def test_submit_cart_forwards_allow_unverified_fulfillment_true(
+        self,
+        mock_order_cls: MagicMock,
+        mock_cart_cls: MagicMock,
+        mock_pantry: MagicMock,
+        mock_client_cls: MagicMock,
+        mock_sub: MagicMock,
+        mock_selector: MagicMock,
+        mock_search: MagicMock,
+        mock_store: MagicMock,
+        safeway_config: Config,
+        mock_cart_summary: CartSummary,
+    ) -> None:
+        """Test submit_cart forwards an explicit fulfillment-gate override.
+
+        Callers (bot confirm view, API confirm endpoint) must be able to
+        pass allow_unverified_fulfillment=True through submit_cart to
+        proceed with an unverified-fulfillment cart after explicit human
+        confirmation.
+        """
+        mock_client_cls.return_value.is_authenticated = True
+        expected = OrderResult(success=True)
+        mock_order_cls.return_value.submit_order.return_value = expected
+        unverified_cart = mock_cart_summary.model_copy(
+            update={"fulfillment_unverified": True}
+        )
+
+        pipeline = SafewayPipeline(safeway_config, ":memory:")
+        result = pipeline.submit_cart(
+            unverified_cart, allow_unverified_fulfillment=True
+        )
+
+        assert result is expected
+        mock_submit = mock_order_cls.return_value.submit_order
+        mock_submit.assert_called_once()
+        _, kwargs = mock_submit.call_args
+        assert kwargs.get("allow_unverified_fulfillment") is True
+
+
+# ---------------------------------------------------------------------------
 # Empty shopping list tests
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Stops masking a failed Safeway fulfillment query with fabricated options (pickup free / delivery $9.95, `available=True`): `CartBuilder` now returns an empty options list plus a new `CartSummary.fulfillment_unverified` flag, so previews and `estimated_total` never present invented availability or fees as real.
- Adds a fail-closed submission gate (`order_service.fulfillment_block_result`, mirrored in `OrderService._preflight_block` and `SafewayPipeline._submit_guarded` before any duplicate-ledger write): an unverified-fulfillment cart cannot be submitted unless the new keyword-only `allow_unverified_fulfillment` override is set, following the issue #59 `allow_review_items` precedent.
- Surfaces the failure honestly in every preview (Discord cart summary, CLI preview, API staged-order message); the API confirm handler and the Discord Confirm button pass the override only because their previews named the problem first, making "confirm" the explicit human acknowledgment. The CLI submit path stays blocked by default.

## Test plan

- TDD: 16 new tests written first (RED, reproducing the fabricated-options behavior), then the fix, across `tests/test_cart_builder.py`, `test_models.py`, `test_order_service.py`, `test_safeway_pipeline.py`, `test_bot.py`, `test_api_destructive.py`, `test_cli.py` — covering flag threading, honest `estimated_total`, gate ordering (review + fulfillment gates independently required), block-before-ledger-write, preview warnings, and confirm-as-override forwarding. Obsolete `_default_fulfillment_options` tests removed with the deleted helper.
- `./scripts/check-all.sh` exits 0: 1545 passed / 10 skipped (pre-existing Postgres env skips), coverage 95.97% (floor 90%), mypy strict clean, ruff clean, bandit + pip-audit clean, complexity within thresholds.
- Security-specialist pass over the gates: fail-closed defaults everywhere, no silent-submission path (including `SafewayPipeline.run`), no ledger row on a blocked attempt, warning strings are static literals.
- Backward compatible: `fulfillment_unverified` defaults `False`, so previously staged carts still validate via `model_validate` round-trips.

Closes #72
