### PR TITLE
fix(cart): route per-item search failures to failed_items instead of aborting the build

### DIFF
--- a/grocery_butler/cart_builder.py
+++ b/grocery_butler/cart_builder.py
@@ -21,6 +21,8 @@ from grocery_butler.models import (
     ShoppingListItem,
     SubstitutionResult,
 )
+from grocery_butler.product_search import ProductSearchError
+from grocery_butler.safeway_client import SafewayAPIError
 from grocery_butler.units import convert, parse_size
 
 if TYPE_CHECKING:
@@ -179,12 +181,52 @@ class CartBuilder:
     ) -> CartItem | SubstitutionResult | None:
         """Process a single shopping list item into a cart item.
 
+        A ``ProductSearchError`` or ``SafewayAPIError`` raised while
+        resolving, substituting, or otherwise handling this item is
+        recoverable at the per-item level -- it means this one item
+        couldn't be sourced, not that the whole cart build should
+        abort (issue #76) -- so it's caught here and logged. A
+        ``SafewayAuthError`` is deliberately *not* caught: an
+        authentication failure dooms every subsequent request, not
+        just this item, so it propagates to the caller rather than
+        being masked as a single failed item.
+
+        Args:
+            item: The shopping list item to process.
+
+        Returns:
+            CartItem if successful, SubstitutionResult if substituted,
+            or None if no product was found or a recoverable search/API
+            error occurred while processing the item (logged as a
+            warning).
+        """
+        try:
+            return self._build_cart_result(item)
+        except (ProductSearchError, SafewayAPIError) as exc:
+            logger.warning(
+                "Search failed for '%s'; adding to failed items: %s",
+                item.search_term,
+                exc,
+            )
+            return None
+
+    def _build_cart_result(
+        self,
+        item: ShoppingListItem,
+    ) -> CartItem | SubstitutionResult | None:
+        """Resolve a shopping list item into a cart item, without error handling.
+
         Args:
             item: The shopping list item to process.
 
         Returns:
             CartItem if successful, SubstitutionResult if substituted,
             or None if no product found.
+
+        Raises:
+            ProductSearchError: If product search fails.
+            SafewayAPIError: If a Safeway API call fails.
+            SafewayAuthError: If Safeway authentication fails.
         """
         product = self._resolve_product(item)
         if product is None:

--- a/tests/test_api_compute.py
+++ b/tests/test_api_compute.py
@@ -419,6 +419,34 @@ class TestOrderPreview:
         assert response.status_code == 200
         assert response.get_json()["total"] == "3.75"
 
+    def test_failed_items_are_serialized_in_cart_response(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """A cart with failed_items still serializes as JSON (issue #76).
+
+        Serialization guard: when CartBuilder routes an item to
+        ``failed_items`` (e.g. after a per-item ``ProductSearchError``),
+        the ``/order/preview`` response must still come back as a clean
+        200 with the failed item present in ``cart.failed_items`` --
+        not blow up or silently drop it.
+        """
+        cart = _make_cart({"pasta": 1.0})
+        failed_item = _make_shopping_item("eggs")
+        cart = cart.model_copy(update={"failed_items": [failed_item]})
+        pipeline = MagicMock()
+        pipeline.build_cart_only.return_value = cart
+        with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
+            response = client.post(
+                "/api/v1/order/preview",
+                json={"shopping_list": [_make_shopping_item().model_dump(mode="json")]},
+                headers=auth_headers,
+            )
+
+        assert response.status_code == 200
+        failed_items = response.get_json()["cart"]["failed_items"]
+        assert len(failed_items) == 1
+        assert failed_items[0]["ingredient"] == "eggs"
+
     def test_pipeline_error_returns_503(
         self, client: FlaskClient, auth_headers: dict[str, str]
     ) -> None:

--- a/tests/test_cart_builder.py
+++ b/tests/test_cart_builder.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
+import pytest
+
 from grocery_butler.cart_builder import (
     MAX_QUANTITY_PER_ITEM,
     CartBuilder,
@@ -27,7 +29,8 @@ from grocery_butler.models import (
     SubstitutionResult,
     SubstitutionSuitability,
 )
-from grocery_butler.product_search import CachedMapping
+from grocery_butler.product_search import CachedMapping, ProductSearchError
+from grocery_butler.safeway_client import SafewayAPIError, SafewayAuthError
 
 # ------------------------------------------------------------------
 # Fixtures
@@ -827,6 +830,212 @@ class TestBuildCart:
         assert cart_item.quantity_to_order == 3
         assert cart_item.needs_review is True
         assert cart_item.review_reason == "quantity_capped"
+
+
+# ------------------------------------------------------------------
+# Tests: CartBuilder.build_cart search/API error isolation (issue #76)
+# ------------------------------------------------------------------
+#
+# Regression guards for issue #76: a ProductSearchError or SafewayAPIError
+# raised while resolving one shopping list item used to propagate uncaught
+# out of CartBuilder.build_cart, aborting the entire cart instead of
+# routing just that item to failed_items. SafewayAuthError (not a
+# SafewayAPIError subclass) must continue to propagate uncaught -- an
+# authentication failure affects every subsequent request, not just the
+# one item being processed, so it must not be swallowed.
+
+
+class TestBuildCartSearchErrors:
+    """Tests for build_cart isolating per-item search/API failures."""
+
+    def _make_dependencies(
+        self,
+    ) -> tuple[MagicMock, MagicMock, MagicMock, MagicMock]:
+        """Create fresh mocks for search, selector, substitution, and client.
+
+        Returns:
+            Tuple of (mock_search, mock_selector, mock_substitution,
+            mock_client). ``mock_search.get_cached_product`` always
+            returns ``None`` so every item takes the search-and-select
+            path.
+        """
+        mock_search = MagicMock()
+        mock_search.get_cached_product.return_value = None
+        mock_selector = MagicMock()
+        mock_substitution = MagicMock()
+        mock_client = MagicMock()
+        mock_client.store_id = "1234"
+        mock_client.get.return_value = {}
+        return mock_search, mock_selector, mock_substitution, mock_client
+
+    def test_search_error_routes_item_to_failed(self) -> None:
+        """Test a ProductSearchError during search routes the item to failed.
+
+        Reproduction of issue #76: previously this exception propagated
+        uncaught out of ``build_cart`` instead of landing the item in
+        ``failed_items``.
+        """
+        mock_search, mock_selector, mock_substitution, mock_client = (
+            self._make_dependencies()
+        )
+        mock_search.search_products.side_effect = ProductSearchError("boom")
+
+        builder = CartBuilder(
+            search_service=mock_search,
+            product_selector=mock_selector,
+            substitution_service=mock_substitution,
+            safeway_client=mock_client,
+        )
+        result = builder.build_cart([_make_item()])
+
+        assert len(result.failed_items) == 1
+        assert result.items == []
+
+    def test_search_error_isolates_single_failing_item(self) -> None:
+        """Test one item's ProductSearchError doesn't abort the other items.
+
+        Acceptance criterion for issue #76: a single bad item must not
+        take down the whole cart -- the remaining items must still be
+        processed and priced normally.
+        """
+        good_a = _make_item(ingredient="chicken thighs", search_term="term-a")
+        bad = _make_item(ingredient="salmon", search_term="term-b")
+        good_c = _make_item(ingredient="ground beef", search_term="term-c")
+
+        product_a = _make_product(product_id="P-A", name="term-a product")
+        product_c = _make_product(product_id="P-C", name="term-c product")
+
+        def _search_side_effect(search_term: str) -> list[SafewayProduct]:
+            """Return candidates per search term, raising for the bad one.
+
+            Args:
+                search_term: The search term passed by CartBuilder.
+
+            Returns:
+                Candidate products for a successful search term.
+
+            Raises:
+                ProductSearchError: When ``search_term`` is the
+                    designated failing term.
+            """
+            if search_term == "term-b":
+                raise ProductSearchError("boom")
+            return [product_a if search_term == "term-a" else product_c]
+
+        def _select_side_effect(
+            item: ShoppingListItem,
+            candidates: list[SafewayProduct],
+        ) -> _MockSelectionResult:
+            """Select the first candidate for whichever item is passed.
+
+            Args:
+                item: The shopping list item being resolved.
+                candidates: Candidate products from search.
+
+            Returns:
+                A selection result choosing the first candidate.
+            """
+            return _MockSelectionResult(
+                item=item, product=candidates[0], reasoning="Test"
+            )
+
+        mock_search, mock_selector, mock_substitution, mock_client = (
+            self._make_dependencies()
+        )
+        mock_search.search_products.side_effect = _search_side_effect
+        mock_selector.select_product.side_effect = _select_side_effect
+
+        builder = CartBuilder(
+            search_service=mock_search,
+            product_selector=mock_selector,
+            substitution_service=mock_substitution,
+            safeway_client=mock_client,
+        )
+        result = builder.build_cart([good_a, bad, good_c])
+
+        assert len(result.failed_items) == 1
+        assert result.failed_items[0].search_term == "term-b"
+        assert len(result.items) == 2
+        product_ids = {i.safeway_product.product_id for i in result.items}
+        assert product_ids == {"P-A", "P-C"}
+
+    def test_substitution_search_error_routes_to_failed(self) -> None:
+        """Test a ProductSearchError from substitution routes item to failed.
+
+        The bug also applies to failures raised from
+        ``SubstitutionService.find_substitutions`` while handling an
+        out-of-stock product.
+        """
+        oos_product = _make_product(in_stock=False)
+        mock_search, mock_selector, mock_substitution, mock_client = (
+            self._make_dependencies()
+        )
+        mock_search.search_products.return_value = [oos_product]
+        mock_selector.select_product.return_value = _MockSelectionResult(
+            item=_make_item(),
+            product=oos_product,
+            reasoning="Test",
+        )
+        mock_substitution.find_substitutions.side_effect = ProductSearchError("boom")
+
+        builder = CartBuilder(
+            search_service=mock_search,
+            product_selector=mock_selector,
+            substitution_service=mock_substitution,
+            safeway_client=mock_client,
+        )
+        result = builder.build_cart([_make_item()])
+
+        assert len(result.failed_items) == 1
+        assert result.items == []
+
+    def test_safeway_api_error_routes_to_failed(self) -> None:
+        """Test a SafewayAPIError during search routes the item to failed.
+
+        A ``SafewayAPIError`` (e.g. a 500 response from Safeway) must be
+        caught alongside ``ProductSearchError`` and never crash
+        ``build_cart``.
+        """
+        mock_search, mock_selector, mock_substitution, mock_client = (
+            self._make_dependencies()
+        )
+        mock_search.search_products.side_effect = SafewayAPIError("500 from safeway")
+
+        builder = CartBuilder(
+            search_service=mock_search,
+            product_selector=mock_selector,
+            substitution_service=mock_substitution,
+            safeway_client=mock_client,
+        )
+        result = builder.build_cart([_make_item()])
+
+        assert len(result.failed_items) == 1
+        assert result.items == []
+
+    def test_safeway_auth_error_propagates(self) -> None:
+        """Test SafewayAuthError still propagates out of build_cart.
+
+        Locks the not-caught contract: unlike ``ProductSearchError`` and
+        ``SafewayAPIError``, an authentication failure affects every
+        subsequent request, not just the one item being processed, so it
+        must not be swallowed and routed to ``failed_items``.
+        """
+        mock_search, mock_selector, mock_substitution, mock_client = (
+            self._make_dependencies()
+        )
+        mock_search.search_products.side_effect = SafewayAuthError(
+            "credentials rejected"
+        )
+
+        builder = CartBuilder(
+            search_service=mock_search,
+            product_selector=mock_selector,
+            substitution_service=mock_substitution,
+            safeway_client=mock_client,
+        )
+
+        with pytest.raises(SafewayAuthError):
+            builder.build_cart([_make_item()])
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- A `ProductSearchError`/`SafewayAPIError` raised while resolving one shopping list item no longer aborts the whole cart build: `CartBuilder._process_item` now catches it per item, logs a WARNING with the item's search term, and routes the item into the existing `CartSummary.failed_items` mechanism while the rest of the cart builds normally.
- The item-resolution body moved unchanged into a new private `_build_cart_result`; `_process_item` is the thin try/except wrapper, keeping every function within the complexity/length limits.
- `SafewayAuthError` is deliberately excluded from the catch (it is not a `SafewayAPIError` subclass): an auth failure dooms every item, so it still propagates for pipeline-level handling — locked in by a dedicated test.

## Test plan

- Gate 1 (TDD): five new tests in `TestBuildCartSearchErrors` (`tests/test_cart_builder.py`) were written first and reproduced the abort — single-item search error routes to `failed_items`; a 3-item build with one failing search keeps the other two priced and intact (acceptance criterion 1); substitution-path search error routes to `failed_items`; `SafewayAPIError` routes to `failed_items`; `SafewayAuthError` still propagates. One API-boundary guard in `tests/test_api_compute.py` asserts a preview whose cart has non-empty `failed_items` returns JSON 200 with the failed item serialized (acceptance criterion 2).
- Gate 2: `./scripts/check-all.sh` exit 0 — 1603 passed, 10 pre-existing env-gated skips, coverage 96.13% (threshold 90%), mypy strict / ruff / bandit / pip-audit / radon all green.
- Gate 2.5: code-review-orchestrator self-review returned CLEAN (no blockers).

## Follow-up noted (pre-existing, out of scope)

The self-review traced a related pre-existing gap unchanged by this PR: a `SafewayAuthError` raised mid-loop (e.g. token expiry partway through a build) escapes `SafewayPipeline.build_cart_only` unwrapped — the preview endpoint only catches `SafewayPipelineError`, so it still yields an HTML 500. Suggested fast-follow: wrap the `build_cart` call in `build_cart_only`/`build_and_submit` so mid-run auth failures become `SafewayPipelineError` → JSON 503. (Automated issue creation was not permitted from this lane; needs a human or the orchestrator to file it.)

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)
