### PR TITLE
fix(api): compute staged-order totals server-side with fulfillment fee and order-value cap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,7 @@ SAFEWAY_STORE_ID=
 # Issue #60: real order submission is descoped for v1.0 (unverified
 # checkout API surface). Leave false until the live flow is verified.
 SAFEWAY_ORDER_SUBMISSION_ENABLED=false
+
+# Issue #73: orders whose fee-inclusive total exceeds this amount (USD)
+# are blocked unless explicitly overridden. Defaults to 300 if unset.
+SAFEWAY_ORDER_VALUE_CAP_USD=300

--- a/grocery_butler/api.py
+++ b/grocery_butler/api.py
@@ -12,7 +12,7 @@ import dataclasses
 import datetime as dt
 import os
 import uuid
-from decimal import Decimal
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 from typing import TYPE_CHECKING, Any
 
 from flask import Blueprint, abort, current_app, jsonify, request
@@ -21,7 +21,7 @@ from pydantic import ValidationError
 from grocery_butler import order_service
 from grocery_butler.auth_middleware import require_bearer
 from grocery_butler.claude_utils import make_anthropic_client
-from grocery_butler.config import ConfigError, load_config
+from grocery_butler.config import ConfigError, load_config, parse_order_value_cap
 from grocery_butler.consolidator import Consolidator
 from grocery_butler.db.adapter import IntegrityError
 from grocery_butler.meal_parser import MealParser
@@ -112,6 +112,29 @@ def _safeway_pipeline() -> SafewayPipeline:
     return SafewayPipeline(
         config, current_app.config["DATABASE_PATH"], _anthropic_client()
     )
+
+
+def _order_value_cap() -> Decimal:
+    """Return the configured Safeway order-value cap (Issue #73).
+
+    Reads ``SAFEWAY_ORDER_VALUE_CAP_USD`` directly via
+    :func:`grocery_butler.config.parse_order_value_cap` rather than
+    going through :func:`grocery_butler.config.load_config`, so the
+    ``/order/submit`` cap gate does not depend on Safeway credentials or
+    ``ANTHROPIC_API_KEY`` being configured the way
+    :func:`_safeway_pipeline` does — staging (as opposed to confirming)
+    an order must work even before the rest of the Safeway integration
+    is configured.
+
+    Returns:
+        The parsed, non-negative cap.
+
+    Raises:
+        ConfigError: If ``SAFEWAY_ORDER_VALUE_CAP_USD`` is set to an
+            invalid value.
+    """
+    raw = os.environ.get("SAFEWAY_ORDER_VALUE_CAP_USD", "300")
+    return parse_order_value_cap(raw)
 
 
 def _json_body() -> dict[str, Any]:
@@ -235,17 +258,6 @@ def _parse_shopping_list_payloads(raw_items: Any) -> list[ShoppingListItem]:
         )
 
 
-def _cart_total(cart: CartSummary) -> Decimal:
-    """Sum item and restock costs without float artifacts."""
-    return sum(
-        (
-            Decimal(str(cart_item.estimated_cost))
-            for cart_item in [*cart.items, *cart.restock_items]
-        ),
-        Decimal("0"),
-    )
-
-
 @api_v1.post("/meals/parse")
 def post_meals_parse() -> Response:
     """Parse free-text meal names into structured ingredient lists."""
@@ -288,7 +300,8 @@ def post_order_preview() -> Response | tuple[Response, int]:
         return jsonify(error=f"cart build failed: {exc}"), 503
     finally:
         pipeline.close()
-    return jsonify(cart=cart.model_dump(mode="json"), total=str(_cart_total(cart)))
+    total = order_service.compute_cart_total(cart)
+    return jsonify(cart=cart.model_dump(mode="json"), total=str(total))
 
 
 # ---------------------------------------------------------------------------
@@ -455,6 +468,94 @@ def _parse_cart_payload(body: dict[str, Any]) -> CartSummary:
     return cart
 
 
+def _parse_total(raw: Any) -> Decimal:
+    """Parse a client-supplied ``total`` value into a Decimal, or abort 400.
+
+    Booleans are rejected explicitly (``isinstance(True, int)`` is
+    ``True`` in Python, so a bare numeric-type check would otherwise
+    silently accept ``True``/``False``). Any other non-numeric type
+    (dict, list, etc.) is rejected too. Numeric and numeric-string
+    values are converted via ``Decimal(str(raw))``, which raises
+    ``InvalidOperation`` only for an unparseable string (int/float
+    always stringify to something Decimal accepts).
+
+    Args:
+        raw: The raw ``total`` value from the request body.
+
+    Returns:
+        The parsed value as a Decimal.
+
+    Raises:
+        werkzeug.exceptions.HTTPException: 400 if ``raw`` is not a
+            parseable number.
+    """
+    if isinstance(raw, bool) or not isinstance(raw, (int, float, str)):
+        abort(400, description="total must be a number")
+    try:
+        return Decimal(str(raw))
+    except InvalidOperation:
+        abort(400, description="total must be a number")
+
+
+def _validate_client_total(body: dict[str, Any], server_total: Decimal) -> None:
+    """Validate an optional client-supplied total against the server total.
+
+    A missing ``total`` is accepted (the server total is authoritative
+    either way); a present ``total`` must parse as a number and match
+    the server-computed total to the cent (Issue #73) — a mismatch (or
+    an unparseable value) is rejected rather than trusted verbatim.
+
+    Args:
+        body: Parsed JSON request body.
+        server_total: Fee-inclusive total computed via
+            :func:`grocery_butler.order_service.compute_cart_total`.
+
+    Raises:
+        werkzeug.exceptions.HTTPException: 400 if ``total`` is present
+            but malformed or does not match ``server_total``.
+    """
+    raw = body.get("total")
+    if raw is None:
+        return
+    client_total = _parse_total(raw).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    if client_total != server_total:
+        abort(
+            400,
+            description=(
+                f"total mismatch: client sent {client_total}, "
+                f"server computed {server_total}"
+            ),
+        )
+
+
+def _enforce_order_cap(server_total: Decimal, override: bool) -> None:
+    """Abort 400 if the total exceeds the order-value cap and isn't overridden.
+
+    Args:
+        server_total: Fee-inclusive server-computed total.
+        override: Whether the caller explicitly opted to bypass the cap
+            (``override_cap`` truthy in the request body).
+
+    Raises:
+        werkzeug.exceptions.HTTPException: 400 if ``server_total``
+            exceeds the configured cap and ``override`` is False.
+        ConfigError: If ``SAFEWAY_ORDER_VALUE_CAP_USD`` is set to an
+            invalid value — callers must handle this (see
+            :func:`post_order_submit`).
+    """
+    if override:
+        return
+    cap = _order_value_cap()
+    if server_total > cap:
+        abort(
+            400,
+            description=(
+                f"order total ${server_total} exceeds the order-value cap "
+                f"of ${cap}. Re-submit with override_cap=true to proceed."
+            ),
+        )
+
+
 def _render_review_section(cart: CartSummary) -> str:
     """Render a staged-message clause naming flagged items and reasons.
 
@@ -483,15 +584,39 @@ def _render_review_section(cart: CartSummary) -> str:
 
 
 @api_v1.post("/order/submit")
-def post_order_submit() -> Response:
-    """Stage a Safeway order for confirmation. Never submits directly."""
+def post_order_submit() -> Response | tuple[Response, int]:
+    """Stage a Safeway order for confirmation. Never submits directly.
+
+    The total is always the server-computed, fee-inclusive
+    :func:`~grocery_butler.order_service.compute_cart_total` — an
+    optional client-supplied ``total`` is validated against it (Issue
+    #73) rather than trusted verbatim. Orders whose total exceeds the
+    configured order-value cap are rejected unless the request sets
+    ``override_cap`` truthy, in which case the override is persisted in
+    the staged payload for :func:`_confirm_order_submit` to forward.
+
+    Returns:
+        The staged-action JSON response, or a 503 JSON error if the
+        order-value cap configuration itself is invalid.
+    """
     require_bearer()
     body = _json_body()
     cart = _parse_cart_payload(body)
-    total = str(body.get("total") or _cart_total(cart))
+    server_total = order_service.compute_cart_total(cart)
+    _validate_client_total(body, server_total)
+    override_cap = bool(body.get("override_cap"))
+    try:
+        _enforce_order_cap(server_total, override_cap)
+    except ConfigError as exc:
+        return jsonify(error=f"order-value cap configuration invalid: {exc}"), 503
+    total = str(server_total)
     action_id = _stage_pending(
         "safeway_order_submit",
-        {"cart": cart.model_dump(mode="json"), "total": total},
+        {
+            "cart": cart.model_dump(mode="json"),
+            "total": total,
+            "allow_over_cap": override_cap,
+        },
     )
     item_count = len(cart.items) + len(cart.restock_items)
     review_section = _render_review_section(cart)
@@ -617,7 +742,22 @@ def _order_failure_response(
 def _confirm_order_submit(
     action: PendingAction, store: PendingActionsStore
 ) -> Response | tuple[Response, int]:
-    """Submit the exact staged cart to Safeway (real money)."""
+    """Submit the exact staged cart to Safeway (real money).
+
+    Forwards ``action.payload["allow_over_cap"]`` (set at staging time
+    by ``post_order_submit`` when the human passed ``override_cap``) to
+    :meth:`SafewayPipeline.submit_cart` so the Issue #73 order-value cap
+    gate can be bypassed exactly when it was already approved at
+    staging time.
+
+    Args:
+        action: The staged, not-yet-claimed pending action.
+        store: Pending-actions store used to claim the action.
+
+    Returns:
+        The confirmation JSON response, or an error response/status
+        code per the failure branch that applies.
+    """
     cart = CartSummary.model_validate(action.payload["cart"])
     try:
         pipeline = _safeway_pipeline()
@@ -643,6 +783,7 @@ def _confirm_order_submit(
             cart,
             idempotency_key=action.action_id,
             allow_review_items=True,
+            allow_over_cap=bool(action.payload.get("allow_over_cap", False)),
         )
     except SafewayPipelineError as exc:
         return jsonify(error=f"order submission failed: {exc}"), 502

--- a/grocery_butler/api.py
+++ b/grocery_butler/api.py
@@ -124,7 +124,11 @@ def _order_value_cap() -> Decimal:
     ``ANTHROPIC_API_KEY`` being configured the way
     :func:`_safeway_pipeline` does — staging (as opposed to confirming)
     an order must work even before the rest of the Safeway integration
-    is configured.
+    is configured. The staging-time cap read here and the confirm-time
+    cap enforced inside :class:`OrderService` (via ``load_config``) use
+    the same env var and parser, which assumes the variable stays
+    static for the lifetime of a staged action — changing it mid-flight
+    could let the two gates diverge.
 
     Returns:
         The parsed, non-negative cap.
@@ -477,7 +481,11 @@ def _parse_total(raw: Any) -> Decimal:
     (dict, list, etc.) is rejected too. Numeric and numeric-string
     values are converted via ``Decimal(str(raw))``, which raises
     ``InvalidOperation`` only for an unparseable string (int/float
-    always stringify to something Decimal accepts).
+    always stringify to something Decimal accepts). Non-finite values
+    are rejected as well: Python's json parser accepts the non-standard
+    ``Infinity``/``NaN`` literals and Decimal accepts ``"Infinity"`` /
+    ``"NaN"`` strings, but quantizing a non-finite Decimal raises
+    ``InvalidOperation`` downstream (Gate 2.5 review, Issue #73).
 
     Args:
         raw: The raw ``total`` value from the request body.
@@ -492,9 +500,12 @@ def _parse_total(raw: Any) -> Decimal:
     if isinstance(raw, bool) or not isinstance(raw, (int, float, str)):
         abort(400, description="total must be a number")
     try:
-        return Decimal(str(raw))
+        value = Decimal(str(raw))
     except InvalidOperation:
         abort(400, description="total must be a number")
+    if not value.is_finite():
+        abort(400, description="total must be a finite number")
+    return value
 
 
 def _validate_client_total(body: dict[str, Any], server_total: Decimal) -> None:

--- a/grocery_butler/config.py
+++ b/grocery_butler/config.py
@@ -48,8 +48,7 @@ def parse_order_value_cap(raw: str) -> Decimal:
         cap = Decimal(raw)
     except InvalidOperation as err:
         raise ConfigError(
-            "SAFEWAY_ORDER_VALUE_CAP_USD must be a valid decimal amount, "
-            f"got: {raw!r}"
+            f"SAFEWAY_ORDER_VALUE_CAP_USD must be a valid decimal amount, got: {raw!r}"
         ) from err
     if cap < 0:
         raise ConfigError(

--- a/grocery_butler/config.py
+++ b/grocery_butler/config.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation
 from typing import TYPE_CHECKING
 
 from dotenv import load_dotenv
@@ -18,6 +19,43 @@ if TYPE_CHECKING:
 
 class ConfigError(Exception):
     """Raised when required configuration is missing or invalid."""
+
+
+#: Issue #73: default Safeway order-value cap when
+#: ``SAFEWAY_ORDER_VALUE_CAP_USD`` is not set.
+DEFAULT_ORDER_VALUE_CAP = Decimal("300")
+
+
+def parse_order_value_cap(raw: str) -> Decimal:
+    """Parse and validate the Safeway order-value cap (Issue #73).
+
+    Shared by :func:`load_config` and callers (such as the API layer)
+    that need the cap without loading full application configuration
+    (e.g. without requiring ``ANTHROPIC_API_KEY``) — single source of
+    truth for the parsing/validation rules.
+
+    Args:
+        raw: Raw string value of ``SAFEWAY_ORDER_VALUE_CAP_USD``.
+
+    Returns:
+        The parsed, non-negative cap as a Decimal.
+
+    Raises:
+        ConfigError: If ``raw`` is not a valid decimal amount or is
+            negative.
+    """
+    try:
+        cap = Decimal(raw)
+    except InvalidOperation as err:
+        raise ConfigError(
+            "SAFEWAY_ORDER_VALUE_CAP_USD must be a valid decimal amount, "
+            f"got: {raw!r}"
+        ) from err
+    if cap < 0:
+        raise ConfigError(
+            f"SAFEWAY_ORDER_VALUE_CAP_USD must not be negative, got: {raw!r}"
+        )
+    return cap
 
 
 @dataclass(frozen=True)
@@ -51,6 +89,10 @@ class Config:
     # API surface). Fail-safe default is off; opt in explicitly once the
     # live Safeway checkout flow has been verified.
     safeway_order_submission_enabled: bool = False
+
+    # Issue #73: order-value cap. Orders whose fee-inclusive total
+    # exceeds this amount are blocked unless explicitly overridden.
+    safeway_order_value_cap: Decimal = DEFAULT_ORDER_VALUE_CAP
 
 
 def load_config(env_path: str | Path | None = None) -> Config:
@@ -92,6 +134,9 @@ def load_config(env_path: str | Path | None = None) -> Config:
 
     database_url = os.getenv("DATABASE_URL", "")
 
+    order_value_cap_raw = os.getenv("SAFEWAY_ORDER_VALUE_CAP_USD", "300")
+    safeway_order_value_cap = parse_order_value_cap(order_value_cap_raw)
+
     return Config(
         anthropic_api_key=anthropic_api_key,
         discord_bot_token=os.getenv("DISCORD_BOT_TOKEN", ""),
@@ -108,4 +153,5 @@ def load_config(env_path: str | Path | None = None) -> Config:
             "SAFEWAY_ORDER_SUBMISSION_ENABLED", "false"
         ).lower()
         in ("true", "1", "yes"),
+        safeway_order_value_cap=safeway_order_value_cap,
     )

--- a/grocery_butler/models.py
+++ b/grocery_butler/models.py
@@ -11,7 +11,7 @@ import logging
 from enum import StrEnum
 from typing import Any
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 logger = logging.getLogger(__name__)
 
@@ -440,6 +440,9 @@ class CartItem(BaseModel):
         safeway_product: The matched Safeway product.
         quantity_to_order: Number of product units to order.
         estimated_cost: Estimated cost for ``quantity_to_order`` units.
+            Must be finite — JSON's non-standard ``Infinity``/``NaN``
+            literals are rejected at validation (issue #73), keeping
+            non-finite values out of server-side total computation.
         needs_review: Whether the item needs human review (e.g. an
             unparseable product size, incomparable units, a quantity
             capped by the per-item maximum, or an auto-selected
@@ -453,17 +456,22 @@ class CartItem(BaseModel):
     shopping_list_item: ShoppingListItem
     safeway_product: SafewayProduct
     quantity_to_order: int
-    estimated_cost: float
+    estimated_cost: float = Field(allow_inf_nan=False)
     needs_review: bool = False
     review_reason: str = ""
 
 
 class FulfillmentOption(BaseModel):
-    """A fulfillment option (pickup or delivery) with scheduling."""
+    """A fulfillment option (pickup or delivery) with scheduling.
+
+    The ``fee`` must be finite — JSON's non-standard ``Infinity``/``NaN``
+    literals are rejected at validation (issue #73), keeping non-finite
+    values out of server-side total computation.
+    """
 
     type: FulfillmentType
     available: bool
-    fee: float
+    fee: float = Field(allow_inf_nan=False)
     windows: list[dict[str, Any]]
     next_window: str | None = None
 
@@ -477,12 +485,14 @@ class CartSummary(BaseModel):
         substituted_items: Out-of-stock items with substitution results.
         skipped_items: Items explicitly skipped by the caller.
         restock_items: Restock-queue cart items.
-        subtotal: Sum of all item costs before fulfillment fees.
+        subtotal: Sum of all item costs before fulfillment fees. Must
+            be finite (issue #73).
         fulfillment_options: Fulfillment options fetched from Safeway, or
             an empty list when the fetch failed (see
             ``fulfillment_unverified``).
         recommended_fulfillment: The recommended fulfillment type.
         estimated_total: Subtotal plus the recommended fulfillment fee.
+            Must be finite (issue #73).
         fulfillment_unverified: True when Safeway's fulfillment options
             could not be fetched, so ``fulfillment_options`` is empty and
             ``estimated_total`` excludes any fulfillment fee (issue #72).
@@ -497,10 +507,10 @@ class CartSummary(BaseModel):
     substituted_items: list[SubstitutionResult]
     skipped_items: list[ShoppingListItem] = []
     restock_items: list[CartItem]
-    subtotal: float
+    subtotal: float = Field(allow_inf_nan=False)
     fulfillment_options: list[FulfillmentOption]
     recommended_fulfillment: FulfillmentType
-    estimated_total: float
+    estimated_total: float = Field(allow_inf_nan=False)
     fulfillment_unverified: bool = False
 
 

--- a/grocery_butler/order_service.py
+++ b/grocery_butler/order_service.py
@@ -395,7 +395,20 @@ def compute_cart_total(cart: CartSummary) -> Decimal:
     cents. Deliberately never reads ``cart.subtotal`` or
     ``cart.estimated_total`` — those fields may be stale or supplied by
     an untrusted client, so this is the single source of truth for what
-    a cart actually costs (Issue #73).
+    a cart actually costs (Issue #73). All monetary inputs are
+    guaranteed finite by model validation (``allow_inf_nan=False`` on
+    the ``CartSummary`` field tree), so the cents-quantize below cannot
+    raise ``InvalidOperation`` for a validated cart.
+
+    Known residual risk (Issue #120): when the cart itself arrives from
+    an API caller (``POST /order/submit``), the per-item
+    ``estimated_cost``/``fee`` fields this sums are still
+    client-supplied and are not re-verified against the Safeway
+    catalog — a caller could deflate them to slip under the order-value
+    cap. This matches the accepted trust model of the Issue #59
+    (``needs_review``) and Issue #72 (``fulfillment_unverified``) gates;
+    binding submitted carts to server-built previews (or re-verifying
+    prices at submit) is tracked in Issue #120.
 
     Args:
         cart: Cart summary to total.

--- a/grocery_butler/order_service.py
+++ b/grocery_butler/order_service.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 import uuid
 from dataclasses import dataclass
+from decimal import ROUND_HALF_UP, Decimal
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
@@ -112,6 +113,10 @@ class OrderService:
             Safeway is descoped for v1.0 because the checkout API surface
             is unverified, so this defaults to ``False``. Callers must
             opt in explicitly (see ``SAFEWAY_ORDER_SUBMISSION_ENABLED``).
+        order_value_cap: Issue #73 order-value cap. A cart whose
+            fee-inclusive total (see :func:`compute_cart_total`) exceeds
+            this amount is blocked before any client call unless the
+            caller opts in via ``allow_over_cap``. Defaults to $300.
     """
 
     def __init__(
@@ -120,6 +125,7 @@ class OrderService:
         pantry_manager: PantryManager,
         *,
         submission_enabled: bool = False,
+        order_value_cap: Decimal = Decimal("300"),
     ) -> None:
         """Initialize the order service.
 
@@ -129,10 +135,14 @@ class OrderService:
             submission_enabled: Issue #60 fail-safe gate. Defaults to
                 ``False`` so submission is blocked unless explicitly
                 enabled by the caller.
+            order_value_cap: Issue #73 order-value cap. Defaults to
+                $300; callers should forward the configured
+                ``Config.safeway_order_value_cap`` value.
         """
         self._client = safeway_client
         self._pantry = pantry_manager
         self._submission_enabled = submission_enabled
+        self._order_value_cap = order_value_cap
 
     def submit_order(
         self,
@@ -140,6 +150,7 @@ class OrderService:
         idempotency_key: str | None = None,
         *,
         allow_review_items: bool = False,
+        allow_over_cap: bool = False,
     ) -> OrderResult:
         """Submit a cart to Safeway and update inventory.
 
@@ -147,6 +158,10 @@ class OrderService:
         by unit-aware quantity math (see :attr:`CartItem.needs_review`).
         Flagged items block submission unless ``allow_review_items`` is
         set, which represents an explicit human override after review.
+        The cart's fee-inclusive total (see :func:`compute_cart_total`)
+        is also checked against ``order_value_cap``; a total exceeding
+        the cap blocks submission unless ``allow_over_cap`` is set
+        (Issue #73).
 
         Sends a ``clientOrderId`` (the given ``idempotency_key``, or a
         freshly generated UUID4 if none is given) with the order so
@@ -164,6 +179,9 @@ class OrderService:
             allow_review_items: If True, bypass the review gate and
                 submit even if items are flagged as ``needs_review``.
                 Defaults to False (safe/blocking).
+            allow_over_cap: If True, bypass the order-value cap gate
+                (Issue #73) even if the cart total exceeds
+                ``order_value_cap``. Defaults to False (safe/blocking).
 
         Returns:
             OrderResult with confirmation or error details. If order
@@ -171,7 +189,11 @@ class OrderService:
             with :data:`ORDER_SUBMISSION_DISABLED_MESSAGE` before any
             other validation or API call.
         """
-        blocked = self._preflight_block(cart, allow_review_items=allow_review_items)
+        blocked = self._preflight_block(
+            cart,
+            allow_review_items=allow_review_items,
+            allow_over_cap=allow_over_cap,
+        )
         if blocked is not None:
             return blocked
 
@@ -263,18 +285,22 @@ class OrderService:
         cart: CartSummary,
         *,
         allow_review_items: bool,
+        allow_over_cap: bool,
     ) -> OrderResult | None:
         """Run the pre-flight gates that block a submission before any I/O.
 
         Gates run in a deliberate order: the Issue #60 descope gate
         short-circuits first (before any other validation), then the
         Issue #59 review gate (unless overridden), then the empty-cart
-        check — all before any HTTP call or ledger write.
+        check, then the Issue #73 order-value cap gate (unless
+        overridden) — all before any HTTP call or ledger write.
 
         Args:
             cart: The built cart summary to validate.
             allow_review_items: If True, skip the review gate (explicit
                 human override).
+            allow_over_cap: If True, skip the order-value cap gate
+                (explicit human override).
 
         Returns:
             A failed OrderResult describing the first gate that blocks
@@ -296,6 +322,18 @@ class OrderService:
                 success=False,
                 error_message="Cart is empty — nothing to order",
             )
+
+        if not allow_over_cap:
+            total = compute_cart_total(cart)
+            if total > self._order_value_cap:
+                return OrderResult(
+                    success=False,
+                    error_message=(
+                        f"Order total ${total} exceeds the order-value cap "
+                        f"of ${self._order_value_cap}. Re-submit with "
+                        "allow_over_cap=True to proceed."
+                    ),
+                )
         return None
 
     def _restock_ordered_items(self, cart: CartSummary) -> int:
@@ -328,6 +366,53 @@ class OrderService:
 # ------------------------------------------------------------------
 # Pure helper functions
 # ------------------------------------------------------------------
+
+
+def compute_cart_total(cart: CartSummary) -> Decimal:
+    """Compute the fee-inclusive, server-trusted total for a cart.
+
+    Sums the estimated cost of every regular and restock item and adds
+    the recommended fulfillment option's fee (see
+    :func:`_recommended_fulfillment_fee`), then quantizes the result to
+    cents. Deliberately never reads ``cart.subtotal`` or
+    ``cart.estimated_total`` — those fields may be stale or supplied by
+    an untrusted client, so this is the single source of truth for what
+    a cart actually costs (Issue #73).
+
+    Args:
+        cart: Cart summary to total.
+
+    Returns:
+        The fee-inclusive total, quantized to cents with ROUND_HALF_UP.
+    """
+    items_total = sum(
+        (Decimal(str(item.estimated_cost)) for item in cart.items + cart.restock_items),
+        Decimal("0"),
+    )
+    total = items_total + _recommended_fulfillment_fee(cart)
+    return total.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+
+
+def _recommended_fulfillment_fee(cart: CartSummary) -> Decimal:
+    """Return the fee for the cart's recommended fulfillment option.
+
+    Deliberately does not import
+    ``grocery_butler.cart_builder._get_fulfillment_fee`` — sibling
+    changes land in ``cart_builder.py`` independently, and this module
+    must not couple to it (chief-architect ruling, Issue #73).
+
+    Args:
+        cart: Cart summary whose fulfillment options to scan.
+
+    Returns:
+        The fee of the fulfillment option matching
+        ``cart.recommended_fulfillment``, or ``Decimal("0")`` if no
+        option matches.
+    """
+    for option in cart.fulfillment_options:
+        if option.type == cart.recommended_fulfillment:
+            return Decimal(str(option.fee))
+    return Decimal("0")
 
 
 def _build_order_payload(

--- a/grocery_butler/safeway_pipeline.py
+++ b/grocery_butler/safeway_pipeline.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import logging
 import uuid
-from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
 from grocery_butler.cart_builder import CartBuilder
@@ -33,6 +32,8 @@ from grocery_butler.safeway_client import SafewayClient
 from grocery_butler.substitution_service import SubstitutionService
 
 if TYPE_CHECKING:
+    from decimal import Decimal
+
     from grocery_butler.config import Config
     from grocery_butler.models import CartSummary, ShoppingListItem
 
@@ -311,9 +312,7 @@ class SafewayPipeline:
             OrderResult with confirmation, error, or DUPLICATE details.
         """
         if not cart.items and not cart.restock_items:
-            return self._order_service.submit_order(
-                cart, allow_over_cap=allow_over_cap
-            )
+            return self._order_service.submit_order(cart, allow_over_cap=allow_over_cap)
 
         if not allow_review_items:
             blocked = review_block_result(cart)

--- a/grocery_butler/safeway_pipeline.py
+++ b/grocery_butler/safeway_pipeline.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
 from grocery_butler.cart_builder import CartBuilder
@@ -116,12 +117,14 @@ class SafewayPipeline:
         # OrderService also defaults to disabled, and this pipeline
         # additionally short-circuits run()/submit_cart() before any I/O.
         self._submission_enabled = config.safeway_order_submission_enabled
+        self._order_value_cap = config.safeway_order_value_cap
 
         pantry_manager = PantryManager(db_path, anthropic_client)
         self._order_service = OrderService(
             self._client,
             pantry_manager,
             submission_enabled=self._submission_enabled,
+            order_value_cap=self._order_value_cap,
         )
         self._order_submissions = OrderSubmissionStore(db_path)
 
@@ -134,6 +137,16 @@ class SafewayPipeline:
             when this pipeline's config was loaded, False otherwise.
         """
         return self._submission_enabled
+
+    @property
+    def order_value_cap(self) -> Decimal:
+        """The configured Safeway order-value cap (Issue #73 gate).
+
+        Returns:
+            The cap threshold read from ``config.safeway_order_value_cap``
+            when this pipeline was constructed.
+        """
+        return self._order_value_cap
 
     def run(
         self,
@@ -190,6 +203,7 @@ class SafewayPipeline:
         idempotency_key: str | None = None,
         *,
         allow_review_items: bool = False,
+        allow_over_cap: bool = False,
     ) -> OrderResult:
         """Submit a pre-built cart to Safeway.
 
@@ -203,6 +217,10 @@ class SafewayPipeline:
             allow_review_items: If True, bypass the review gate for
                 items flagged as ``needs_review`` (explicit human
                 override). Defaults to False (safe/blocking).
+            allow_over_cap: If True, bypass the Issue #73 order-value
+                cap gate for a total exceeding ``order_value_cap``
+                (explicit human override). Defaults to False
+                (safe/blocking).
 
         Returns:
             OrderResult with confirmation or error details.
@@ -216,7 +234,10 @@ class SafewayPipeline:
             raise OrderSubmissionDisabledError(ORDER_SUBMISSION_DISABLED_MESSAGE)
         self._authenticate()
         return self._submit_guarded(
-            cart, idempotency_key, allow_review_items=allow_review_items
+            cart,
+            idempotency_key,
+            allow_review_items=allow_review_items,
+            allow_over_cap=allow_over_cap,
         )
 
     def close(self) -> None:
@@ -242,6 +263,7 @@ class SafewayPipeline:
         idempotency_key: str | None,
         *,
         allow_review_items: bool = False,
+        allow_over_cap: bool = False,
     ) -> OrderResult:
         """Submit a cart through the duplicate-order guard (Issue #61).
 
@@ -267,12 +289,17 @@ class SafewayPipeline:
             allow_review_items: If True, bypass the review gate for
                 flagged items (explicit human override). Defaults to
                 False (safe/blocking).
+            allow_over_cap: If True, bypass the Issue #73 order-value
+                cap gate (explicit human override). Defaults to False
+                (safe/blocking).
 
         Returns:
             OrderResult with confirmation, error, or DUPLICATE details.
         """
         if not cart.items and not cart.restock_items:
-            return self._order_service.submit_order(cart)
+            return self._order_service.submit_order(
+                cart, allow_over_cap=allow_over_cap
+            )
 
         if not allow_review_items:
             blocked = review_block_result(cart)
@@ -305,6 +332,7 @@ class SafewayPipeline:
             cart,
             idempotency_key=key,
             allow_review_items=allow_review_items,
+            allow_over_cap=allow_over_cap,
         )
 
         self._finalize_submission(submission_id, result)

--- a/tests/test_api_compute.py
+++ b/tests/test_api_compute.py
@@ -24,6 +24,7 @@ from grocery_butler.auth_middleware import SECRET_ENV_VAR, mint_token
 from grocery_butler.models import (
     CartItem,
     CartSummary,
+    FulfillmentOption,
     FulfillmentType,
     Ingredient,
     IngredientCategory,
@@ -381,7 +382,12 @@ class TestOrderPreview:
     def test_builds_cart_and_returns_decimal_safe_total(
         self, client: FlaskClient, auth_headers: dict[str, str]
     ) -> None:
-        """0.1 + 0.2 comes back as exactly "0.3", not a float artifact."""
+        """0.1 + 0.2 comes back as exactly "0.30", not a float artifact.
+
+        Issue #73: totals are now server-computed via
+        ``order_service.compute_cart_total``, which quantizes monetary
+        values to cents — hence "0.30" rather than the bare "0.3".
+        """
         pipeline = MagicMock()
         pipeline.build_cart_only.return_value = _make_cart({"pasta": 0.1, "beans": 0.2})
         item = _make_shopping_item()
@@ -396,7 +402,7 @@ class TestOrderPreview:
         pipeline.build_cart_only.assert_called_once_with([item])
         pipeline.close.assert_called_once_with()
         body = response.get_json()
-        assert body["total"] == "0.3"
+        assert body["total"] == "0.30"
         assert len(body["cart"]["items"]) == 2
 
     def test_restock_items_count_toward_total(
@@ -418,6 +424,44 @@ class TestOrderPreview:
 
         assert response.status_code == 200
         assert response.get_json()["total"] == "3.75"
+
+    def test_order_preview_total_includes_fulfillment_fee(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """Test the preview total includes the recommended fulfillment fee.
+
+        Issue #73: /order/preview computes its total via the same
+        fee-omitting ``_cart_total`` helper as /order/submit. A cart
+        with a $4.00 recommended-fulfillment fee on top of a $1.25 item
+        must preview a $5.25 total, not $1.25.
+        """
+        cart = _make_cart({"pasta": 1.25})
+        cart = cart.model_copy(
+            update={
+                "fulfillment_options": [
+                    FulfillmentOption(
+                        type=FulfillmentType.PICKUP,
+                        available=True,
+                        fee=4.00,
+                        windows=[],
+                    ),
+                ],
+                "recommended_fulfillment": FulfillmentType.PICKUP,
+            }
+        )
+        pipeline = MagicMock()
+        pipeline.build_cart_only.return_value = cart
+        with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
+            response = client.post(
+                "/api/v1/order/preview",
+                json={
+                    "shopping_list": [_make_shopping_item().model_dump(mode="json")]
+                },
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 200
+        assert response.get_json()["total"] == "5.25"
 
     def test_pipeline_error_returns_503(
         self, client: FlaskClient, auth_headers: dict[str, str]

--- a/tests/test_api_compute.py
+++ b/tests/test_api_compute.py
@@ -454,9 +454,7 @@ class TestOrderPreview:
         with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
             response = client.post(
                 "/api/v1/order/preview",
-                json={
-                    "shopping_list": [_make_shopping_item().model_dump(mode="json")]
-                },
+                json={"shopping_list": [_make_shopping_item().model_dump(mode="json")]},
                 headers=auth_headers,
             )
 

--- a/tests/test_api_destructive.py
+++ b/tests/test_api_destructive.py
@@ -32,6 +32,7 @@ from grocery_butler.models import (
     BrandPreferenceType,
     CartItem,
     CartSummary,
+    FulfillmentOption,
     FulfillmentType,
     IngredientCategory,
     PendingActionStatus,
@@ -157,6 +158,43 @@ def _make_cart(costs: dict[str, float]) -> CartSummary:
         fulfillment_options=[],
         recommended_fulfillment=FulfillmentType.PICKUP,
         estimated_total=sum(costs.values()),
+    )
+
+
+def _make_cart_with_fee(costs: dict[str, float], fee: float) -> CartSummary:
+    """Return a CartSummary whose recommended fulfillment option has a fee.
+
+    Unlike :func:`_make_cart` (empty ``fulfillment_options``), this pins
+    a non-zero fee on the recommended (pickup) fulfillment option so
+    tests can verify the staged total includes it (issue #73).
+    ``estimated_total`` deliberately omits the fee, matching the shape
+    of a cart built by today's (buggy) pipeline.
+
+    Args:
+        costs: Mapping of ingredient name to estimated cost.
+        fee: Fee for the recommended pickup fulfillment option.
+
+    Returns:
+        A CartSummary with a non-zero recommended-fulfillment fee.
+    """
+    items = [_make_cart_item(name, cost) for name, cost in costs.items()]
+    subtotal = sum(costs.values())
+    return CartSummary(
+        items=items,
+        failed_items=[],
+        substituted_items=[],
+        restock_items=[],
+        subtotal=subtotal,
+        fulfillment_options=[
+            FulfillmentOption(
+                type=FulfillmentType.PICKUP,
+                available=True,
+                fee=fee,
+                windows=[],
+            ),
+        ],
+        recommended_fulfillment=FulfillmentType.PICKUP,
+        estimated_total=subtotal,
     )
 
 
@@ -397,6 +435,194 @@ class TestOrderSubmitStaging:
         assert response.status_code == 200
         message = response.get_json()["message"]
         assert "review" not in message.lower()
+
+
+# ---------------------------------------------------------------------------
+# POST /order/submit — issue #73: server-trusted total and order-value cap
+#
+# Today ``post_order_submit`` does
+# ``total = str(body.get("total") or _cart_total(cart))``: a client-
+# supplied total is trusted verbatim (staged into the confirmation
+# message and audit payload), ``_cart_total`` omits the recommended
+# fulfillment fee, and there is no order-value cap anywhere. These tests
+# pin the fixed behavior: the server always computes the fee-inclusive
+# total, a mismatching/non-numeric client total is rejected, and orders
+# over a configurable cap are blocked unless explicitly overridden.
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, SECRET_ENV)
+class TestOrderSubmitTotalValidationAndCap:
+    """/order/submit trusts only the server total and enforces a value cap."""
+
+    def test_order_submit_rejects_client_total_mismatch_returns_400(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """Test a client total that mismatches the server total is rejected.
+
+        A $200 cart staged with a lying client total of "7.75" must be
+        rejected with 400. Today it is staged as-is: the client's lie
+        becomes the audited total.
+        """
+        cart = _make_cart({"steak": 200.00})
+        response = client.post(
+            "/api/v1/order/submit",
+            json={"cart": cart.model_dump(mode="json"), "total": "7.75"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 400
+        assert "total" in response.get_json()["error"].lower()
+
+    @pytest.mark.parametrize(
+        "bad_total",
+        [{"x": 1}, True, [1, 2], "not-a-number"],
+        ids=["dict", "bool", "list", "unparseable-str"],
+    )
+    def test_order_submit_rejects_non_numeric_total_returns_400(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        bad_total: Any,
+    ) -> None:
+        """Test dict/list/bool/unparseable-string totals are rejected with 400.
+
+        Today's ``body.get("total") or _cart_total(cart)`` accepts any
+        truthy value verbatim — a dict or list would even survive
+        ``str()`` into the staged message and audit payload.
+        """
+        body = _order_body()
+        body["total"] = bad_total
+        response = client.post(
+            "/api/v1/order/submit", json=body, headers=auth_headers
+        )
+        assert response.status_code == 400
+        assert "total" in response.get_json()["error"].lower()
+
+    def test_order_submit_accepts_matching_client_total(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        pending_store: PendingActionsStore,
+    ) -> None:
+        """Test a client total exactly equal to the server total is accepted.
+
+        Once total validation exists, a correct client total must still
+        stage normally (200) with the server-computed total persisted
+        in the pending payload.
+        """
+        cart = _make_cart({"pasta": 3.50, "sauce": 4.25})
+        response = client.post(
+            "/api/v1/order/submit",
+            json={"cart": cart.model_dump(mode="json"), "total": "7.75"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        action = pending_store.get_pending_action(response.get_json()["action_id"])
+        assert action is not None
+        assert action.payload["total"] == "7.75"
+
+    def test_order_submit_message_uses_fee_inclusive_server_total(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        pending_store: PendingActionsStore,
+    ) -> None:
+        """Test the staged total/message include the recommended fulfillment fee.
+
+        ``_cart_total`` in api.py sums only item/restock costs and
+        omits ``cart.fulfillment_options[].fee`` for the recommended
+        option. With no client total supplied, the staged total must be
+        item-plus-fee inclusive: $3.50 + $4.25 + $2.50 fee = $10.25.
+        """
+        cart = _make_cart_with_fee({"pasta": 3.50, "sauce": 4.25}, fee=2.50)
+        response = client.post(
+            "/api/v1/order/submit",
+            json={"cart": cart.model_dump(mode="json")},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        data = response.get_json()
+        assert "$10.25" in data["message"]
+        action = pending_store.get_pending_action(data["action_id"])
+        assert action is not None
+        assert action.payload["total"] == "10.25"
+
+    def test_order_submit_over_cap_without_override_returns_400(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """Test a cart whose server total exceeds the cap is rejected with 400.
+
+        There is no order-value cap anywhere today, so a cart totalling
+        well over $300 stages successfully. The fixed behavior must
+        reject staging with 400 mentioning the cap unless overridden.
+        """
+        cart = _make_cart({"prime rib": 350.00})
+        response = client.post(
+            "/api/v1/order/submit",
+            json={"cart": cart.model_dump(mode="json")},
+            headers=auth_headers,
+        )
+        assert response.status_code == 400
+        assert "cap" in response.get_json()["error"].lower()
+
+    def test_order_submit_over_cap_with_override_stages_with_flag(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        pending_store: PendingActionsStore,
+    ) -> None:
+        """Test override_cap=true stages an over-cap order with the flag persisted.
+
+        When a human explicitly overrides the cap, staging must succeed
+        and record ``allow_over_cap=True`` in the pending payload so the
+        confirm path can thread it through to OrderService's cap gate.
+        """
+        cart = _make_cart({"prime rib": 350.00})
+        response = client.post(
+            "/api/v1/order/submit",
+            json={"cart": cart.model_dump(mode="json"), "override_cap": True},
+            headers=auth_headers,
+        )
+        assert response.status_code == 200
+        action = pending_store.get_pending_action(response.get_json()["action_id"])
+        assert action is not None
+        assert action.payload["allow_over_cap"] is True
+
+    def test_confirm_order_submit_passes_allow_over_cap_to_pipeline(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """Test confirm forwards allow_over_cap from the staged payload.
+
+        ``_confirm_order_submit`` must read
+        ``action.payload.get("allow_over_cap", False)`` and forward it
+        to ``pipeline.submit_cart`` so the OrderService cap gate can be
+        overridden by a human who already approved the over-cap total
+        at staging time.
+        """
+        cart = _make_cart({"prime rib": 350.00})
+        stage_response = client.post(
+            "/api/v1/order/submit",
+            json={"cart": cart.model_dump(mode="json"), "override_cap": True},
+            headers=auth_headers,
+        )
+        assert stage_response.status_code == 200
+        action_id = stage_response.get_json()["action_id"]
+
+        pipeline = MagicMock()
+        pipeline.submit_cart.return_value = _successful_order_result()
+        with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
+            response = client.post(
+                "/api/v1/actions/confirm",
+                json={"action_id": action_id},
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 200
+        pipeline.submit_cart.assert_called_once()
+        _, kwargs = pipeline.submit_cart.call_args
+        assert kwargs.get("allow_over_cap") is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_api_destructive.py
+++ b/tests/test_api_destructive.py
@@ -525,9 +525,7 @@ class TestOrderSubmitTotalValidationAndCap:
         """
         body = _order_body()
         body["total"] = bad_total
-        response = client.post(
-            "/api/v1/order/submit", json=body, headers=auth_headers
-        )
+        response = client.post("/api/v1/order/submit", json=body, headers=auth_headers)
         assert response.status_code == 400
         assert "total" in response.get_json()["error"].lower()
 

--- a/tests/test_api_destructive.py
+++ b/tests/test_api_destructive.py
@@ -508,8 +508,26 @@ class TestOrderSubmitTotalValidationAndCap:
 
     @pytest.mark.parametrize(
         "bad_total",
-        [{"x": 1}, True, [1, 2], "not-a-number"],
-        ids=["dict", "bool", "list", "unparseable-str"],
+        [
+            {"x": 1},
+            True,
+            [1, 2],
+            "not-a-number",
+            float("inf"),
+            float("nan"),
+            "Infinity",
+            "NaN",
+        ],
+        ids=[
+            "dict",
+            "bool",
+            "list",
+            "unparseable-str",
+            "inf",
+            "nan",
+            "inf-str",
+            "nan-str",
+        ],
     )
     def test_order_submit_rejects_non_numeric_total_returns_400(
         self,
@@ -517,17 +535,60 @@ class TestOrderSubmitTotalValidationAndCap:
         auth_headers: dict[str, str],
         bad_total: Any,
     ) -> None:
-        """Test dict/list/bool/unparseable-string totals are rejected with 400.
+        """Test non-numeric and non-finite totals are rejected with 400.
 
         Today's ``body.get("total") or _cart_total(cart)`` accepts any
         truthy value verbatim — a dict or list would even survive
-        ``str()`` into the staged message and audit payload.
+        ``str()`` into the staged message and audit payload. Python's
+        json parser also accepts the non-standard ``Infinity``/``NaN``
+        literals, and ``"Infinity"``/``"NaN"`` strings are valid Decimal
+        literals — quantizing them raises ``InvalidOperation``, so
+        without an explicit finiteness check they crash with an
+        unhandled 500 instead of this clean 400 (Gate 2.5 review).
         """
         body = _order_body()
         body["total"] = bad_total
         response = client.post("/api/v1/order/submit", json=body, headers=auth_headers)
         assert response.status_code == 400
         assert "total" in response.get_json()["error"].lower()
+
+    def test_order_submit_rejects_non_finite_cart_costs_returns_400(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """Test a cart item with an Infinity estimated_cost is rejected with 400.
+
+        Python's json parser accepts the non-standard ``Infinity``
+        literal, and a non-finite item cost reaches
+        ``compute_cart_total`` whose cents-quantize step raises an
+        uncaught ``decimal.InvalidOperation`` — an unhandled 500 instead
+        of a clean 400 (Gate 2.5 review). The model layer must reject
+        non-finite monetary fields so ``_parse_cart_payload``'s existing
+        ValidationError handler turns this into a 400.
+        """
+        body = _order_body()
+        body["cart"]["items"][0]["estimated_cost"] = float("inf")
+        del body["total"]
+        response = client.post("/api/v1/order/submit", json=body, headers=auth_headers)
+        assert response.status_code == 400
+        assert "cart" in response.get_json()["error"].lower()
+
+    def test_order_submit_invalid_cap_config_returns_503(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """Test an unparseable SAFEWAY_ORDER_VALUE_CAP_USD yields a JSON 503.
+
+        The cap gate reads the env var at staging time; if an operator
+        has set it to garbage the request must fail with a clean JSON
+        503 naming the configuration problem, not an unhandled 500.
+        """
+        body = _order_body()
+        del body["total"]
+        with patch.dict(os.environ, {"SAFEWAY_ORDER_VALUE_CAP_USD": "garbage"}):
+            response = client.post(
+                "/api/v1/order/submit", json=body, headers=auth_headers
+            )
+        assert response.status_code == 503
+        assert "cap" in response.get_json()["error"].lower()
 
     def test_order_submit_accepts_matching_client_total(
         self,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -284,6 +284,8 @@ class TestOrderValueCap:
             "ANTHROPIC_API_KEY": "sk-test",
             "SAFEWAY_ORDER_VALUE_CAP_USD": raw_value,
         }
-        with patch.dict(os.environ, env, clear=True):
-            with pytest.raises(ConfigError, match="SAFEWAY_ORDER_VALUE_CAP_USD"):
-                load_config()
+        with (
+            patch.dict(os.environ, env, clear=True),
+            pytest.raises(ConfigError, match="SAFEWAY_ORDER_VALUE_CAP_USD"),
+        ):
+            load_config()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from decimal import Decimal
 from typing import TYPE_CHECKING
 from unittest.mock import patch
 
@@ -243,3 +244,46 @@ class TestLoadConfig:
         with patch.dict(os.environ, env, clear=True):
             cfg = load_config()
         assert cfg.safeway_order_submission_enabled is expected
+
+
+class TestOrderValueCap:
+    """Tests for the Issue #73 order-value cap config field.
+
+    ``Config.safeway_order_value_cap`` does not exist yet, so reading it
+    below raises ``AttributeError`` — the acceptable RED for a
+    not-yet-existing config field.
+    """
+
+    def test_order_value_cap_defaults_to_300(self) -> None:
+        """Test Config.safeway_order_value_cap defaults to $300."""
+        cfg = Config(anthropic_api_key="sk-test")
+        assert cfg.safeway_order_value_cap == Decimal("300")
+
+    @patch.dict(
+        os.environ,
+        {
+            "ANTHROPIC_API_KEY": "sk-test",
+            "SAFEWAY_ORDER_VALUE_CAP_USD": "150.50",
+        },
+        clear=True,
+    )
+    def test_order_value_cap_reads_env(self) -> None:
+        """Test load_config parses SAFEWAY_ORDER_VALUE_CAP_USD as a Decimal."""
+        cfg = load_config()
+        assert cfg.safeway_order_value_cap == Decimal("150.50")
+
+    @pytest.mark.parametrize("raw_value", ["abc", "-5"])
+    def test_order_value_cap_invalid_raises_config_error(self, raw_value: str) -> None:
+        """Test a non-numeric or negative cap value raises ConfigError.
+
+        Today load_config performs no validation at all on this env var
+        (it isn't even read), so this currently fails with "DID NOT
+        RAISE" rather than a real ConfigError.
+        """
+        env = {
+            "ANTHROPIC_API_KEY": "sk-test",
+            "SAFEWAY_ORDER_VALUE_CAP_USD": raw_value,
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(ConfigError, match="SAFEWAY_ORDER_VALUE_CAP_USD"):
+                load_config()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -904,3 +904,70 @@ class TestCartSummary:
 
         assert dumped["fulfillment_unverified"] is True
         assert restored.fulfillment_unverified is True
+
+
+class TestMonetaryFieldsRejectNonFinite:
+    """Non-finite monetary values are rejected at model validation (issue #73).
+
+    JSON's ``Infinity``/``NaN`` literals are accepted by Python's json
+    parser, and a non-finite Decimal crashes ``quantize`` with
+    ``InvalidOperation`` deep inside ``compute_cart_total`` — an
+    unhandled 500 instead of a clean 400. Rejecting non-finite floats at
+    the model boundary turns any such payload into a normal
+    ``ValidationError`` (which the API maps to 400).
+    """
+
+    @pytest.mark.parametrize("bad_value", [float("inf"), float("-inf"), float("nan")])
+    def test_cart_item_rejects_non_finite_estimated_cost(
+        self, bad_value: float
+    ) -> None:
+        """Test CartItem rejects inf/-inf/nan estimated_cost."""
+        shopping_item = ShoppingListItem(
+            ingredient="milk",
+            quantity=1.0,
+            unit="gallon",
+            category=IngredientCategory.DAIRY,
+            search_term="whole milk",
+            from_meals=["Cereal"],
+        )
+        product = SafewayProduct(
+            product_id="SW-001",
+            name="Whole Milk",
+            price=5.99,
+            size="1 gallon",
+        )
+        with pytest.raises(ValidationError):
+            CartItem(
+                shopping_list_item=shopping_item,
+                safeway_product=product,
+                quantity_to_order=1,
+                estimated_cost=bad_value,
+            )
+
+    @pytest.mark.parametrize("bad_value", [float("inf"), float("-inf"), float("nan")])
+    def test_fulfillment_option_rejects_non_finite_fee(self, bad_value: float) -> None:
+        """Test FulfillmentOption rejects inf/-inf/nan fee."""
+        with pytest.raises(ValidationError):
+            FulfillmentOption(
+                type=FulfillmentType.PICKUP,
+                available=True,
+                fee=bad_value,
+                windows=[],
+            )
+
+    @pytest.mark.parametrize("field", ["subtotal", "estimated_total"])
+    def test_cart_summary_rejects_non_finite_totals(self, field: str) -> None:
+        """Test CartSummary rejects inf subtotal/estimated_total."""
+        kwargs: dict[str, object] = {
+            "items": [],
+            "failed_items": [],
+            "substituted_items": [],
+            "restock_items": [],
+            "subtotal": 0.0,
+            "fulfillment_options": [],
+            "recommended_fulfillment": FulfillmentType.PICKUP,
+            "estimated_total": 0.0,
+        }
+        kwargs[field] = float("inf")
+        with pytest.raises(ValidationError):
+            CartSummary(**kwargs)

--- a/tests/test_order_service.py
+++ b/tests/test_order_service.py
@@ -1380,7 +1380,7 @@ class TestComputeCartTotal:
         assert result == Decimal("8.99")
 
     def test_compute_cart_total_ignores_client_supplied_totals(self) -> None:
-        """Test the total is computed from items+fee, never cart.subtotal/estimated_total.
+        """Test the total derives from items+fee, never subtotal/estimated_total.
 
         A cart whose ``subtotal``/``estimated_total`` fields have been
         tampered with (e.g. a client-supplied cart payload) must not

--- a/tests/test_order_service.py
+++ b/tests/test_order_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from decimal import Decimal
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -138,6 +139,49 @@ def _make_cart(
             ),
         ],
         recommended_fulfillment=FulfillmentType.PICKUP,
+        estimated_total=subtotal,
+    )
+
+
+def _make_cart_with_fee(
+    items: list[CartItem] | None = None,
+    fee: float = 5.99,
+    recommended: FulfillmentType = FulfillmentType.PICKUP,
+) -> CartSummary:
+    """Create a test CartSummary whose recommended fulfillment option has a fee.
+
+    Unlike :func:`_make_cart` (fee always 0.0), this pins a non-zero fee
+    on the recommended fulfillment option so tests can verify
+    ``compute_cart_total`` includes it (issue #73). ``estimated_total``
+    and ``subtotal`` deliberately omit the fee, matching the shape of a
+    cart built by today's (buggy) pipeline.
+
+    Args:
+        items: Regular cart items (defaults to a single $8.99 item).
+        fee: Fee for the recommended (pickup) fulfillment option.
+        recommended: Fulfillment type the cart recommends.
+
+    Returns:
+        CartSummary with a non-zero recommended-fulfillment fee.
+    """
+    cart_items = [_make_cart_item()] if items is None else items
+    subtotal = sum(i.estimated_cost for i in cart_items)
+    return CartSummary(
+        items=cart_items,
+        failed_items=[],
+        substituted_items=[],
+        skipped_items=[],
+        restock_items=[],
+        subtotal=subtotal,
+        fulfillment_options=[
+            FulfillmentOption(
+                type=FulfillmentType.PICKUP,
+                available=True,
+                fee=fee,
+                windows=[],
+            ),
+        ],
+        recommended_fulfillment=recommended,
         estimated_total=subtotal,
     )
 
@@ -1070,3 +1114,158 @@ class TestSubmitOrderClientOrderId:
 
         _args, kwargs = mock_client.post.call_args
         assert kwargs.get("retry_on_auth_failure") is False
+
+
+# ------------------------------------------------------------------
+# Issue #73: compute_cart_total — fee-inclusive, server-trusted total
+#
+# grocery_butler.order_service.compute_cart_total does not exist yet, so
+# it is imported locally inside each test body (matching the file's
+# existing convention for names introduced test-first, e.g. OrderOutcome
+# above) rather than at module scope, where the ImportError would break
+# collection of every other test in this file.
+# ------------------------------------------------------------------
+
+
+class TestComputeCartTotal:
+    """Tests for order_service.compute_cart_total (issue #73)."""
+
+    def test_compute_cart_total_includes_recommended_fulfillment_fee(self) -> None:
+        """Test the total sums item costs plus the recommended fulfillment fee.
+
+        Today's ``_cart_total`` helper in ``api.py`` sums only item and
+        restock costs and never looks at ``fulfillment_options`` at all,
+        so a cart with a $0.005 pickup fee on top of an $8.99 item would
+        total $8.99 instead of the correct fee-inclusive $9.00. This also
+        pins cents quantization: 8.99 + 0.005 = 8.995, which rounds
+        half-up to 9.00.
+        """
+        from grocery_butler.order_service import compute_cart_total
+
+        cart = _make_cart_with_fee(fee=0.005)
+
+        result = compute_cart_total(cart)
+
+        assert result == Decimal("9.00")
+
+    def test_compute_cart_total_no_matching_option_is_items_only(self) -> None:
+        """Test the fee is 0 when no fulfillment option matches the recommended type.
+
+        The cart recommends DELIVERY but ``fulfillment_options`` only
+        contains a PICKUP entry, so there is no fee to add.
+        """
+        from grocery_butler.order_service import compute_cart_total
+
+        cart = _make_cart_with_fee(fee=5.99, recommended=FulfillmentType.DELIVERY)
+
+        result = compute_cart_total(cart)
+
+        assert result == Decimal("8.99")
+
+    def test_compute_cart_total_ignores_client_supplied_totals(self) -> None:
+        """Test the total is computed from items+fee, never cart.subtotal/estimated_total.
+
+        A cart whose ``subtotal``/``estimated_total`` fields have been
+        tampered with (e.g. a client-supplied cart payload) must not
+        leak into ``compute_cart_total``'s answer — it must derive its
+        result solely from ``items``, ``restock_items``, and the
+        recommended fulfillment option's fee.
+        """
+        from grocery_butler.order_service import compute_cart_total
+
+        cart = _make_cart_with_fee(fee=1.00)
+        tampered = cart.model_copy(
+            update={"subtotal": 999999.99, "estimated_total": 999999.99}
+        )
+
+        result = compute_cart_total(tampered)
+
+        assert result == Decimal("9.99")
+
+
+# ------------------------------------------------------------------
+# Issue #73: OrderService order-value cap preflight gate
+#
+# OrderService.__init__ does not accept order_value_cap yet, so
+# constructing the service below raises TypeError — the acceptable RED
+# for a not-yet-existing constructor keyword argument.
+# ------------------------------------------------------------------
+
+
+class TestSubmitOrderValueCap:
+    """Tests for the Issue #73 order-value cap preflight gate."""
+
+    def _make_service(
+        self,
+        *,
+        order_value_cap: Decimal = Decimal("300"),
+        api_response: dict[str, Any] | None = None,
+    ) -> OrderService:
+        """Create a submission-enabled OrderService with the given cap.
+
+        Args:
+            order_value_cap: Cap forwarded to the constructor.
+            api_response: Response the mocked client should return if
+                the submission is allowed to proceed.
+
+        Returns:
+            OrderService wired to mocked client/pantry dependencies.
+        """
+        mock_client = MagicMock()
+        mock_client.post.return_value = api_response or {
+            "orderId": "ORD-CAP",
+            "status": "confirmed",
+            "total": 8.99,
+        }
+        mock_pantry = MagicMock()
+        mock_pantry.mark_restocked.return_value = 0
+        return OrderService(
+            mock_client,
+            mock_pantry,
+            submission_enabled=True,
+            order_value_cap=order_value_cap,
+        )
+
+    def _make_priced_cart(self, price: float) -> CartSummary:
+        """Return a single-item cart totalling exactly ``price``."""
+        item = _make_cart_item(price=price)
+        return _make_cart(items=[item])
+
+    def test_submit_order_blocks_when_total_exceeds_cap(self) -> None:
+        """Test a cart over the cap is blocked before any client call.
+
+        No HTTP post should occur and the error message must mention
+        the cap.
+        """
+        service = self._make_service(order_value_cap=Decimal("300"))
+        cart = self._make_priced_cart(350.00)
+
+        result = service.submit_order(cart)
+
+        assert result.success is False
+        assert "cap" in result.error_message.lower()
+        service._client.post.assert_not_called()
+
+    def test_submit_order_allows_over_cap_with_override(self) -> None:
+        """Test allow_over_cap=True is an explicit human override of the cap gate."""
+        service = self._make_service(order_value_cap=Decimal("300"))
+        cart = self._make_priced_cart(350.00)
+
+        result = service.submit_order(cart, allow_over_cap=True)
+
+        assert result.success is True
+        service._client.post.assert_called_once()
+
+    def test_submit_order_under_cap_proceeds(self) -> None:
+        """Test a total exactly equal to the cap is not blocked.
+
+        The cap gate must be exclusive: it blocks only when the total is
+        strictly greater than the cap.
+        """
+        service = self._make_service(order_value_cap=Decimal("300"))
+        cart = self._make_priced_cart(300.00)
+
+        result = service.submit_order(cart)
+
+        assert result.success is True
+        service._client.post.assert_called_once()

--- a/tests/test_safeway_pipeline.py
+++ b/tests/test_safeway_pipeline.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import threading
 import uuid
+from decimal import Decimal
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
@@ -1238,3 +1239,81 @@ class TestSubmissionDisabledDoesNotAffectBuildCartOnly:
         cart = pipeline.build_cart_only(sample_items)
 
         assert cart is mock_cart_summary
+
+
+# ---------------------------------------------------------------------------
+# Issue #73: order-value cap — pipeline exposes the config cap and threads
+# allow_over_cap through to OrderService.
+# ---------------------------------------------------------------------------
+
+
+class TestOrderValueCapForwarding:
+    """Tests for SafewayPipeline's Issue #73 order-value cap plumbing."""
+
+    @patch("grocery_butler.safeway_pipeline.RecipeStore")
+    @patch("grocery_butler.safeway_pipeline.ProductSearchService")
+    @patch("grocery_butler.safeway_pipeline.ProductSelector")
+    @patch("grocery_butler.safeway_pipeline.SubstitutionService")
+    @patch("grocery_butler.safeway_pipeline.SafewayClient")
+    @patch("grocery_butler.safeway_pipeline.PantryManager")
+    def test_pipeline_exposes_order_value_cap_from_config(
+        self,
+        mock_pantry: MagicMock,
+        mock_client_cls: MagicMock,
+        mock_sub: MagicMock,
+        mock_selector: MagicMock,
+        mock_search: MagicMock,
+        mock_store: MagicMock,
+        safeway_config: Config,
+    ) -> None:
+        """Test the pipeline exposes the configured order-value cap.
+
+        Architecture: SafewayPipeline reads
+        ``config.safeway_order_value_cap`` and exposes it as a read-only
+        ``order_value_cap`` property, mirroring
+        ``order_submission_enabled``. There is no such property today.
+        """
+        pipeline = SafewayPipeline(safeway_config, ":memory:")
+
+        assert pipeline.order_value_cap == Decimal("300")
+
+    @patch("grocery_butler.safeway_pipeline.RecipeStore")
+    @patch("grocery_butler.safeway_pipeline.ProductSearchService")
+    @patch("grocery_butler.safeway_pipeline.ProductSelector")
+    @patch("grocery_butler.safeway_pipeline.SubstitutionService")
+    @patch("grocery_butler.safeway_pipeline.SafewayClient")
+    @patch("grocery_butler.safeway_pipeline.PantryManager")
+    @patch("grocery_butler.safeway_pipeline.CartBuilder")
+    @patch("grocery_butler.safeway_pipeline.OrderService")
+    def test_pipeline_passes_cap_and_override_to_order_service(
+        self,
+        mock_order_cls: MagicMock,
+        mock_cart_cls: MagicMock,
+        mock_pantry: MagicMock,
+        mock_client_cls: MagicMock,
+        mock_sub: MagicMock,
+        mock_selector: MagicMock,
+        mock_search: MagicMock,
+        mock_store: MagicMock,
+        safeway_config: Config,
+        mock_cart_summary: CartSummary,
+    ) -> None:
+        """Test submit_cart forwards allow_over_cap to OrderService.submit_order.
+
+        Architecture: OrderService.submit_order gains a keyword-only
+        ``allow_over_cap`` parameter, and ``submit_cart`` must thread the
+        caller's override through so a human-approved over-cap order can
+        proceed. ``submit_cart`` accepts no such keyword today.
+        """
+        mock_client_cls.return_value.is_authenticated = True
+        expected = OrderResult(success=True)
+        mock_order_cls.return_value.submit_order.return_value = expected
+
+        pipeline = SafewayPipeline(safeway_config, ":memory:")
+        result = pipeline.submit_cart(mock_cart_summary, allow_over_cap=True)
+
+        assert result is expected
+        mock_submit = mock_order_cls.return_value.submit_order
+        mock_submit.assert_called_once()
+        _args, kwargs = mock_submit.call_args
+        assert kwargs.get("allow_over_cap") is True


### PR DESCRIPTION
## Summary

- `POST /order/submit` no longer trusts the caller's `total`: the staged/confirmation total is always the server-computed, fee-inclusive `order_service.compute_cart_total` (items + restock items + recommended fulfillment fee, cents-quantized). A client-supplied `total` that is non-numeric, non-finite (JSON `Infinity`/`NaN`), or deviating from the server value is rejected with 400. `POST /order/preview` uses the same helper, so previews no longer understate by the fulfillment fee.
- Adds a configurable order-value cap (`SAFEWAY_ORDER_VALUE_CAP_USD`, default $300) as the last line of defense against inflated carts. Enforced at staging (400 unless the request sets `override_cap`, which is persisted as `allow_over_cap` in the staged payload and forwarded on confirm) and again in `OrderService._preflight_block` before any HTTP call or ledger write.
- Monetary model fields (`CartItem.estimated_cost`, `FulfillmentOption.fee`, `CartSummary.subtotal`/`estimated_total`) are constrained with `allow_inf_nan=False`, so non-finite values become a clean 400 at the API boundary instead of an uncaught `decimal.InvalidOperation` 500.
- `compute_cart_total` deliberately never reads `cart.subtotal` / `cart.estimated_total` (untrusted aggregate fields). Known residual risk: the per-item costs in a client-submitted cart are not re-verified against the Safeway catalog (same trust model as the #59/#72 gates) — documented in the docstring and tracked in #120. Merged with `main`'s #116 (substitutions land in `cart.items`, so they are priced automatically) and #119 (`fulfillment_unverified` carts carry empty options, so no phantom fee is added).

## Test plan

- New tests in `tests/test_api_destructive.py`: mismatching client total → 400; dict/bool/list/unparseable/`Infinity`/`NaN` totals → 400; matching client total accepted; staged message and payload use the fee-inclusive server total; over-cap staging → 400 without `override_cap`; `override_cap` stages with `allow_over_cap` persisted; confirm forwards `allow_over_cap` to `pipeline.submit_cart`; cart item with `Infinity` cost → 400; garbage `SAFEWAY_ORDER_VALUE_CAP_USD` → JSON 503.
- New tests in `tests/test_order_service.py`: `compute_cart_total` includes the recommended fulfillment fee, falls back to items-only when no option matches, and ignores tampered `subtotal`/`estimated_total`; `submit_order` blocks over-cap totals, allows them with `allow_over_cap=True`, and proceeds under the cap.
- New tests in `tests/test_models.py`: all four monetary fields reject `inf`/`-inf`/`nan`.
- New tests in `tests/test_config.py` / `tests/test_safeway_pipeline.py`: cap parsing (default 300, env override, invalid/negative → `ConfigError`) and cap/override plumbing from `Config` through the pipeline to `OrderService`.
- `./scripts/check-all.sh` → exit 0 (1637 passed, 96%+ branch coverage, ruff/mypy/bandit/pip-audit/interrogate/radon clean). Gate 2.5 self-review passed after fixing both blocking findings (non-finite 500s; residual trust boundary documented in #120).

Refs #120

Closes #73
