### PR TITLE
fix(security): harden pending-actions audit trail (requester/resolver, logging, failed status, sweep + read endpoints, atomic prefs, leak fix)

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,15 +465,23 @@ unchanged. The blueprint lives in `grocery_butler/api.py` and is registered by
   `grocery_butler.auth_middleware.mint_token`. An unauthenticated
   `GET /healthz` liveness probe is exempt.
 - **Surface:** read endpoints (`/inventory`, `/pantry`, `/recipes`, `/brands`,
-  `/preferences`, `/restock`), compute previews (`/meals/parse`,
-  `/shopping-list/preview`, `/order/preview`), low-stakes writes
-  (`/stock/update`, `/stock/add`, `/restock/clear`, `/recipes/save`,
-  `DELETE /recipes/<id>`), and staged destructive actions (`/order/submit`,
-  `/brands/set`, `/preferences/set` → `/actions/confirm` / `/actions/deny`
-  against the `pending_actions` audit table).
+  `/preferences`, `/restock`, `/actions`, `/actions/<action_id>`), compute
+  previews (`/meals/parse`, `/shopping-list/preview`, `/order/preview`),
+  low-stakes writes (`/stock/update`, `/stock/add`, `/restock/clear`,
+  `/recipes/save`, `DELETE /recipes/<id>`), and staged destructive actions
+  (`/order/submit`, `/brands/set`, `/preferences/set` → `/actions/confirm` /
+  `/actions/deny` against the `pending_actions` audit table). `GET /actions`
+  lists staged/resolved actions (`?limit=`, default 50, cap 200; `?status=`
+  filter), sweeping past-due pending rows to `expired` first -- the three
+  staging routes (`/order/submit`, `/brands/set`, `/preferences/set`) sweep
+  on write too, so a row never sits `pending` past its TTL just because the
+  audit log went unread; `GET /actions/<action_id>` returns one action or a
+  JSON 404.
 - **Safety:** destructive actions follow draft → confirm → execute. Staging
   returns a `pending_confirmation` action id with a 5-minute expiry; nothing
   executes until RubotPaul confirms after Geoff replies "confirm" in chat.
+  Resolved actions record a terminal status of `approved`, `denied`,
+  `expired`, or `failed` (a claimed order whose Safeway submission failed).
 
 ### Discord Bot Commands
 

--- a/grocery_butler/api.py
+++ b/grocery_butler/api.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 
 import dataclasses
 import datetime as dt
+import logging
 import os
 import uuid
-from decimal import Decimal
+from decimal import Decimal, InvalidOperation
 from typing import TYPE_CHECKING, Any
 
 from flask import Blueprint, abort, current_app, jsonify, request
@@ -54,6 +55,8 @@ if TYPE_CHECKING:
     from grocery_butler.models import PendingAction
 
 api_v1 = Blueprint("api_v1", __name__, url_prefix="/api/v1")
+
+LOG = logging.getLogger("api")
 
 #: How long a staged destructive action stays confirmable.
 CONFIRMATION_TTL = dt.timedelta(minutes=5)
@@ -246,6 +249,40 @@ def _cart_total(cart: CartSummary) -> Decimal:
     )
 
 
+def _resolve_order_total(body: dict[str, Any], cart: CartSummary) -> str:
+    """Return the staged order total, validating any client override.
+
+    A client-supplied ``total`` must parse as a finite decimal amount
+    (issue #75, log hygiene): an unvalidated free-form value would flow
+    verbatim into the ``_stage_pending`` audit-log line and the
+    human-facing confirmation message, letting a caller forge extra log
+    lines (embedded newlines/control characters) or display a
+    misleading total. A missing, falsy, or invalid override falls back
+    to the cart's own computed total rather than trusting raw input.
+
+    Args:
+        body: The request's JSON object body.
+        cart: The validated cart being staged.
+
+    Returns:
+        The total to stage, as a plain decimal string.
+
+    Raises:
+        HTTPException: 400 if ``total`` is present but not a finite
+            numeric value.
+    """
+    raw_total = body.get("total")
+    if not raw_total:
+        return str(_cart_total(cart))
+    try:
+        total = Decimal(str(raw_total))
+    except (InvalidOperation, ValueError, TypeError):
+        abort(400, description="total must be a numeric value")
+    if not total.is_finite():
+        abort(400, description="total must be a numeric value")
+    return str(total)
+
+
 @api_v1.post("/meals/parse")
 def post_meals_parse() -> Response:
     """Parse free-text meal names into structured ingredient lists."""
@@ -430,14 +467,70 @@ def _pending_store() -> PendingActionsStore:
     return PendingActionsStore(current_app.config["DATABASE_PATH"])
 
 
-def _stage_pending(kind: str, payload: dict[str, Any]) -> str:
-    """Stage a pending action with the standard TTL; return its action_id."""
-    action = _pending_store().insert_pending_action(
+def _log_resolution(status: str, action: PendingAction) -> None:
+    """Log an INFO transition line naming only the action_id and kind.
+
+    Never includes payload contents (issue #75, W2): every audit-trail
+    log line is deliberately restricted to non-sensitive metadata.
+
+    Args:
+        status: Transition status word (e.g. ``"confirmed"``, ``"denied"``).
+        action: The pending action being transitioned.
+    """
+    LOG.info("%s action_id=%s kind=%s", status, action.action_id, action.kind)
+
+
+def _sweep_expired(store: PendingActionsStore) -> None:
+    """Sweep past-due pending rows to expired, logging the count if any.
+
+    Shared by every route that touches ``pending_actions`` -- the three
+    staging routes and the ``GET /actions`` listing (issue #75, W4) --
+    so a row can never sit ``pending`` past its TTL just because the
+    audit log was never read.
+
+    Args:
+        store: The PendingActionsStore to sweep.
+    """
+    swept = store.sweep_expired()
+    if swept > 0:
+        LOG.info("swept expired_count=%s", swept)
+
+
+def _stage_pending(kind: str, payload: dict[str, Any], *, requester: str) -> str:
+    """Stage a pending action with the standard TTL; return its action_id.
+
+    Sweeps past-due pending rows to expired first (issue #75, W4) so the
+    lazy sweep runs on every write path, not only on ``GET /actions``.
+    Logs an INFO audit line naming the action_id and kind (and, for
+    order submissions, the staged total) -- never the payload contents
+    (issue #75, W1/W2).
+
+    Args:
+        kind: Action kind, e.g. ``safeway_order_submit``.
+        payload: JSON-serializable action payload.
+        requester: The authenticated caller_id staging this action.
+
+    Returns:
+        The new pending action's id.
+    """
+    store = _pending_store()
+    _sweep_expired(store)
+    action = store.insert_pending_action(
         action_id=str(uuid.uuid4()),
         kind=kind,
         payload=payload,
         expires_at=dt.datetime.now(dt.UTC) + CONFIRMATION_TTL,
+        requester=requester,
     )
+    if kind == "safeway_order_submit":
+        LOG.info(
+            "staged action_id=%s kind=%s total=%s",
+            action.action_id,
+            kind,
+            payload.get("total"),
+        )
+    else:
+        LOG.info("staged action_id=%s kind=%s", action.action_id, kind)
     return action.action_id
 
 
@@ -511,13 +604,14 @@ def _render_fulfillment_section(cart: CartSummary) -> str:
 @api_v1.post("/order/submit")
 def post_order_submit() -> Response:
     """Stage a Safeway order for confirmation. Never submits directly."""
-    require_bearer()
+    caller_id = require_bearer()
     body = _json_body()
     cart = _parse_cart_payload(body)
-    total = str(body.get("total") or _cart_total(cart))
+    total = _resolve_order_total(body, cart)
     action_id = _stage_pending(
         "safeway_order_submit",
         {"cart": cart.model_dump(mode="json"), "total": total},
+        requester=caller_id,
     )
     item_count = len(cart.items) + len(cart.restock_items)
     review_section = _render_review_section(cart)
@@ -535,13 +629,15 @@ def post_order_submit() -> Response:
 @api_v1.post("/brands/set")
 def post_brands_set() -> Response:
     """Stage a brand preference rule for confirmation."""
-    require_bearer()
+    caller_id = require_bearer()
     body = _json_body()
     try:
         pref = BrandPreference.model_validate(body)
     except ValidationError as exc:
         abort(400, description=f"invalid brand rule: {exc.error_count()} error(s)")
-    action_id = _stage_pending("brands_set", pref.model_dump(mode="json"))
+    action_id = _stage_pending(
+        "brands_set", pref.model_dump(mode="json"), requester=caller_id
+    )
     return jsonify(
         status="pending_confirmation",
         action_id=action_id,
@@ -566,9 +662,11 @@ def _parse_preferences_payload(body: dict[str, Any]) -> dict[str, str]:
 @api_v1.post("/preferences/set")
 def post_preferences_set() -> Response:
     """Stage app-level preference changes for confirmation."""
-    require_bearer()
+    caller_id = require_bearer()
     preferences = _parse_preferences_payload(_json_body())
-    action_id = _stage_pending("preferences_set", {"preferences": preferences})
+    action_id = _stage_pending(
+        "preferences_set", {"preferences": preferences}, requester=caller_id
+    )
     keys = ", ".join(sorted(preferences))
     return jsonify(
         status="pending_confirmation",
@@ -588,14 +686,23 @@ def _load_pending_action(body: dict[str, Any]) -> PendingAction:
     return action
 
 
-def _claim_pending(store: PendingActionsStore, action_id: str) -> None:
+def _claim_pending(
+    store: PendingActionsStore, action_id: str, *, resolver: str
+) -> None:
     """Atomically claim a pending action as approved, or abort 409.
 
     The guarded UPDATE in the store is the exactly-once gate: only one
     caller can transition the row out of ``pending``, so a raced double
     confirm cannot execute twice.
+
+    Args:
+        store: Store used to attempt the claim.
+        action_id: Identifier of the action to claim.
+        resolver: The confirming caller_id, stamped as the resolver
+            (issue #75, W1) -- distinct from the requester who staged
+            the action.
     """
-    if not store.mark_pending_approved(action_id):
+    if not store.mark_pending_approved(action_id, resolver=resolver):
         abort(409, description="action already resolved")
 
 
@@ -641,24 +748,39 @@ def _order_failure_response(
     return response, code
 
 
-def _confirm_order_submit(
-    action: PendingAction, store: PendingActionsStore
+def _mark_order_failed(store: PendingActionsStore, action: PendingAction) -> None:
+    """Resolve a claimed order action as failed and log the transition.
+
+    Args:
+        store: Store used to resolve the action.
+        action: The claimed (approved) pending action.
+    """
+    store.mark_pending_failed(action.action_id)
+    _log_resolution("failed", action)
+
+
+def _submit_claimed_order(
+    action: PendingAction,
+    store: PendingActionsStore,
+    pipeline: SafewayPipeline,
+    cart: CartSummary,
 ) -> Response | tuple[Response, int]:
-    """Submit the exact staged cart to Safeway (real money)."""
-    cart = CartSummary.model_validate(action.payload["cart"])
-    try:
-        pipeline = _safeway_pipeline()
-    except (ConfigError, SafewayPipelineError) as exc:
-        # Not claimed yet: the action stays pending so it can be retried
-        # (until it expires) once configuration is fixed.
-        return jsonify(error=f"safeway pipeline unavailable: {exc}"), 503
-    if not pipeline.order_submission_enabled:
-        # Issue #60: order submission is descoped for v1.0. Not claimed —
-        # the action stays pending so it can be retried once the flag is
-        # flipped on after live verification.
-        pipeline.close()
-        return jsonify(error=ORDER_SUBMISSION_DISABLED_MESSAGE), 501
-    _claim_pending(store, action.action_id)
+    """Submit an already-claimed order's cart and resolve its outcome.
+
+    Any post-claim failure -- a raised ``SafewayPipelineError`` or a
+    ``result.success is False`` outcome -- resolves the row as
+    ``failed`` (issue #75, W3), so a claimed action is never left
+    stuck ``approved`` with no record that execution actually failed.
+
+    Args:
+        action: The staged (already-claimed) pending action.
+        store: Store used to resolve the action's final status.
+        pipeline: An already-built, enabled Safeway pipeline.
+        cart: The exact staged cart to submit.
+
+    Returns:
+        The success or failure response for this confirmation.
+    """
     try:
         # The staged message (post_order_submit) already named every
         # flagged item and its reason code, so replying "confirm" IS the
@@ -677,11 +799,12 @@ def _confirm_order_submit(
             allow_unverified_fulfillment=True,
         )
     except SafewayPipelineError as exc:
+        _mark_order_failed(store, action)
         return jsonify(error=f"order submission failed: {exc}"), 502
-    finally:
-        pipeline.close()
     if not result.success:
+        _mark_order_failed(store, action)
         return _order_failure_response(action, result.error_message, result.outcome)
+    _log_resolution("confirmed", action)
     confirmation = (
         dataclasses.asdict(result.confirmation) if result.confirmation else {}
     )
@@ -690,29 +813,65 @@ def _confirm_order_submit(
     )
 
 
-def _confirm_brands_set(action: PendingAction, store: PendingActionsStore) -> Response:
+def _confirm_order_submit(
+    action: PendingAction, store: PendingActionsStore, resolver: str
+) -> Response | tuple[Response, int]:
+    """Submit the exact staged cart to Safeway (real money)."""
+    cart = CartSummary.model_validate(action.payload["cart"])
+    try:
+        pipeline = _safeway_pipeline()
+    except (ConfigError, SafewayPipelineError) as exc:
+        # Not claimed yet: the action stays pending so it can be retried
+        # (until it expires) once configuration is fixed.
+        return jsonify(error=f"safeway pipeline unavailable: {exc}"), 503
+    if not pipeline.order_submission_enabled:
+        # Issue #60: order submission is descoped for v1.0. Not claimed —
+        # the action stays pending so it can be retried once the flag is
+        # flipped on after live verification.
+        pipeline.close()
+        return jsonify(error=ORDER_SUBMISSION_DISABLED_MESSAGE), 501
+    # W6 (issue #75): the claim happens *inside* this try/finally so a
+    # raced claim that aborts 409 still closes the pipeline already built
+    # for this request — a bare pre-claim abort would leak it otherwise.
+    try:
+        _claim_pending(store, action.action_id, resolver=resolver)
+        return _submit_claimed_order(action, store, pipeline, cart)
+    finally:
+        pipeline.close()
+
+
+def _confirm_brands_set(
+    action: PendingAction, store: PendingActionsStore, resolver: str
+) -> Response:
     """Apply the staged brand preference rule."""
     pref = BrandPreference.model_validate(action.payload)
-    _claim_pending(store, action.action_id)
+    _claim_pending(store, action.action_id, resolver=resolver)
     pref_id = _recipe_store().add_brand_preference(pref)
+    _log_resolution("confirmed", action)
     return _approved(action, {**pref.model_dump(mode="json"), "id": pref_id})
 
 
 def _confirm_preferences_set(
-    action: PendingAction, store: PendingActionsStore
+    action: PendingAction, store: PendingActionsStore, resolver: str
 ) -> Response:
-    """Apply the staged app-level preference changes."""
+    """Apply the staged app-level preference changes atomically.
+
+    Uses :meth:`RecipeStore.set_preferences` -- one connection, one
+    commit for every staged key -- so a mid-way failure leaves the
+    store completely untouched instead of half-applied (issue #75, W5).
+    """
     preferences: dict[str, str] = action.payload["preferences"]
-    _claim_pending(store, action.action_id)
-    store_ = _recipe_store()
-    for key, value in preferences.items():
-        store_.set_preference(key, value)
-    return _approved(action, {"updated": len(preferences)})
+    _claim_pending(store, action.action_id, resolver=resolver)
+    updated = _recipe_store().set_preferences(preferences)
+    _log_resolution("confirmed", action)
+    return _approved(action, {"updated": updated})
 
 
 _CONFIRM_EXECUTORS: dict[
     str,
-    Callable[[PendingAction, PendingActionsStore], Response | tuple[Response, int]],
+    Callable[
+        [PendingAction, PendingActionsStore, str], Response | tuple[Response, int]
+    ],
 ] = {
     "safeway_order_submit": _confirm_order_submit,
     "brands_set": _confirm_brands_set,
@@ -723,18 +882,19 @@ _CONFIRM_EXECUTORS: dict[
 @api_v1.post("/actions/confirm")
 def post_actions_confirm() -> Response | tuple[Response, int]:
     """Execute a staged action exactly once after chat confirmation."""
-    require_bearer()
+    caller_id = require_bearer()
     action = _load_pending_action(_json_body())
     store = _pending_store()
     if action.status is not PendingActionStatus.PENDING:
         abort(409, description="action already resolved")
     if action.is_expired():
         store.mark_pending_expired(action.action_id)
+        _log_resolution("expired", action)
         abort(410, description="action expired — stage it again")
     executor = _CONFIRM_EXECUTORS.get(action.kind)
     if executor is None:
         abort(400, description=f"unknown action kind: {action.kind}")
-    return executor(action, store)
+    return executor(action, store, caller_id)
 
 
 @api_v1.post("/actions/deny")
@@ -745,8 +905,80 @@ def post_actions_deny() -> Response:
     check the TTL — a denied-after-expiry action records the user's
     explicit "no" rather than a timeout.
     """
-    require_bearer()
+    resolver = require_bearer()
     action = _load_pending_action(_json_body())
-    if not _pending_store().mark_pending_denied(action.action_id):
+    if not _pending_store().mark_pending_denied(action.action_id, resolver=resolver):
         abort(409, description="action already resolved")
+    _log_resolution("denied", action)
     return jsonify(status="denied", action_id=action.action_id, kind=action.kind)
+
+
+# ---------------------------------------------------------------------------
+# GET /actions and /actions/<action_id> — read access to the audit log (W4)
+# ---------------------------------------------------------------------------
+
+#: Default and hard-cap page sizes for GET /actions (W4, issue #75).
+_DEFAULT_ACTIONS_LIMIT = 50
+_MAX_ACTIONS_LIMIT = 200
+
+
+def _pending_action_json(action: PendingAction) -> dict[str, Any]:
+    """Serialize a PendingAction to a JSON-safe dict."""
+    return action.model_dump(mode="json")
+
+
+def _parse_actions_query() -> tuple[int, PendingActionStatus | None]:
+    """Parse and validate the ``?limit`` and ``?status`` query params.
+
+    Returns:
+        Tuple of (clamped limit, optional status filter). An omitted or
+        over-cap ``?limit`` is clamped into ``[1, _MAX_ACTIONS_LIMIT]``
+        rather than rejected.
+
+    Raises:
+        HTTPException: 400 if ``limit`` is not an integer, or if
+            ``status`` is present but not a recognized
+            :class:`PendingActionStatus` value.
+    """
+    raw_limit = request.args.get("limit", str(_DEFAULT_ACTIONS_LIMIT))
+    try:
+        limit = int(raw_limit)
+    except ValueError:
+        abort(400, description="limit must be an integer")
+    limit = max(1, min(limit, _MAX_ACTIONS_LIMIT))
+
+    raw_status = request.args.get("status")
+    if raw_status is None:
+        return limit, None
+    try:
+        status = PendingActionStatus(raw_status)
+    except ValueError:
+        abort(400, description="unknown status value")
+    return limit, status
+
+
+@api_v1.get("/actions")
+def get_actions() -> Response:
+    """List staged/resolved actions, sweeping expired rows first (W4).
+
+    Reading the audit log first sweeps any past-due pending rows to
+    ``expired`` so the returned statuses are current, not stale.
+    """
+    require_bearer()
+    limit, status = _parse_actions_query()
+    store = _pending_store()
+    _sweep_expired(store)
+    actions = store.list_pending_actions(limit=limit, status=status)
+    return jsonify(
+        actions=[_pending_action_json(a) for a in actions], count=len(actions)
+    )
+
+
+@api_v1.get("/actions/<action_id>")
+def get_action(action_id: str) -> Response | tuple[Response, int]:
+    """Return one staged/resolved action by id, or a JSON 404 (W4)."""
+    require_bearer()
+    action = _pending_store().get_pending_action(action_id)
+    if action is None:
+        return jsonify(error="unknown action_id"), 404
+    return jsonify(_pending_action_json(action))

--- a/grocery_butler/db/migrations/008_pending_actions_resolver.sql
+++ b/grocery_butler/db/migrations/008_pending_actions_resolver.sql
@@ -1,0 +1,7 @@
+-- Migration 008: pending_actions resolver column (SQLite).
+-- Issue #75 (W1): confirm/deny routes must record which caller resolved
+-- a staged action, distinct from the requester who staged it. Nullable
+-- because system-initiated resolutions (TTL expiry) have no resolving
+-- caller.
+
+ALTER TABLE pending_actions ADD COLUMN resolver TEXT;

--- a/grocery_butler/db/migrations/008_pending_actions_resolver_pg.sql
+++ b/grocery_butler/db/migrations/008_pending_actions_resolver_pg.sql
@@ -1,0 +1,7 @@
+-- Migration 008: pending_actions resolver column (PostgreSQL).
+-- Issue #75 (W1): confirm/deny routes must record which caller resolved
+-- a staged action, distinct from the requester who staged it. Nullable
+-- because system-initiated resolutions (TTL expiry) have no resolving
+-- caller.
+
+ALTER TABLE pending_actions ADD COLUMN IF NOT EXISTS resolver TEXT;

--- a/grocery_butler/models.py
+++ b/grocery_butler/models.py
@@ -511,6 +511,7 @@ class PendingActionStatus(StrEnum):
     APPROVED = "approved"
     DENIED = "denied"
     EXPIRED = "expired"
+    FAILED = "failed"
 
 
 class PendingAction(BaseModel):
@@ -518,7 +519,13 @@ class PendingAction(BaseModel):
 
     Rows live in the ``pending_actions`` table and record every staged
     Safeway submission or preference change, whether it was ultimately
-    approved, denied, or expired.
+    approved, denied, expired, or (after being claimed) failed.
+
+    Attributes:
+        requester: The caller_id that staged this action.
+        resolver: The caller_id that resolved this action (approved or
+            denied it), or None for a system-initiated resolution such
+            as TTL expiry, which has no resolving caller.
     """
 
     action_id: str
@@ -526,6 +533,7 @@ class PendingAction(BaseModel):
     payload: dict[str, Any]
     status: PendingActionStatus = PendingActionStatus.PENDING
     requester: str = "rubotpaul"
+    resolver: str | None = None
     expires_at: dt.datetime
     created_at: dt.datetime | None = None
     resolved_at: dt.datetime | None = None

--- a/grocery_butler/pending_actions.py
+++ b/grocery_butler/pending_actions.py
@@ -3,7 +3,9 @@
 The ``pending_actions`` table is the server-side staging area and audit
 log for destructive operations (Safeway order submissions, brand and
 preference changes). Rows are inserted as ``pending`` and resolved to
-``approved``, ``denied``, or ``expired`` exactly once.
+``approved``, ``denied``, or ``expired`` exactly once; an ``approved``
+row may additionally transition to ``failed`` if execution errors out
+after being claimed.
 
 Uses the same connection-per-operation pattern as
 :class:`grocery_butler.recipe_store.RecipeStore`, so it works against
@@ -45,6 +47,7 @@ def _row_to_pending_action(row: DictRow) -> PendingAction:
         payload=payload,
         status=PendingActionStatus(row["status"]),
         requester=row["requester"],
+        resolver=row["resolver"],
         expires_at=row["expires_at"],
         created_at=row["created_at"],
         resolved_at=row["resolved_at"],
@@ -131,7 +134,7 @@ class PendingActionsStore:
         conn = self._connect()
         try:
             result = conn.execute(
-                "SELECT action_id, kind, payload, status, requester, "
+                "SELECT action_id, kind, payload, status, requester, resolver, "
                 "expires_at, created_at, resolved_at "
                 "FROM pending_actions WHERE action_id = ?",
                 (action_id,),
@@ -143,30 +146,51 @@ class PendingActionsStore:
             return None
         return _row_to_pending_action(row)
 
-    def mark_pending_approved(self, action_id: str) -> bool:
+    def mark_pending_approved(
+        self, action_id: str, *, resolver: str | None = None
+    ) -> bool:
         """Resolve a pending action as approved.
 
         Args:
             action_id: Identifier of the action to approve.
+            resolver: The caller_id that approved the action, or None to
+                leave any previously stamped resolver untouched.
 
         Returns:
             True if the action was pending and is now approved.
         """
-        return self._resolve(action_id, PendingActionStatus.APPROVED)
+        return self._transition(
+            action_id,
+            from_status=PendingActionStatus.PENDING,
+            to_status=PendingActionStatus.APPROVED,
+            resolver=resolver,
+        )
 
-    def mark_pending_denied(self, action_id: str) -> bool:
+    def mark_pending_denied(
+        self, action_id: str, *, resolver: str | None = None
+    ) -> bool:
         """Resolve a pending action as denied.
 
         Args:
             action_id: Identifier of the action to deny.
+            resolver: The caller_id that denied the action, or None to
+                leave any previously stamped resolver untouched.
 
         Returns:
             True if the action was pending and is now denied.
         """
-        return self._resolve(action_id, PendingActionStatus.DENIED)
+        return self._transition(
+            action_id,
+            from_status=PendingActionStatus.PENDING,
+            to_status=PendingActionStatus.DENIED,
+            resolver=resolver,
+        )
 
     def mark_pending_expired(self, action_id: str) -> bool:
         """Resolve a pending action as expired.
+
+        Expiry is always system-initiated (a TTL deadline, not a human
+        decision), so no resolver is ever stamped by this method.
 
         Args:
             action_id: Identifier of the action to expire.
@@ -174,34 +198,150 @@ class PendingActionsStore:
         Returns:
             True if the action was pending and is now expired.
         """
-        return self._resolve(action_id, PendingActionStatus.EXPIRED)
+        return self._transition(
+            action_id,
+            from_status=PendingActionStatus.PENDING,
+            to_status=PendingActionStatus.EXPIRED,
+        )
 
-    def _resolve(self, action_id: str, new_status: PendingActionStatus) -> bool:
-        """Transition an action from pending to a terminal status.
+    def mark_pending_failed(self, action_id: str) -> bool:
+        """Resolve an approved action as failed after a post-claim error.
 
-        The UPDATE is guarded on ``status = 'pending'`` so an action can
-        only be resolved once; later attempts (or unknown ids) fail.
+        Guarded on ``status = 'approved'`` (not ``'pending'``): this
+        transition only ever applies to a row that was already claimed
+        by :meth:`mark_pending_approved` and then failed during
+        execution (e.g. the Safeway submission raised or reported
+        failure). The resolver already stamped by the approval is left
+        untouched.
 
         Args:
-            action_id: Identifier of the action to resolve.
-            new_status: Terminal status to apply.
+            action_id: Identifier of the action to mark failed.
 
         Returns:
-            True if exactly one pending row was transitioned.
+            True if the action was approved and is now failed.
+        """
+        return self._transition(
+            action_id,
+            from_status=PendingActionStatus.APPROVED,
+            to_status=PendingActionStatus.FAILED,
+        )
+
+    def _transition(
+        self,
+        action_id: str,
+        *,
+        from_status: PendingActionStatus,
+        to_status: PendingActionStatus,
+        resolver: str | None = None,
+    ) -> bool:
+        """Transition a row from one status to another, guarded exactly once.
+
+        The UPDATE is guarded on ``status = from_status`` so a given
+        transition can only ever apply once; later attempts (unknown
+        ids, or rows already in a different status) report failure
+        rather than raising. When ``resolver`` is omitted (None), any
+        resolver already stamped on the row is preserved rather than
+        cleared, via ``COALESCE`` -- this lets system-initiated
+        transitions (expiry, post-claim failure) leave the audit trail
+        of who originally resolved the row intact.
+
+        Args:
+            action_id: Identifier of the action to transition.
+            from_status: Required current status for the transition to
+                apply.
+            to_status: New status to apply.
+            resolver: Caller who resolved the action, or None to leave
+                any existing resolver value untouched.
+
+        Returns:
+            True if exactly one row in ``from_status`` was transitioned.
         """
         conn = self._connect()
         try:
             result = conn.execute(
-                "UPDATE pending_actions SET status = ?, resolved_at = ? "
+                "UPDATE pending_actions SET status = ?, "
+                "resolver = COALESCE(?, resolver), resolved_at = ? "
                 "WHERE action_id = ? AND status = ?",
                 (
-                    new_status.value,
+                    to_status.value,
+                    resolver,
                     dt.datetime.now(dt.UTC).isoformat(),
                     action_id,
-                    PendingActionStatus.PENDING.value,
+                    from_status.value,
                 ),
             )
             conn.commit()
             return result.rowcount == 1
         finally:
             conn.close()
+
+    def sweep_expired(self, now: dt.datetime | None = None) -> int:
+        """Resolve every past-due pending row as expired in one bulk update.
+
+        Rows are never auto-resolved just by being read (see
+        :meth:`PendingAction.is_expired`); only an explicit sweep (or a
+        direct resolution) transitions them. This is system-initiated,
+        so ``resolver`` is left untouched (it is already NULL for any
+        row that reaches this method, since only pending rows qualify).
+
+        Args:
+            now: Reference time to compare deadlines against; defaults
+                to the current UTC time.
+
+        Returns:
+            Number of rows transitioned to expired.
+        """
+        reference = now if now is not None else dt.datetime.now(dt.UTC)
+        conn = self._connect()
+        try:
+            result = conn.execute(
+                "UPDATE pending_actions SET status = ?, resolved_at = ? "
+                "WHERE status = ? AND expires_at < ?",
+                (
+                    PendingActionStatus.EXPIRED.value,
+                    dt.datetime.now(dt.UTC).isoformat(),
+                    PendingActionStatus.PENDING.value,
+                    reference.isoformat(),
+                ),
+            )
+            conn.commit()
+            return result.rowcount
+        finally:
+            conn.close()
+
+    def list_pending_actions(
+        self, *, limit: int, status: PendingActionStatus | None = None
+    ) -> list[PendingAction]:
+        """List staged/resolved actions, newest first.
+
+        Args:
+            limit: Maximum number of rows to return.
+            status: If given, only rows with this status are returned;
+                None (the default) returns rows regardless of status.
+
+        Returns:
+            List of PendingAction models ordered by created_at
+            descending (ties broken by action_id descending for
+            deterministic pagination).
+        """
+        conn = self._connect()
+        try:
+            if status is None:
+                result = conn.execute(
+                    "SELECT action_id, kind, payload, status, requester, resolver, "
+                    "expires_at, created_at, resolved_at FROM pending_actions "
+                    "ORDER BY created_at DESC, action_id DESC LIMIT ?",
+                    (limit,),
+                )
+            else:
+                result = conn.execute(
+                    "SELECT action_id, kind, payload, status, requester, resolver, "
+                    "expires_at, created_at, resolved_at FROM pending_actions "
+                    "WHERE status = ? "
+                    "ORDER BY created_at DESC, action_id DESC LIMIT ?",
+                    (status.value, limit),
+                )
+            rows = result.fetchall()
+        finally:
+            conn.close()
+        return [_row_to_pending_action(row) for row in rows]

--- a/grocery_butler/recipe_store.py
+++ b/grocery_butler/recipe_store.py
@@ -490,6 +490,36 @@ class RecipeStore:
         finally:
             conn.close()
 
+    def set_preferences(self, values: dict[str, str]) -> int:
+        """Set multiple preferences atomically (all-or-nothing).
+
+        Uses a single connection and a single commit for every key
+        (issue #75, W5), unlike a per-key loop over :meth:`set_preference`
+        -- a failure partway through leaves the store completely
+        untouched instead of half-applied, since nothing is committed
+        until every upsert has succeeded.
+
+        Args:
+            values: Mapping of preference keys to their new values.
+
+        Returns:
+            Number of preferences upserted.
+        """
+        conn = self._connect()
+        try:
+            for key, value in values.items():
+                result = conn.execute(
+                    "INSERT INTO preferences (key, value) VALUES (?, ?)"
+                    " ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+                    " RETURNING key",
+                    (key, value),
+                )
+                result.fetchall()  # drain RETURNING so commit sees no open cursor
+            conn.commit()
+            return len(values)
+        finally:
+            conn.close()
+
     def get_all_preferences(self) -> dict[str, str]:
         """Return all preferences as a dict.
 

--- a/tests/test_api_destructive.py
+++ b/tests/test_api_destructive.py
@@ -10,6 +10,7 @@ client — the pipeline factory is mocked everywhere it could execute.
 from __future__ import annotations
 
 import datetime as dt
+import logging
 import os
 import uuid
 from typing import TYPE_CHECKING, Any
@@ -26,6 +27,7 @@ if TYPE_CHECKING:
 from grocery_butler.app import create_app
 from grocery_butler.auth_middleware import SECRET_ENV_VAR, mint_token
 from grocery_butler.config import ConfigError
+from grocery_butler.db import get_connection
 from grocery_butler.models import (
     BrandMatchType,
     BrandPreference,
@@ -42,6 +44,7 @@ from grocery_butler.models import (
 from grocery_butler.order_service import OrderConfirmation, OrderResult
 from grocery_butler.pending_actions import PendingActionsStore
 from grocery_butler.recipe_store import RecipeStore
+from grocery_butler.safeway_pipeline import SafewayPipelineError
 
 TEST_SECRET = "test-shared-secret"
 SECRET_ENV = {SECRET_ENV_VAR: TEST_SECRET}
@@ -97,6 +100,18 @@ def auth_headers() -> dict[str, str]:
     """Return a valid Authorization header minted with the test secret."""
     with patch.dict(os.environ, SECRET_ENV):
         token = mint_token("rubotpaul")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _headers_for(caller_id: str) -> dict[str, str]:
+    """Return a valid Authorization header minted for a specific caller.
+
+    Used to distinguish the staging caller (requester) from the
+    confirming/denying caller (resolver) in W1 audit-trail tests
+    (issue #75).
+    """
+    with patch.dict(os.environ, SECRET_ENV):
+        token = mint_token(caller_id)
     return {"Authorization": f"Bearer {token}"}
 
 
@@ -247,6 +262,293 @@ def _stage_via_api(
 
 
 # ---------------------------------------------------------------------------
+# W1 (issue #75): requester/resolver recorded from the real caller_id
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, SECRET_ENV)
+class TestRequesterAndResolverAtRoutes:
+    """Every staged/resolved action records the real caller (W1, issue #75).
+
+    Two distinct callers are minted so requester (the staging caller) and
+    resolver (the confirming/denying caller) can be told apart in the
+    audit trail -- neither should ever fall back to the old
+    "rubotpaul"-only default.
+    """
+
+    def test_order_submit_records_requester_as_caller_id(
+        self, client: FlaskClient, pending_store: PendingActionsStore
+    ) -> None:
+        """Staging an order records the token's caller_id as requester."""
+        headers = _headers_for("alice")
+        response = client.post(
+            "/api/v1/order/submit", json=_order_body(), headers=headers
+        )
+        assert response.status_code == 200
+        action = pending_store.get_pending_action(response.get_json()["action_id"])
+        assert action is not None
+        assert action.requester == "alice"
+
+    def test_brands_set_records_requester_as_caller_id(
+        self, client: FlaskClient, pending_store: PendingActionsStore
+    ) -> None:
+        """Staging a brand rule records the token's caller_id as requester."""
+        headers = _headers_for("bob")
+        response = client.post(
+            "/api/v1/brands/set", json=_brand_body(), headers=headers
+        )
+        assert response.status_code == 200
+        action = pending_store.get_pending_action(response.get_json()["action_id"])
+        assert action is not None
+        assert action.requester == "bob"
+
+    def test_preferences_set_records_requester_as_caller_id(
+        self, client: FlaskClient, pending_store: PendingActionsStore
+    ) -> None:
+        """Staging preferences records the token's caller_id as requester."""
+        headers = _headers_for("carol")
+        body = {"preferences": {"fulfillment": "pickup"}}
+        response = client.post("/api/v1/preferences/set", json=body, headers=headers)
+        assert response.status_code == 200
+        action = pending_store.get_pending_action(response.get_json()["action_id"])
+        assert action is not None
+        assert action.requester == "carol"
+
+    def test_confirm_records_resolver_as_confirming_caller_id(
+        self,
+        client: FlaskClient,
+        pending_store: PendingActionsStore,
+    ) -> None:
+        """Confirming stamps resolver with the CONFIRMING caller, not requester."""
+        stage_headers = _headers_for("alice")
+        confirm_headers = _headers_for("bob")
+        action_id = _stage_via_api(
+            client, stage_headers, "/api/v1/brands/set", _brand_body()
+        )
+        response = client.post(
+            "/api/v1/actions/confirm",
+            json={"action_id": action_id},
+            headers=confirm_headers,
+        )
+        assert response.status_code == 200
+        action = pending_store.get_pending_action(action_id)
+        assert action is not None
+        assert action.requester == "alice"
+        assert action.resolver == "bob"
+
+    def test_deny_records_resolver_as_denying_caller_id(
+        self,
+        client: FlaskClient,
+        pending_store: PendingActionsStore,
+    ) -> None:
+        """Denying stamps the resolver with the DENYING caller."""
+        stage_headers = _headers_for("alice")
+        deny_headers = _headers_for("dave")
+        action_id = _stage_via_api(
+            client, stage_headers, "/api/v1/brands/set", _brand_body()
+        )
+        response = client.post(
+            "/api/v1/actions/deny",
+            json={"action_id": action_id},
+            headers=deny_headers,
+        )
+        assert response.status_code == 200
+        action = pending_store.get_pending_action(action_id)
+        assert action is not None
+        assert action.resolver == "dave"
+
+    def test_system_expiry_via_confirm_leaves_resolver_none(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        pending_store: PendingActionsStore,
+    ) -> None:
+        """Confirming an expired action resolves it as expired, no resolver.
+
+        Expiry is a system-initiated resolution (the human never actually
+        confirmed anything -- the TTL did), so the resolver must stay
+        NULL even though a caller made the doomed confirm request.
+        """
+        action_id = str(uuid.uuid4())
+        pending_store.insert_pending_action(
+            action_id=action_id,
+            kind="preferences_set",
+            payload={"preferences": {"fulfillment": "pickup"}},
+            expires_at=dt.datetime.now(dt.UTC) - dt.timedelta(seconds=1),
+        )
+        response = client.post(
+            "/api/v1/actions/confirm",
+            json={"action_id": action_id},
+            headers=auth_headers,
+        )
+        assert response.status_code == 410
+        action = pending_store.get_pending_action(action_id)
+        assert action is not None
+        assert action.status is PendingActionStatus.EXPIRED
+        assert action.resolver is None
+
+
+# ---------------------------------------------------------------------------
+# W2 (issue #75): every transition logs INFO with action_id/kind, never
+# payload contents
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, SECRET_ENV)
+class TestActionAuditLogging:
+    """Every staged-action transition is logged at INFO (W2, issue #75).
+
+    Uses a distinctive ingredient name as a payload-content marker: none
+    of the captured log messages may ever contain it, proving the audit
+    trail logs metadata (action_id, kind) and never the payload itself.
+    """
+
+    _MARKER_INGREDIENT = "unobtainium-marker-item"
+
+    def _order_body_with_marker(self) -> dict[str, Any]:
+        """Return an /order/submit body containing the payload marker."""
+        return _order_body({self._MARKER_INGREDIENT: 9.99})
+
+    def test_staging_order_logs_info_with_action_id_and_total(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Staging an order logs an INFO line naming the action and kind."""
+        with caplog.at_level(logging.INFO, logger="api"):
+            response = client.post(
+                "/api/v1/order/submit",
+                json=self._order_body_with_marker(),
+                headers=auth_headers,
+            )
+        assert response.status_code == 200
+        action_id = response.get_json()["action_id"]
+        messages = [r.getMessage() for r in caplog.records if r.name == "api"]
+        assert any(action_id in m for m in messages)
+        assert any("safeway_order_submit" in m for m in messages)
+        assert not any(self._MARKER_INGREDIENT in m for m in messages)
+
+    def test_staging_brands_logs_info_with_action_id_and_kind(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Staging a brand rule logs an INFO line, never the brand name."""
+        with caplog.at_level(logging.INFO, logger="api"):
+            response = client.post(
+                "/api/v1/brands/set", json=_brand_body(), headers=auth_headers
+            )
+        assert response.status_code == 200
+        action_id = response.get_json()["action_id"]
+        messages = [r.getMessage() for r in caplog.records if r.name == "api"]
+        assert any(action_id in m and "brands_set" in m for m in messages)
+        assert not any("Clover" in m for m in messages)
+
+    def test_confirm_logs_info_with_action_id_and_kind(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Confirming a staged action logs a transition INFO line."""
+        action_id = _stage_via_api(
+            client, auth_headers, "/api/v1/brands/set", _brand_body()
+        )
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="api"):
+            response = client.post(
+                "/api/v1/actions/confirm",
+                json={"action_id": action_id},
+                headers=auth_headers,
+            )
+        assert response.status_code == 200
+        messages = [r.getMessage() for r in caplog.records if r.name == "api"]
+        assert any(action_id in m and "brands_set" in m for m in messages)
+        assert not any("Clover" in m for m in messages)
+
+    def test_confirm_failure_logs_failed_transition(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A failed order submission logs a 'failed' transition line."""
+        action_id = _stage_via_api(
+            client,
+            auth_headers,
+            "/api/v1/order/submit",
+            self._order_body_with_marker(),
+        )
+        pipeline = MagicMock()
+        pipeline.submit_cart.return_value = OrderResult(
+            success=False, error_message="Safeway is down"
+        )
+        caplog.clear()
+        with (
+            patch("grocery_butler.api._safeway_pipeline", return_value=pipeline),
+            caplog.at_level(logging.INFO, logger="api"),
+        ):
+            response = client.post(
+                "/api/v1/actions/confirm",
+                json={"action_id": action_id},
+                headers=auth_headers,
+            )
+        assert response.status_code == 502
+        messages = [r.getMessage() for r in caplog.records if r.name == "api"]
+        assert any(action_id in m and "failed" in m.lower() for m in messages)
+        assert not any(self._MARKER_INGREDIENT in m for m in messages)
+
+    def test_deny_logs_info_with_action_id_and_kind(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Denying a staged action logs a 'denied' transition line."""
+        action_id = _stage_via_api(
+            client, auth_headers, "/api/v1/brands/set", _brand_body()
+        )
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="api"):
+            response = client.post(
+                "/api/v1/actions/deny",
+                json={"action_id": action_id},
+                headers=auth_headers,
+            )
+        assert response.status_code == 200
+        messages = [r.getMessage() for r in caplog.records if r.name == "api"]
+        assert any(action_id in m and "denied" in m.lower() for m in messages)
+        assert not any("Clover" in m for m in messages)
+
+    def test_expire_logs_info_with_action_id_and_kind(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        pending_store: PendingActionsStore,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Confirming an expired action logs an 'expired' transition line."""
+        action_id = str(uuid.uuid4())
+        pending_store.insert_pending_action(
+            action_id=action_id,
+            kind="preferences_set",
+            payload={"preferences": {"fulfillment": "pickup"}},
+            expires_at=dt.datetime.now(dt.UTC) - dt.timedelta(seconds=1),
+        )
+        with caplog.at_level(logging.INFO, logger="api"):
+            response = client.post(
+                "/api/v1/actions/confirm",
+                json={"action_id": action_id},
+                headers=auth_headers,
+            )
+        assert response.status_code == 410
+        messages = [r.getMessage() for r in caplog.records if r.name == "api"]
+        assert any(action_id in m and "expired" in m.lower() for m in messages)
+
+
+# ---------------------------------------------------------------------------
 # Auth: every destructive endpoint rejects unauthenticated requests
 # ---------------------------------------------------------------------------
 
@@ -364,6 +666,45 @@ class TestOrderSubmitStaging:
         action = pending_store.get_pending_action(response.get_json()["action_id"])
         assert action is not None
         assert action.payload["total"] == "7.75"
+
+    def test_non_numeric_total_returns_400(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """A total that isn't a numeric amount is rejected, not staged."""
+        cart = _make_cart({"pasta": 3.50, "sauce": 4.25})
+        response = client.post(
+            "/api/v1/order/submit",
+            json={"cart": cart.model_dump(mode="json"), "total": "not-a-number"},
+            headers=auth_headers,
+        )
+        assert response.status_code == 400
+        assert "total" in response.get_json()["error"]
+
+    def test_total_with_embedded_newline_returns_400_and_is_not_logged(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A total crafted to forge a fake log line is rejected before staging.
+
+        Regression test (issue #75, log hygiene): an unvalidated client
+        ``total`` used to flow verbatim into the ``staged action_id=...``
+        audit-log line, letting a caller embed a newline and forge a fake
+        transition line. It must now be rejected outright rather than
+        staged or logged.
+        """
+        cart = _make_cart({"pasta": 3.50, "sauce": 4.25})
+        forged = "7.75\nfailed action_id=forged-marker kind=safeway_order_submit"
+        with caplog.at_level(logging.INFO, logger="api"):
+            response = client.post(
+                "/api/v1/order/submit",
+                json={"cart": cart.model_dump(mode="json"), "total": forged},
+                headers=auth_headers,
+            )
+        assert response.status_code == 400
+        messages = [r.getMessage() for r in caplog.records if r.name == "api"]
+        assert not any("forged-marker" in m for m in messages)
 
     def test_staging_never_touches_the_safeway_pipeline(
         self, client: FlaskClient, auth_headers: dict[str, str]
@@ -684,7 +1025,12 @@ class TestActionsConfirm:
         auth_headers: dict[str, str],
         pending_store: PendingActionsStore,
     ) -> None:
-        """A failed Safeway submission reports 502; the claim is consumed."""
+        """A failed Safeway submission reports 502 and resolves as failed.
+
+        Issue #75 (W3): a post-claim failure (``result.success is False``)
+        must resolve the row as ``failed``, not leave it stuck
+        ``approved`` with no record that the submission actually failed.
+        """
         action_id = _stage_via_api(
             client, auth_headers, "/api/v1/order/submit", _order_body()
         )
@@ -702,7 +1048,39 @@ class TestActionsConfirm:
         assert "Safeway is down" in response.get_json()["error"]
         action = pending_store.get_pending_action(action_id)
         assert action is not None
-        assert action.status is PendingActionStatus.APPROVED
+        assert action.status is PendingActionStatus.FAILED
+        assert action.resolved_at is not None
+
+    def test_pipeline_exception_after_claim_marks_action_failed(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        pending_store: PendingActionsStore,
+    ) -> None:
+        """A SafewayPipelineError raised by submit_cart marks the row failed.
+
+        Distinct from the pre-claim 503/501 paths (which never claim the
+        row): once the claim succeeds, ANY post-claim failure -- an
+        exception from ``submit_cart`` or a False ``result.success`` --
+        must resolve the row as failed, never leave it stuck approved
+        (issue #75, W3).
+        """
+        action_id = _stage_via_api(
+            client, auth_headers, "/api/v1/order/submit", _order_body()
+        )
+        pipeline = MagicMock()
+        pipeline.submit_cart.side_effect = SafewayPipelineError("network blip")
+        with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
+            response = client.post(
+                "/api/v1/actions/confirm",
+                json={"action_id": action_id},
+                headers=auth_headers,
+            )
+        assert response.status_code == 502
+        pipeline.close.assert_called_once()
+        action = pending_store.get_pending_action(action_id)
+        assert action is not None
+        assert action.status is PendingActionStatus.FAILED
 
     def test_unavailable_pipeline_returns_503_and_keeps_action_pending(
         self,
@@ -986,7 +1364,12 @@ class TestConfirmOrderIdempotency:
         auth_headers: dict[str, str],
         pending_store: PendingActionsStore,
     ) -> None:
-        """Test an UNKNOWN order outcome surfaces as HTTP 504 with status unknown."""
+        """Test an UNKNOWN order outcome surfaces as HTTP 504 with status unknown.
+
+        Issue #75 (W3): UNKNOWN is a ``result.success is False`` outcome,
+        so it's a post-claim failure like any other and must resolve the
+        row as ``failed``, not leave it stuck ``approved``.
+        """
         from grocery_butler.order_service import OrderOutcome
 
         action_id = _stage_via_api(
@@ -1012,7 +1395,7 @@ class TestConfirmOrderIdempotency:
 
         action = pending_store.get_pending_action(action_id)
         assert action is not None
-        assert action.status is PendingActionStatus.APPROVED
+        assert action.status is PendingActionStatus.FAILED
 
     def test_duplicate_outcome_returns_409(
         self,
@@ -1020,7 +1403,11 @@ class TestConfirmOrderIdempotency:
         auth_headers: dict[str, str],
         pending_store: PendingActionsStore,
     ) -> None:
-        """Test a DUPLICATE order outcome surfaces as HTTP 409 duplicate_prevented."""
+        """Test a DUPLICATE order outcome surfaces as HTTP 409 duplicate_prevented.
+
+        Issue #75 (W3): DUPLICATE is also a ``result.success is False``
+        outcome, so it too must resolve the row as ``failed``.
+        """
         from grocery_butler.order_service import OrderOutcome
 
         action_id = _stage_via_api(
@@ -1045,4 +1432,310 @@ class TestConfirmOrderIdempotency:
 
         action = pending_store.get_pending_action(action_id)
         assert action is not None
-        assert action.status is PendingActionStatus.APPROVED
+        assert action.status is PendingActionStatus.FAILED
+
+
+# ---------------------------------------------------------------------------
+# W6 (issue #75): a raced/duplicate confirm must still close the pipeline
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, SECRET_ENV)
+class TestPipelineLeakOnRace:
+    """A raced/duplicate confirm must still close the Safeway pipeline (W6).
+
+    ``post_actions_confirm`` reads the action once, then the executor
+    builds a Safeway pipeline before atomically claiming the row. If a
+    concurrent request already resolved the row by the time the claim
+    runs, the claim fails (409) -- but the pipeline that was already
+    constructed for THIS request must still be closed, or every raced
+    confirm leaks a client/session (issue #75).
+    """
+
+    def test_claim_race_still_closes_pipeline_before_409(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """A claim that loses the race closes the already-built pipeline."""
+        action_id = _stage_via_api(
+            client, auth_headers, "/api/v1/order/submit", _order_body()
+        )
+        pipeline = MagicMock()
+        with (
+            patch("grocery_butler.api._safeway_pipeline", return_value=pipeline),
+            patch.object(
+                PendingActionsStore, "mark_pending_approved", return_value=False
+            ),
+        ):
+            response = client.post(
+                "/api/v1/actions/confirm",
+                json={"action_id": action_id},
+                headers=auth_headers,
+            )
+        assert response.status_code == 409
+        pipeline.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# W5 (issue #75): preferences confirmation must be all-or-nothing
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, SECRET_ENV)
+class TestPreferencesAtomicity:
+    """Confirming preferences_set must be all-or-nothing (W5, issue #75).
+
+    ``_confirm_preferences_set`` must use a single connection / one
+    commit for every staged key (``RecipeStore.set_preferences``)
+    instead of the old per-key loop, so a mid-way failure leaves the
+    store completely untouched rather than half-applied.
+    """
+
+    def test_mid_write_failure_leaves_no_keys_applied(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        recipe_store: RecipeStore,
+    ) -> None:
+        """A failure applying the second key rolls back the first too."""
+        body = {"preferences": {"fulfillment": "pickup", "store_id": "1234"}}
+        action_id = _stage_via_api(
+            client, auth_headers, "/api/v1/preferences/set", body
+        )
+
+        class _FailSecondWrite:
+            """Connection proxy that fails starting on its second execute()."""
+
+            def __init__(self, real_conn: Any) -> None:
+                self._real = real_conn
+                self._calls = 0
+
+            def execute(self, sql: str, params: Any = ()) -> Any:
+                self._calls += 1
+                if self._calls > 1:
+                    raise RuntimeError("simulated mid-transaction failure")
+                return self._real.execute(sql, params)
+
+            def executescript(self, sql: str) -> None:
+                self._real.executescript(sql)
+
+            def commit(self) -> None:
+                self._real.commit()
+
+            def close(self) -> None:
+                self._real.close()
+
+        def _fake_get_connection(path: str) -> _FailSecondWrite:
+            return _FailSecondWrite(get_connection(path))
+
+        with (
+            patch(
+                "grocery_butler.recipe_store.get_connection",
+                side_effect=_fake_get_connection,
+            ),
+            pytest.raises(RuntimeError, match="simulated mid-transaction failure"),
+        ):
+            client.post(
+                "/api/v1/actions/confirm",
+                json={"action_id": action_id},
+                headers=auth_headers,
+            )
+
+        stored = recipe_store.get_all_preferences()
+        assert "fulfillment" not in stored
+        assert "store_id" not in stored
+
+
+# ---------------------------------------------------------------------------
+# W4 (issue #75): GET /api/v1/actions and GET /api/v1/actions/<action_id>
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, SECRET_ENV)
+class TestListActionsEndpoint:
+    """GET /api/v1/actions -- paginated, filterable audit-trail read (W4).
+
+    Issue #75: read access to the pending_actions audit log so an
+    operator (or RubotPaul) can see what's staged, resolved, or expired
+    without querying the database directly.
+    """
+
+    def test_missing_bearer_returns_401(self, client: FlaskClient) -> None:
+        """Unauthenticated requests are rejected."""
+        response = client.get("/api/v1/actions")
+        assert response.status_code == 401
+
+    def test_returns_staged_actions_with_count(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """Staged actions show up in the list with a matching count."""
+        action_id = _stage_via_api(
+            client, auth_headers, "/api/v1/brands/set", _brand_body()
+        )
+        response = client.get("/api/v1/actions", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.get_json()
+        assert "actions" in data
+        assert "count" in data
+        assert data["count"] == len(data["actions"])
+        ids = [a["action_id"] for a in data["actions"]]
+        assert action_id in ids
+
+    def test_sweeps_expired_actions_before_listing(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        pending_store: PendingActionsStore,
+    ) -> None:
+        """A past-due pending row shows up as expired, not pending."""
+        action_id = str(uuid.uuid4())
+        pending_store.insert_pending_action(
+            action_id=action_id,
+            kind="brands_set",
+            payload={},
+            expires_at=dt.datetime.now(dt.UTC) - dt.timedelta(seconds=1),
+        )
+        response = client.get("/api/v1/actions", headers=auth_headers)
+        assert response.status_code == 200
+        matching = [
+            a for a in response.get_json()["actions"] if a["action_id"] == action_id
+        ]
+        assert matching
+        assert matching[0]["status"] == "expired"
+
+    def test_default_limit_is_50(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """Omitting ?limit uses a default of 50."""
+        with patch.object(
+            PendingActionsStore, "list_pending_actions", return_value=[]
+        ) as mock_list:
+            response = client.get("/api/v1/actions", headers=auth_headers)
+        assert response.status_code == 200
+        assert mock_list.call_args.kwargs.get("limit") == 50
+
+    def test_limit_over_max_is_clamped_not_rejected(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """A ?limit above the hard cap is clamped to 200, not a 400."""
+        with patch.object(
+            PendingActionsStore, "list_pending_actions", return_value=[]
+        ) as mock_list:
+            response = client.get("/api/v1/actions?limit=99999", headers=auth_headers)
+        assert response.status_code == 200
+        assert mock_list.call_args.kwargs.get("limit") == 200
+
+    def test_status_filter_returns_only_matching_actions(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """?status= filters the returned actions by that status."""
+        denied_id = _stage_via_api(
+            client, auth_headers, "/api/v1/brands/set", _brand_body()
+        )
+        client.post(
+            "/api/v1/actions/deny",
+            json={"action_id": denied_id},
+            headers=auth_headers,
+        )
+        _stage_via_api(client, auth_headers, "/api/v1/brands/set", _brand_body())
+
+        response = client.get("/api/v1/actions?status=denied", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.get_json()
+        assert all(a["status"] == "denied" for a in data["actions"])
+        assert denied_id in [a["action_id"] for a in data["actions"]]
+
+    def test_unknown_status_value_returns_400(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """An unrecognized ?status value is rejected, not silently ignored."""
+        response = client.get(
+            "/api/v1/actions?status=not_a_real_status", headers=auth_headers
+        )
+        assert response.status_code == 400
+
+
+@patch.dict(os.environ, SECRET_ENV)
+class TestGetActionEndpoint:
+    """GET /api/v1/actions/<action_id> -- single-row audit-trail read (W4)."""
+
+    def test_missing_bearer_returns_401(self, client: FlaskClient) -> None:
+        """Unauthenticated requests are rejected."""
+        response = client.get(f"/api/v1/actions/{uuid.uuid4()}")
+        assert response.status_code == 401
+
+    def test_returns_serialized_action(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """A known action_id returns its full serialized row."""
+        action_id = _stage_via_api(
+            client, auth_headers, "/api/v1/brands/set", _brand_body()
+        )
+        response = client.get(f"/api/v1/actions/{action_id}", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["action_id"] == action_id
+        assert data["kind"] == "brands_set"
+        assert data["status"] == "pending"
+
+    def test_unknown_action_id_returns_404(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """An unknown action_id gets a JSON 404."""
+        response = client.get(f"/api/v1/actions/{uuid.uuid4()}", headers=auth_headers)
+        assert response.status_code == 404
+        assert "error" in response.get_json()
+
+
+# ---------------------------------------------------------------------------
+# W4 (issue #75): staging endpoints also sweep past-due pending rows first
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, SECRET_ENV)
+class TestStagingSweepsExpiredActions:
+    """Staging a new action sweeps expired rows too, not just GET /actions.
+
+    Issue #75 (W4) requires the lazy sweep to run wherever a caller
+    touches the pending_actions table, not only on read: otherwise a
+    past-due row can sit ``pending`` forever if the audit log is never
+    listed. Each of the three staging routes must trigger the sweep as
+    a side effect of inserting its own new row.
+    """
+
+    @pytest.mark.parametrize(
+        ("path", "body"),
+        [
+            ("/api/v1/order/submit", _order_body()),
+            ("/api/v1/brands/set", _brand_body()),
+            ("/api/v1/preferences/set", {"preferences": {"fulfillment": "pickup"}}),
+        ],
+        ids=["order_submit", "brands_set", "preferences_set"],
+    )
+    def test_staging_sweeps_unrelated_past_due_row(
+        self,
+        client: FlaskClient,
+        auth_headers: dict[str, str],
+        pending_store: PendingActionsStore,
+        path: str,
+        body: dict[str, Any],
+    ) -> None:
+        """An unrelated past-due pending row flips to expired on staging."""
+        stale_id = str(uuid.uuid4())
+        pending_store.insert_pending_action(
+            action_id=stale_id,
+            kind="brands_set",
+            payload={},
+            expires_at=dt.datetime.now(dt.UTC) - dt.timedelta(seconds=1),
+        )
+        response = client.post(path, json=body, headers=auth_headers)
+        assert response.status_code == 200
+
+        stale = pending_store.get_pending_action(stale_id)
+        assert stale is not None
+        assert stale.status is PendingActionStatus.EXPIRED
+        assert stale.resolved_at is not None
+        assert stale.resolver is None

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -518,6 +518,33 @@ class TestMigration007ProductMappingStockSize:
         assert migrate(db_path) == 0
 
 
+class TestMigration008PendingActionsResolver:
+    """Tests for migration 008 (pending_actions.resolver column, issue #75).
+
+    W1: confirm/deny routes must record which caller resolved a staged
+    action. This nullable column is the audit trail for that caller
+    (rows resolved by the system, e.g. TTL expiry, leave it NULL).
+    """
+
+    def test_migration_008_adds_resolver_column(self, db_path: str) -> None:
+        """Test migrate() adds a nullable resolver column to pending_actions.
+
+        Running migrate() a second time afterwards must apply zero
+        additional migrations (idempotency).
+        """
+        migrate(db_path)
+
+        conn = get_connection(db_path)
+        try:
+            cursor = conn.execute("PRAGMA table_info(pending_actions)")
+            columns = {row["name"] for row in cursor.fetchall()}
+        finally:
+            conn.close()
+
+        assert "resolver" in columns
+        assert migrate(db_path) == 0
+
+
 class TestCLI:
     """Tests for the CLI entry point."""
 

--- a/tests/test_pending_actions.py
+++ b/tests/test_pending_actions.py
@@ -330,7 +330,15 @@ class TestExpirySemantics:
     def test_deadline_passing_does_not_change_status(
         self, store: PendingActionsStore
     ) -> None:
-        """Test rows stay 'pending' until explicitly marked expired."""
+        """Test rows stay 'pending' until explicitly swept or resolved.
+
+        Issue #75 (W4): a past-due row is *not* auto-resolved just by
+        being read -- only an explicit :meth:`PendingActionsStore.sweep_expired`
+        call (or a direct resolution) transitions it. This extends the
+        original "no implicit sweeper" pin with the new explicit-sweep
+        half of the contract, rather than replacing it, since both
+        halves still hold under the new sweep semantics.
+        """
         past = dt.datetime.now(dt.UTC) - dt.timedelta(minutes=1)
         store.insert_pending_action(
             action_id="e5",
@@ -342,6 +350,366 @@ class TestExpirySemantics:
         assert action is not None
         assert action.status is PendingActionStatus.PENDING
         assert action.is_expired() is True
+
+        # Only an explicit sweep flips the row.
+        assert store.sweep_expired() == 1
+        swept = store.get_pending_action("e5")
+        assert swept is not None
+        assert swept.status is PendingActionStatus.EXPIRED
+
+
+# ---------------------------------------------------------------------------
+# W1 (issue #75): requester/resolver persistence
+# ---------------------------------------------------------------------------
+
+
+class TestRequesterAndResolver:
+    """Tests for requester/resolver persistence (W1, issue #75)."""
+
+    def test_insert_pending_action_resolver_defaults_to_none(
+        self, store: PendingActionsStore
+    ) -> None:
+        """Test a freshly staged action has no resolver yet."""
+        action = store.insert_pending_action(
+            action_id="rr1",
+            kind="brands_set",
+            payload={},
+            expires_at=_in_five_minutes(),
+        )
+        assert action.resolver is None
+
+    def test_mark_approved_records_resolver(self, store: PendingActionsStore) -> None:
+        """Test approving a row stamps the resolving caller."""
+        store.insert_pending_action(
+            action_id="rr2",
+            kind="brands_set",
+            payload={},
+            expires_at=_in_five_minutes(),
+        )
+        assert store.mark_pending_approved("rr2", resolver="alice") is True
+        action = store.get_pending_action("rr2")
+        assert action is not None
+        assert action.resolver == "alice"
+
+    def test_mark_denied_records_resolver(self, store: PendingActionsStore) -> None:
+        """Test denying a row stamps the resolving caller."""
+        store.insert_pending_action(
+            action_id="rr3",
+            kind="brands_set",
+            payload={},
+            expires_at=_in_five_minutes(),
+        )
+        assert store.mark_pending_denied("rr3", resolver="bob") is True
+        action = store.get_pending_action("rr3")
+        assert action is not None
+        assert action.resolver == "bob"
+
+    def test_mark_expired_leaves_resolver_none(
+        self, store: PendingActionsStore
+    ) -> None:
+        """Test expiry is system-initiated, so no resolver is stamped."""
+        store.insert_pending_action(
+            action_id="rr4",
+            kind="brands_set",
+            payload={},
+            expires_at=_in_five_minutes(),
+        )
+        assert store.mark_pending_expired("rr4") is True
+        action = store.get_pending_action("rr4")
+        assert action is not None
+        assert action.resolver is None
+
+
+# ---------------------------------------------------------------------------
+# W3 (issue #75): PendingActionStatus.FAILED and mark_pending_failed
+# ---------------------------------------------------------------------------
+
+
+class TestMarkPendingFailed:
+    """Tests for PendingActionsStore.mark_pending_failed (W3, issue #75)."""
+
+    def _staged(self, store: PendingActionsStore, action_id: str) -> PendingAction:
+        """Stage a fresh pending action for transition tests."""
+        return store.insert_pending_action(
+            action_id=action_id,
+            kind="safeway_order_submit",
+            payload=_payload(),
+            expires_at=_in_five_minutes(),
+        )
+
+    def test_failed_status_member_exists(self) -> None:
+        """Test PendingActionStatus gains a FAILED member."""
+        assert PendingActionStatus.FAILED.value == "failed"
+
+    def test_mark_failed_after_approved_transitions_to_failed(
+        self, store: PendingActionsStore
+    ) -> None:
+        """Test an approved row can be marked failed after a post-claim error."""
+        self._staged(store, "mf1")
+        store.mark_pending_approved("mf1", resolver="bot")
+        assert store.mark_pending_failed("mf1") is True
+        action = store.get_pending_action("mf1")
+        assert action is not None
+        assert action.status is PendingActionStatus.FAILED
+        assert action.resolved_at is not None
+        assert action.resolver == "bot"
+
+    def test_mark_failed_from_pending_returns_false(
+        self, store: PendingActionsStore
+    ) -> None:
+        """Test a never-claimed row cannot be marked failed directly."""
+        self._staged(store, "mf2")
+        assert store.mark_pending_failed("mf2") is False
+        action = store.get_pending_action("mf2")
+        assert action is not None
+        assert action.status is PendingActionStatus.PENDING
+
+    def test_mark_failed_from_denied_returns_false(
+        self, store: PendingActionsStore
+    ) -> None:
+        """Test a denied row cannot be marked failed."""
+        self._staged(store, "mf3")
+        store.mark_pending_denied("mf3", resolver="bot")
+        assert store.mark_pending_failed("mf3") is False
+
+    def test_mark_failed_from_expired_returns_false(
+        self, store: PendingActionsStore
+    ) -> None:
+        """Test an expired row cannot be marked failed."""
+        self._staged(store, "mf4")
+        store.mark_pending_expired("mf4")
+        assert store.mark_pending_failed("mf4") is False
+
+    def test_mark_failed_idempotent_second_call_returns_false(
+        self, store: PendingActionsStore
+    ) -> None:
+        """Test marking failed twice reports failure the second time."""
+        self._staged(store, "mf5")
+        store.mark_pending_approved("mf5", resolver="bot")
+        assert store.mark_pending_failed("mf5") is True
+        assert store.mark_pending_failed("mf5") is False
+
+    def test_mark_failed_unknown_id_returns_false(
+        self, store: PendingActionsStore
+    ) -> None:
+        """Test an unknown action id reports failure, not an error."""
+        assert store.mark_pending_failed("ghost") is False
+
+
+# ---------------------------------------------------------------------------
+# W4 (issue #75): sweep_expired
+# ---------------------------------------------------------------------------
+
+
+class TestSweepExpired:
+    """Tests for PendingActionsStore.sweep_expired (W4, issue #75)."""
+
+    def _stage_past_due(self, store: PendingActionsStore, action_id: str) -> None:
+        """Stage a pending action whose expiry is already in the past."""
+        past = dt.datetime.now(dt.UTC) - dt.timedelta(minutes=1)
+        store.insert_pending_action(
+            action_id=action_id,
+            kind="brands_set",
+            payload={},
+            expires_at=past,
+        )
+
+    def test_sweep_expired_flips_past_due_pending_row(
+        self, store: PendingActionsStore
+    ) -> None:
+        """Test a pending row past its deadline flips to expired on sweep."""
+        self._stage_past_due(store, "sw1")
+        count = store.sweep_expired()
+        assert count == 1
+        action = store.get_pending_action("sw1")
+        assert action is not None
+        assert action.status is PendingActionStatus.EXPIRED
+        assert action.resolved_at is not None
+
+    def test_sweep_expired_resolver_stays_none(
+        self, store: PendingActionsStore
+    ) -> None:
+        """Test sweeping is system-initiated: resolver stays NULL."""
+        self._stage_past_due(store, "sw2")
+        store.sweep_expired()
+        action = store.get_pending_action("sw2")
+        assert action is not None
+        assert action.resolver is None
+
+    def test_sweep_expired_returns_count_of_affected_rows(
+        self, store: PendingActionsStore
+    ) -> None:
+        """Test multiple past-due rows are all counted in one sweep."""
+        for action_id in ("sw3", "sw4", "sw5"):
+            self._stage_past_due(store, action_id)
+        assert store.sweep_expired() == 3
+
+    def test_sweep_expired_is_idempotent(self, store: PendingActionsStore) -> None:
+        """Test a second sweep call finds nothing new to expire."""
+        self._stage_past_due(store, "sw6")
+        assert store.sweep_expired() == 1
+        assert store.sweep_expired() == 0
+
+    def test_sweep_expired_leaves_future_pending_untouched(
+        self, store: PendingActionsStore
+    ) -> None:
+        """Test a pending row not yet due is left alone."""
+        store.insert_pending_action(
+            action_id="sw7",
+            kind="brands_set",
+            payload={},
+            expires_at=_in_five_minutes(),
+        )
+        assert store.sweep_expired() == 0
+        action = store.get_pending_action("sw7")
+        assert action is not None
+        assert action.status is PendingActionStatus.PENDING
+
+    def test_sweep_expired_leaves_approved_untouched(
+        self, store: PendingActionsStore
+    ) -> None:
+        """Test an already-approved row is never re-resolved by the sweep."""
+        self._stage_past_due(store, "sw8")
+        store.mark_pending_approved("sw8", resolver="bot")
+        assert store.sweep_expired() == 0
+        action = store.get_pending_action("sw8")
+        assert action is not None
+        assert action.status is PendingActionStatus.APPROVED
+
+    def test_sweep_expired_leaves_denied_untouched(
+        self, store: PendingActionsStore
+    ) -> None:
+        """Test an already-denied row is never re-resolved by the sweep."""
+        self._stage_past_due(store, "sw9")
+        store.mark_pending_denied("sw9", resolver="bot")
+        assert store.sweep_expired() == 0
+        action = store.get_pending_action("sw9")
+        assert action is not None
+        assert action.status is PendingActionStatus.DENIED
+
+    def test_sweep_expired_accepts_explicit_now(
+        self, store: PendingActionsStore
+    ) -> None:
+        """Test an explicit reference time is honored over wall-clock now."""
+        future_deadline = dt.datetime.now(dt.UTC) + dt.timedelta(minutes=10)
+        store.insert_pending_action(
+            action_id="sw10",
+            kind="brands_set",
+            payload={},
+            expires_at=future_deadline,
+        )
+        way_future = future_deadline + dt.timedelta(minutes=1)
+        assert store.sweep_expired(now=way_future) == 1
+        action = store.get_pending_action("sw10")
+        assert action is not None
+        assert action.status is PendingActionStatus.EXPIRED
+
+
+# ---------------------------------------------------------------------------
+# W4 (issue #75): list_pending_actions
+# ---------------------------------------------------------------------------
+
+
+class TestListPendingActions:
+    """Tests for PendingActionsStore.list_pending_actions (W4, issue #75)."""
+
+    def _set_created_at(self, db_path: str, action_id: str, when: dt.datetime) -> None:
+        """Force a row's created_at for deterministic ordering assertions."""
+        conn = get_connection(db_path)
+        try:
+            conn.execute(
+                "UPDATE pending_actions SET created_at = ? WHERE action_id = ?",
+                (when.isoformat(), action_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def test_list_pending_actions_orders_by_created_at_desc(
+        self, store: PendingActionsStore, db_path: str
+    ) -> None:
+        """Test rows come back newest-created first."""
+        base = dt.datetime.now(dt.UTC)
+        for offset, action_id in enumerate(("la1", "la2", "la3")):
+            store.insert_pending_action(
+                action_id=action_id,
+                kind="brands_set",
+                payload={},
+                expires_at=_in_five_minutes(),
+            )
+            self._set_created_at(
+                db_path, action_id, base + dt.timedelta(minutes=offset)
+            )
+
+        actions = store.list_pending_actions(limit=50, status=None)
+        ids = [a.action_id for a in actions if a.action_id in ("la1", "la2", "la3")]
+        assert ids == ["la3", "la2", "la1"]
+
+    def test_list_pending_actions_respects_limit(
+        self, store: PendingActionsStore
+    ) -> None:
+        """Test only the requested number of rows are returned."""
+        for action_id in ("lb1", "lb2", "lb3"):
+            store.insert_pending_action(
+                action_id=action_id,
+                kind="brands_set",
+                payload={},
+                expires_at=_in_five_minutes(),
+            )
+        actions = store.list_pending_actions(limit=2, status=None)
+        assert len(actions) == 2
+
+    def test_list_pending_actions_filters_by_status(
+        self, store: PendingActionsStore
+    ) -> None:
+        """Test only rows matching the requested status are returned."""
+        store.insert_pending_action(
+            action_id="lc1",
+            kind="brands_set",
+            payload={},
+            expires_at=_in_five_minutes(),
+        )
+        store.insert_pending_action(
+            action_id="lc2",
+            kind="brands_set",
+            payload={},
+            expires_at=_in_five_minutes(),
+        )
+        store.mark_pending_denied("lc2", resolver="bot")
+
+        actions = store.list_pending_actions(
+            limit=50, status=PendingActionStatus.DENIED
+        )
+        ids = [a.action_id for a in actions]
+        assert ids == ["lc2"]
+
+    def test_list_pending_actions_status_none_returns_all_statuses(
+        self, store: PendingActionsStore
+    ) -> None:
+        """Test a None status filter returns rows regardless of status."""
+        store.insert_pending_action(
+            action_id="ld1",
+            kind="brands_set",
+            payload={},
+            expires_at=_in_five_minutes(),
+        )
+        store.insert_pending_action(
+            action_id="ld2",
+            kind="brands_set",
+            payload={},
+            expires_at=_in_five_minutes(),
+        )
+        store.mark_pending_denied("ld2", resolver="bot")
+
+        actions = store.list_pending_actions(limit=50, status=None)
+        ids = {a.action_id for a in actions}
+        assert {"ld1", "ld2"}.issubset(ids)
+
+    def test_list_pending_actions_empty_when_no_rows(
+        self, store: PendingActionsStore
+    ) -> None:
+        """Test an empty table yields an empty list, not an error."""
+        assert store.list_pending_actions(limit=50, status=None) == []
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Audit rows now record who acted: staging persists the real bearer `caller_id` as `requester` (no more hardcoded `rubotpaul`), and confirm/deny stamp a new nullable `resolver` column (migration 008, SQLite + PostgreSQL variants; expiry stays system-initiated with a NULL resolver).
- The money path finally logs and tells the truth: INFO lines for staged/confirmed/failed/denied/expired transitions (action_id, kind, total only — never payloads or tokens), a new terminal `failed` status so a claimed order whose Safeway submission fails is recorded `approved -> failed` instead of a permanent lying `approved` (pre-claim 503/501 still leave the row `pending` for retry), and client-supplied totals are validated as finite Decimals (400 otherwise) to close a log-injection vector found during the security pass.
- Lifecycle hygiene: past-due `pending` rows are lazily swept to `expired` on staging and on the new bearer-gated read endpoints `GET /api/v1/actions` (`?limit=` default 50/cap 200, `?status=` filter) and `GET /api/v1/actions/<action_id>`; staged preference changes apply atomically (one connection, one commit); and the raced double-confirm 409 path now closes the Safeway pipeline (claim moved inside the try/finally) instead of leaking the authenticated httpx session.

Note for reviewers: the exactly-once guarded UPDATE was preserved verbatim (refactored into a shared `_transition` helper with `COALESCE` resolver semantics); the behavior change flipping failed submissions from `approved` to `failed` deliberately rewrites the pinned expectation in `test_api_destructive.py`, per the issue. `_resolve_order_total` (api.py) validates the client total for log hygiene only — total *computation* remains issue #73's territory.

## Test plan
- Gate 1 TDD: 57+ failing tests written first across `tests/test_pending_actions.py` (requester/resolver persistence, `mark_pending_failed` transitions, `sweep_expired` idempotency, `list_pending_actions` ordering/filtering), `tests/test_api_destructive.py` (per-route requester/resolver, caplog transition logging incl. payload-never-logged markers, failed-status rewrites, pipeline close-on-409, preferences atomicity via fault-injecting connection, GET endpoints auth/clamp/filter/sweep, staging-sweep regression, total-injection 400s), and `tests/test_migrate.py` (migration 008 adds `resolver`, idempotent re-run) — then implemented to green.
- `./scripts/check-all.sh` exit 0: lint, format, mypy strict, bandit + pip-audit, complexity (radon A), 1652 passed / 10 skipped (pre-existing Postgres-only skips), coverage 96.20% (threshold 90%).
- Gate 2.5 self-review: security-specialist pass (log hygiene, read-surface authz, leak paths, status-machine abuse) and code-review-orchestrator returned CLEAN after fixing its one blocker (sweep-on-stage) test-first.

Closes #75
