### PR TITLE
fix(security): bind bearer tokens to method/path/body, enforce auth by default

### DIFF
--- a/grocery_butler/api.py
+++ b/grocery_butler/api.py
@@ -58,6 +58,35 @@ api_v1 = Blueprint("api_v1", __name__, url_prefix="/api/v1")
 #: How long a staged destructive action stays confirmable.
 CONFIRMATION_TTL = dt.timedelta(minutes=5)
 
+#: Endpoints on this blueprint exempt from the auth-by-default hook below.
+#: Intentionally empty: every route on ``api_v1`` requires a bearer token.
+#: This is the explicit opt-out seam for a future unauthenticated route
+#: (e.g. a webhook) -- health endpoints are registered at the app level
+#: in ``grocery_butler.app``, not on this blueprint, so they never need
+#: an entry here.
+_AUTH_EXEMPT_ENDPOINTS: frozenset[str] = frozenset()
+
+
+@api_v1.before_request
+def _enforce_bearer_auth() -> None:
+    """Require a valid bearer token for every request on this blueprint.
+
+    Issue #74 AC#2: auth-by-default. Previously each view called
+    ``require_bearer()`` individually, so a route that forgot the call
+    would silently ship unauthenticated. This ``before_request`` hook is
+    now the single enforcement point for the whole blueprint; routes no
+    longer call ``require_bearer()`` themselves.
+
+    Raises:
+        werkzeug.exceptions.HTTPException: Aborts with 401 (via
+            :func:`grocery_butler.auth_middleware.require_bearer`) when
+            the request's bearer token is missing or invalid for this
+            exact request.
+    """
+    if request.endpoint in _AUTH_EXEMPT_ENDPOINTS:
+        return
+    require_bearer()
+
 
 @api_v1.errorhandler(400)
 @api_v1.errorhandler(401)
@@ -145,7 +174,6 @@ def _brand(pref: BrandPreference) -> dict[str, Any]:
 @api_v1.get("/inventory")
 def get_inventory() -> Response:
     """Return all tracked inventory items."""
-    require_bearer()
     items = _pantry_manager().get_inventory()
     return jsonify(items=[_item(i) for i in items])
 
@@ -153,21 +181,18 @@ def get_inventory() -> Response:
 @api_v1.get("/pantry")
 def get_pantry() -> Response:
     """Return all pantry staples."""
-    require_bearer()
     return jsonify(staples=_recipe_store().get_pantry_staples())
 
 
 @api_v1.get("/recipes")
 def list_recipes() -> Response:
     """Return summary rows for all saved recipes."""
-    require_bearer()
     return jsonify(recipes=_recipe_store().list_recipes())
 
 
 @api_v1.get("/recipes/<int:recipe_id>")
 def get_recipe(recipe_id: int) -> Response | tuple[Response, int]:
     """Return one full recipe by id, or a JSON 404 if unknown."""
-    require_bearer()
     meal = _recipe_store().get_recipe_by_id(recipe_id)
     if meal is None:
         return jsonify(error="recipe not found"), 404
@@ -177,7 +202,6 @@ def get_recipe(recipe_id: int) -> Response | tuple[Response, int]:
 @api_v1.get("/brands")
 def list_brands() -> Response:
     """Return all brand preference rules."""
-    require_bearer()
     prefs = _recipe_store().get_brand_preferences()
     return jsonify(brands=[_brand(p) for p in prefs])
 
@@ -185,14 +209,12 @@ def list_brands() -> Response:
 @api_v1.get("/preferences")
 def get_preferences() -> Response:
     """Return all app-level preferences as a flat object."""
-    require_bearer()
     return jsonify(_recipe_store().get_all_preferences())
 
 
 @api_v1.get("/restock")
 def get_restock() -> Response:
     """Return the restock queue (items low or out)."""
-    require_bearer()
     items = _pantry_manager().get_restock_queue()
     return jsonify(items=[_item(i) for i in items])
 
@@ -249,7 +271,6 @@ def _cart_total(cart: CartSummary) -> Decimal:
 @api_v1.post("/meals/parse")
 def post_meals_parse() -> Response:
     """Parse free-text meal names into structured ingredient lists."""
-    require_bearer()
     text = str(_json_body().get("text", "")).strip()
     if not text:
         abort(400, description="text required")
@@ -260,7 +281,6 @@ def post_meals_parse() -> Response:
 @api_v1.post("/shopping-list/preview")
 def post_shopping_list_preview() -> Response:
     """Consolidate meals into a shopping list without persisting anything."""
-    require_bearer()
     body = _json_body()
     meals = _parse_meal_payloads(body.get("meals", []))
     include_restock = bool(body.get("include_restock", True))
@@ -276,7 +296,6 @@ def post_shopping_list_preview() -> Response:
 @api_v1.post("/order/preview")
 def post_order_preview() -> Response | tuple[Response, int]:
     """Build a Safeway cart for review without submitting an order."""
-    require_bearer()
     shopping_list = _parse_shopping_list_payloads(_json_body().get("shopping_list"))
     try:
         pipeline = _safeway_pipeline()
@@ -333,7 +352,6 @@ def _parse_servings(body: dict[str, Any]) -> int:
 @api_v1.post("/stock/update")
 def post_stock_update() -> Response:
     """Set a tracked item's stock status; writes immediately."""
-    require_bearer()
     body = _json_body()
     status = body.get("status")
     if not isinstance(status, str) or status not in _STATUS_TOKENS:
@@ -352,7 +370,6 @@ def post_stock_update() -> Response:
 @api_v1.post("/stock/add")
 def post_stock_add() -> tuple[Response, int]:
     """Start tracking a new inventory item; writes immediately."""
-    require_bearer()
     body = _json_body()
     name = _required_text(body, "item", "item and category required")
     raw_category = _required_text(body, "category", "item and category required")
@@ -376,7 +393,6 @@ def post_stock_add() -> tuple[Response, int]:
 @api_v1.post("/restock/clear")
 def post_restock_clear() -> Response:
     """Move every low/out item back to on_hand; writes immediately."""
-    require_bearer()
     cleared = _pantry_manager().clear_restock_queue()
     return jsonify(ok=True, cleared=cleared)
 
@@ -384,7 +400,6 @@ def post_restock_clear() -> Response:
 @api_v1.post("/recipes/save")
 def post_recipes_save() -> tuple[Response, int]:
     """Save a new recipe; 409 if the name is already taken."""
-    require_bearer()
     body = _json_body()
     name = _required_text(body, "name", "name and ingredients required")
     ingredients = _parse_ingredient_payloads(body.get("ingredients"))
@@ -407,7 +422,6 @@ def post_recipes_save() -> tuple[Response, int]:
 @api_v1.delete("/recipes/<int:recipe_id>")
 def delete_recipe(recipe_id: int) -> tuple[str, int]:
     """Delete a recipe by id; 404 if unknown."""
-    require_bearer()
     store = _recipe_store()
     if store.get_recipe_by_id(recipe_id) is None:
         abort(404, description="recipe not found")
@@ -511,7 +525,6 @@ def _render_fulfillment_section(cart: CartSummary) -> str:
 @api_v1.post("/order/submit")
 def post_order_submit() -> Response:
     """Stage a Safeway order for confirmation. Never submits directly."""
-    require_bearer()
     body = _json_body()
     cart = _parse_cart_payload(body)
     total = str(body.get("total") or _cart_total(cart))
@@ -535,7 +548,6 @@ def post_order_submit() -> Response:
 @api_v1.post("/brands/set")
 def post_brands_set() -> Response:
     """Stage a brand preference rule for confirmation."""
-    require_bearer()
     body = _json_body()
     try:
         pref = BrandPreference.model_validate(body)
@@ -566,7 +578,6 @@ def _parse_preferences_payload(body: dict[str, Any]) -> dict[str, str]:
 @api_v1.post("/preferences/set")
 def post_preferences_set() -> Response:
     """Stage app-level preference changes for confirmation."""
-    require_bearer()
     preferences = _parse_preferences_payload(_json_body())
     action_id = _stage_pending("preferences_set", {"preferences": preferences})
     keys = ", ".join(sorted(preferences))
@@ -723,7 +734,6 @@ _CONFIRM_EXECUTORS: dict[
 @api_v1.post("/actions/confirm")
 def post_actions_confirm() -> Response | tuple[Response, int]:
     """Execute a staged action exactly once after chat confirmation."""
-    require_bearer()
     action = _load_pending_action(_json_body())
     store = _pending_store()
     if action.status is not PendingActionStatus.PENDING:
@@ -745,7 +755,6 @@ def post_actions_deny() -> Response:
     check the TTL — a denied-after-expiry action records the user's
     explicit "no" rather than a timeout.
     """
-    require_bearer()
     action = _load_pending_action(_json_body())
     if not _pending_store().mark_pending_denied(action.action_id):
         abort(409, description="action already resolved")

--- a/grocery_butler/auth_middleware.py
+++ b/grocery_butler/auth_middleware.py
@@ -20,12 +20,41 @@ Usage (aiohttp):
     app = web.Application(middlewares=[aiohttp_auth_middleware])
 
 Token format: "<caller_id>.<timestamp>.<hmac_hex>"
-HMAC = HMAC-SHA256(SHARED_SECRET, f"{caller_id}.{timestamp}").hexdigest()
-TTL: tokens older than MAX_TOKEN_AGE_SECONDS are rejected.
+HMAC = HMAC-SHA256(
+    SHARED_SECRET,
+    "\\x00".join((caller_id, str(timestamp), method.upper(), path, body_sha256)),
+).hexdigest()
+The method/path/body-hash triple is a :class:`RequestBinding`: the
+signature is bound to the exact request it authorizes, so a token minted
+for one endpoint cannot be replayed against another. TTL: tokens older
+than ``MAX_TOKEN_AGE_SECONDS`` are rejected.
+
+Security posture (issue #74)
+-----------------------------
+* **Cross-endpoint replay: CLOSED.** Method, path, and a SHA-256 hash of
+  the body are bound into the HMAC, and tokens are minted per-request.
+  A token stolen from one request cannot authorize a different
+  method/path/body triple.
+* **Same-request replay within the 5-minute TTL: ACCEPTED/DEFERRED.**
+  Binding a request does not stop the *same* token from being replayed
+  against the *same* endpoint again before it expires. This is
+  mitigated in depth by the pending-action state machine: destructive
+  operations stage first and only execute via ``/actions/confirm``,
+  which claims the row exactly once (a second confirm returns 409), and
+  the staged ``action_id`` doubles as the Safeway idempotency key. A
+  replayed confirm therefore cannot double-submit. A nonce cache would
+  close this window fully but is deliberately out of scope for #74.
+* **Distinct confirm credential / second factor: DEFERRED.** A second
+  secret held by the same calling principal (RubotPaul) would add
+  little defense-in-depth. The real second factor in this system is
+  product-level: stage -> human-reviewed chat message -> confirm. A
+  human-held second factor is tracked as follow-up work, not a blocker
+  for #74.
 """
 
 from __future__ import annotations
 
+import dataclasses
 import hashlib
 import hmac
 import logging
@@ -64,8 +93,93 @@ def _shared_secret() -> bytes:
     return secret.encode()
 
 
-def _verify_token(token: str, *, now: float | None = None) -> str:
-    """Return caller_id if token valid, else raise AuthError."""
+@dataclasses.dataclass(frozen=True)
+class RequestBinding:
+    """The (method, path, body) triple a bearer token's signature is bound to.
+
+    Issue #74: binding tokens to the exact request they authorize closes
+    the replay window where a token minted for one endpoint (e.g. a
+    harmless read) could be reused against any other endpoint (e.g. a
+    destructive write) within its TTL.
+
+    Attributes:
+        method: The HTTP method, stored verbatim (uncanonicalized) as
+            given to :meth:`of`.
+        path: The request path, stored verbatim as given to :meth:`of`.
+        body_sha256: Hex SHA-256 digest of the exact request body bytes.
+    """
+
+    method: str
+    path: str
+    body_sha256: str
+
+    @classmethod
+    def of(cls, method: str, path: str, body: bytes) -> RequestBinding:
+        """Build a RequestBinding from a request's method, path, and body.
+
+        Args:
+            method: The HTTP method of the request (case preserved
+                as-given; canonicalization happens later, only inside
+                the signing payload).
+            path: The exact request path.
+            body: The exact raw request body bytes.
+
+        Returns:
+            A RequestBinding with ``body`` hashed via SHA-256.
+        """
+        return cls(
+            method=method, path=path, body_sha256=hashlib.sha256(body).hexdigest()
+        )
+
+
+def _signing_payload(caller_id: str, ts: int, binding: RequestBinding) -> bytes:
+    """Build the exact bytes signed/verified for a request-bound token.
+
+    Fields are joined with a NUL delimiter (rather than the legacy dotted
+    concatenation) so no combination of field values can be ambiguously
+    reinterpreted as a different field split -- the wire token format
+    (``<caller_id>.<ts>.<hmac_hex>``) is unaffected; only the bytes fed
+    into the HMAC change. The method is canonicalized to uppercase here
+    (and only here) so minting against a lowercase method and verifying
+    against the uppercase form Flask/aiohttp always report still match.
+
+    Args:
+        caller_id: The caller identity embedded in the token.
+        ts: The token's Unix timestamp.
+        binding: The request the token is bound to.
+
+    Returns:
+        The UTF-8 encoded payload to sign or verify.
+    """
+    return "\x00".join(
+        (
+            caller_id,
+            str(ts),
+            binding.method.upper(),
+            binding.path,
+            binding.body_sha256,
+        )
+    ).encode()
+
+
+def _verify_token(
+    token: str, binding: RequestBinding, *, now: float | None = None
+) -> str:
+    """Return caller_id if token is valid for the given binding, else raise.
+
+    Args:
+        token: The bearer token string (``<caller_id>.<ts>.<hmac_hex>``).
+        binding: The request the token must be bound to.
+        now: Override for the current time (epoch seconds); defaults to
+            the wall clock.
+
+    Returns:
+        The caller_id embedded in the token.
+
+    Raises:
+        AuthError: If the token is malformed, expired, from the future,
+            or its signature does not match ``binding``.
+    """
     now = now if now is not None else time.time()
     parts = token.split(".")
     if len(parts) != 3:
@@ -86,7 +200,7 @@ def _verify_token(token: str, *, now: float | None = None) -> str:
 
     expected = hmac.new(
         _shared_secret(),
-        f"{caller_id}.{ts}".encode(),
+        _signing_payload(caller_id, ts, binding),
         hashlib.sha256,
     ).hexdigest()
     if not hmac.compare_digest(expected, sig):
@@ -95,12 +209,24 @@ def _verify_token(token: str, *, now: float | None = None) -> str:
     return caller_id
 
 
-def mint_token(caller_id: str, *, now: float | None = None) -> str:
-    """Generate a token. Used by RubotPaul-side client code."""
+def mint_token(
+    caller_id: str, binding: RequestBinding, *, now: float | None = None
+) -> str:
+    """Generate a token bound to one exact request. Used by RubotPaul.
+
+    Args:
+        caller_id: The caller identity to embed in the token.
+        binding: The request (method, path, body) this token authorizes.
+        now: Override for the mint time (epoch seconds); defaults to the
+            wall clock.
+
+    Returns:
+        The token string ``<caller_id>.<ts>.<hmac_hex>``.
+    """
     ts = int(now if now is not None else time.time())
     sig = hmac.new(
         _shared_secret(),
-        f"{caller_id}.{ts}".encode(),
+        _signing_payload(caller_id, ts, binding),
         hashlib.sha256,
     ).hexdigest()
     return f"{caller_id}.{ts}.{sig}"
@@ -110,7 +236,21 @@ def mint_token(caller_id: str, *, now: float | None = None) -> str:
 
 
 def require_bearer() -> str:
-    """Flask: validate Authorization header. Returns caller_id; aborts on failure."""
+    """Flask: validate Authorization header against the live request.
+
+    Builds the :class:`RequestBinding` from the current Flask request's
+    method, path, and raw body bytes (via ``request.get_data()``, which
+    Werkzeug caches so the view can still call ``request.get_json()``
+    afterward).
+
+    Returns:
+        The caller_id embedded in the validated token.
+
+    Raises:
+        werkzeug.exceptions.HTTPException: Aborts with 401 (or the
+            AuthError's status) when the header is missing or the token
+            is invalid for this request.
+    """
     # Local import keeps this file framework-agnostic.
     from flask import abort, request
 
@@ -119,8 +259,9 @@ def require_bearer() -> str:
         LOG.warning("auth_missing path=%s", request.path)
         abort(401, description="missing bearer token")
     token = header[len("Bearer ") :]
+    binding = RequestBinding.of(request.method, request.path, request.get_data())
     try:
-        caller_id = _verify_token(token)
+        caller_id = _verify_token(token, binding)
     except AuthError as exc:
         LOG.warning("auth_failed reason=%s path=%s", exc.reason, request.path)
         abort(exc.status, description=exc.reason)
@@ -134,16 +275,30 @@ def require_bearer() -> str:
 async def aiohttp_auth_middleware(
     app: Any, handler: Callable[[Any], Awaitable[Any]]
 ) -> Callable[[Any], Awaitable[Any]]:
-    """aiohttp middleware factory. Use with web.Application(middlewares=[...])."""
+    """aiohttp middleware factory. Use with web.Application(middlewares=[...]).
+
+    Args:
+        app: The aiohttp application (unused; required by the middleware
+            factory signature).
+        handler: The next handler in the middleware chain.
+
+    Returns:
+        A middleware callable that validates the bearer token against a
+        :class:`RequestBinding` built from the request's method, path,
+        and body before delegating to ``handler``.
+    """
     from aiohttp import web
 
     async def middleware(request: Any) -> Any:
+        """Validate the request's bearer token, then delegate to handler."""
         header = request.headers.get("Authorization", "")
         if not header.startswith("Bearer "):
             return web.json_response({"error": "missing bearer token"}, status=401)
         token = header[len("Bearer ") :]
+        body = await request.read()
+        binding = RequestBinding.of(request.method, request.path, body)
         try:
-            caller_id = _verify_token(token)
+            caller_id = _verify_token(token, binding)
         except AuthError as exc:
             return web.json_response({"error": exc.reason}, status=exc.status)
         request["caller_id"] = caller_id

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,45 @@
+"""Shared pytest fixtures and helpers for the grocery-butler test suite.
+
+Centralizes the single source of truth for minting request-bound bearer
+tokens in tests (issue #74): every test module that needs an
+``Authorization`` header for a specific HTTP request should call
+:func:`bearer_header` rather than hand-rolling ``mint_token`` calls, so
+the whole suite stays in sync with the ``RequestBinding`` contract in
+``grocery_butler.auth_middleware``.
+"""
+
+from __future__ import annotations
+
+from grocery_butler.auth_middleware import RequestBinding, mint_token
+
+
+def bearer_header(
+    caller_id: str, method: str, path: str, body: bytes = b""
+) -> dict[str, str]:
+    """Return an ``Authorization`` header bound to one exact HTTP request.
+
+    Mints a token whose signature is bound to ``method``, ``path``, and a
+    SHA-256 digest of ``body`` via
+    :class:`~grocery_butler.auth_middleware.RequestBinding`, matching what
+    the server-side verifier reconstructs from the live request. A header
+    minted for one request is not valid for a different method, path, or
+    body -- that is the whole point of the request-bound token contract
+    (issue #74).
+
+    Args:
+        caller_id: The caller identity to embed in the token.
+        method: The HTTP method the token will be sent with (e.g.
+            ``"GET"``, ``"POST"``). Case does not matter -- the signing
+            payload canonicalizes it to uppercase.
+        path: The exact request path the token will be sent to (e.g.
+            ``"/api/v1/inventory"``).
+        body: The exact raw request body bytes that will be sent, if
+            any. Defaults to an empty body.
+
+    Returns:
+        A single-entry dict suitable for passing as test-client
+        ``headers``, e.g. ``{"Authorization": "Bearer <token>"}``.
+    """
+    binding = RequestBinding.of(method, path, body)
+    token = mint_token(caller_id, binding)
+    return {"Authorization": f"Bearer {token}"}

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -17,6 +17,7 @@ secrets) and locally.
 
 from __future__ import annotations
 
+import json
 import os
 import time
 from dataclasses import dataclass, field
@@ -27,7 +28,7 @@ import httpx
 import pytest
 
 from grocery_butler.app import create_app
-from grocery_butler.auth_middleware import SECRET_ENV_VAR, mint_token
+from grocery_butler.auth_middleware import SECRET_ENV_VAR, RequestBinding, mint_token
 from grocery_butler.models import Ingredient, IngredientCategory, ParsedMeal
 from grocery_butler.recipe_store import RecipeStore
 from grocery_butler.safeway_client import OKTA_CLIENT_ID
@@ -198,10 +199,16 @@ def signed_headers() -> Callable[..., dict[str, str]]:
 
     Supports building expired, future-dated, and foreign-secret tokens
     for exercising the auth module's rejection paths, in addition to
-    plain valid tokens.
+    plain valid tokens. Issue #74: tokens are now bound to the exact
+    request they authorize (method + path + body hash) via
+    ``RequestBinding``, so the factory accepts ``method``/``path``/
+    ``body`` overrides -- defaulting to a bodyless ``GET
+    /api/v1/inventory``, the request this fixture is most commonly used
+    against across the e2e suite.
 
     Returns:
-        A callable ``(caller_id="rubotpaul", *, now_offset=0.0,
+        A callable ``(caller_id="rubotpaul", *, method="GET",
+        path="/api/v1/inventory", body=b"", now_offset=0.0,
         secret=None) -> {"Authorization": "Bearer <token>"}``. Positive
         ``now_offset`` mints a future-dated token; a very negative one
         mints an expired token. ``secret`` signs with a different
@@ -211,22 +218,71 @@ def signed_headers() -> Callable[..., dict[str, str]]:
     def _make(
         caller_id: str = "rubotpaul",
         *,
+        method: str = "GET",
+        path: str = "/api/v1/inventory",
+        body: bytes = b"",
         now_offset: float = 0.0,
         secret: str | None = None,
     ) -> dict[str, str]:
+        binding = RequestBinding.of(method, path, body)
         now = time.time() + now_offset
         if secret is None:
-            token = mint_token(caller_id, now=now)
+            token = mint_token(caller_id, binding, now=now)
         else:
             real_secret = os.environ[SECRET_ENV_VAR]
             os.environ[SECRET_ENV_VAR] = secret
             try:
-                token = mint_token(caller_id, now=now)
+                token = mint_token(caller_id, binding, now=now)
             finally:
                 os.environ[SECRET_ENV_VAR] = real_secret
         return {"Authorization": f"Bearer {token}"}
 
     return _make
+
+
+@pytest.fixture()
+def signed_request(
+    client: FlaskClient, signed_headers: Callable[..., dict[str, str]]
+) -> Callable[..., Any]:
+    """Return a helper that mints a bound token and sends one request atomically.
+
+    Issue #74 bound every bearer token to the exact ``(method, path,
+    body)`` triple it authorizes, so a header dict minted once can no
+    longer be reused across requests to different endpoints or with
+    different bodies. This fixture closes that gap for callers that
+    need to hit several endpoints in one test: it serializes
+    ``json_body`` to bytes exactly once and mints the token off those
+    same bytes, then sends those same bytes -- never re-serializing
+    (which could byte-differ, e.g. on key order) between minting and
+    sending.
+
+    Args:
+        client: The Flask test client.
+        signed_headers: The token-minting header factory fixture.
+
+    Returns:
+        A callable ``(method, path, json_body=None, **header_kwargs) ->
+        werkzeug.test.TestResponse``. ``json_body`` is any
+        JSON-serializable value; omit it (or pass ``None``) to send a
+        bodyless request. Extra ``header_kwargs`` (``caller_id``,
+        ``now_offset``, ``secret``) are forwarded to ``signed_headers``.
+    """
+
+    def _send(
+        method: str,
+        path: str,
+        json_body: Any = None,
+        **header_kwargs: Any,
+    ) -> Any:
+        """Mint a token bound to this exact request, then send it."""
+        body = b"" if json_body is None else json.dumps(json_body).encode()
+        headers = signed_headers(method=method, path=path, body=body, **header_kwargs)
+        call = getattr(client, method.lower())
+        if json_body is None:
+            return call(path, headers=headers)
+        return call(path, data=body, content_type="application/json", headers=headers)
+
+    return _send
 
 
 # ---------------------------------------------------------------------------

--- a/tests/e2e/test_api_chain.py
+++ b/tests/e2e/test_api_chain.py
@@ -11,7 +11,7 @@ separately in ``test_ordering.py``.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -21,80 +21,63 @@ from grocery_butler.pending_actions import PendingActionsStore
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from flask.testing import FlaskClient
-
     from tests.e2e.conftest import SafewayMockState
 
 pytestmark = pytest.mark.e2e
 
 
 def _stage_order(
-    client: FlaskClient,
-    headers: dict[str, str],
+    signed_request: Callable[..., Any],
     meal_name: str,
 ) -> str:
     """Run meals/parse -> shopping-list/preview -> order/preview -> submit.
 
     Args:
-        client: The Flask test client.
-        headers: Bearer auth headers.
+        signed_request: The bound-token request-sending fixture.
         meal_name: Name of a recipe already resolvable via the recipe store.
 
     Returns:
         The ``action_id`` of the staged ``safeway_order_submit`` action.
     """
-    parsed = client.post(
-        "/api/v1/meals/parse",
-        json={"text": meal_name},
-        headers=headers,
-    )
+    parsed = signed_request("POST", "/api/v1/meals/parse", {"text": meal_name})
     meals = parsed.get_json()["meals"]
-    preview = client.post(
+    preview = signed_request(
+        "POST",
         "/api/v1/shopping-list/preview",
-        json={"meals": meals, "include_restock": False},
-        headers=headers,
+        {"meals": meals, "include_restock": False},
     )
     shopping_list = preview.get_json()["items"]
-    order_preview = client.post(
-        "/api/v1/order/preview",
-        json={"shopping_list": shopping_list},
-        headers=headers,
+    order_preview = signed_request(
+        "POST", "/api/v1/order/preview", {"shopping_list": shopping_list}
     )
     order_body = order_preview.get_json()
-    submitted = client.post(
+    submitted = signed_request(
+        "POST",
         "/api/v1/order/submit",
-        json={"cart": order_body["cart"], "total": order_body["total"]},
-        headers=headers,
+        {"cart": order_body["cart"], "total": order_body["total"]},
     )
     action_id: str = submitted.get_json()["action_id"]
     return action_id
 
 
 def test_full_chain_meal_to_confirmed_order(
-    client: FlaskClient,
-    signed_headers: Callable[..., dict[str, str]],
+    signed_request: Callable[..., Any],
     seed_recipe: ParsedMeal,
     no_claude: None,
     safeway_mock: SafewayMockState,
     db_path: str,
 ) -> None:
     """meals/parse -> shopping-list/preview -> order/preview -> submit -> confirm."""
-    headers = signed_headers()
-
-    parsed = client.post(
-        "/api/v1/meals/parse",
-        json={"text": seed_recipe.name},
-        headers=headers,
-    )
+    parsed = signed_request("POST", "/api/v1/meals/parse", {"text": seed_recipe.name})
     assert parsed.status_code == 200
     meals = parsed.get_json()["meals"]
     assert len(meals) == 1
     assert meals[0]["known_recipe"] is True
 
-    preview = client.post(
+    preview = signed_request(
+        "POST",
         "/api/v1/shopping-list/preview",
-        json={"meals": meals, "include_restock": False},
-        headers=headers,
+        {"meals": meals, "include_restock": False},
     )
     assert preview.status_code == 200
     shopping_list = preview.get_json()["items"]
@@ -104,10 +87,8 @@ def test_full_chain_meal_to_confirmed_order(
         "tomato sauce",
     }
 
-    order_preview = client.post(
-        "/api/v1/order/preview",
-        json={"shopping_list": shopping_list},
-        headers=headers,
+    order_preview = signed_request(
+        "POST", "/api/v1/order/preview", {"shopping_list": shopping_list}
     )
     assert order_preview.status_code == 200
     order_body = order_preview.get_json()
@@ -116,10 +97,10 @@ def test_full_chain_meal_to_confirmed_order(
     assert cart["substituted_items"] == []
     assert len(cart["items"]) == 3
 
-    submitted = client.post(
+    submitted = signed_request(
+        "POST",
         "/api/v1/order/submit",
-        json={"cart": cart, "total": order_body["total"]},
-        headers=headers,
+        {"cart": cart, "total": order_body["total"]},
     )
     assert submitted.status_code == 200
     submit_body = submitted.get_json()
@@ -136,10 +117,8 @@ def test_full_chain_meal_to_confirmed_order(
     assert "tomato sauce" in staged_message
     assert "incomparable_units" in staged_message
 
-    confirmed = client.post(
-        "/api/v1/actions/confirm",
-        json={"action_id": action_id},
-        headers=headers,
+    confirmed = signed_request(
+        "POST", "/api/v1/actions/confirm", {"action_id": action_id}
     )
     assert confirmed.status_code == 200
     confirm_body = confirmed.get_json()
@@ -154,8 +133,7 @@ def test_full_chain_meal_to_confirmed_order(
 
 
 def test_disabled_submission_returns_501_default_off(
-    client: FlaskClient,
-    signed_headers: Callable[..., dict[str, str]],
+    signed_request: Callable[..., Any],
     seed_recipe: ParsedMeal,
     no_claude: None,
     safeway_mock: SafewayMockState,
@@ -174,13 +152,10 @@ def test_disabled_submission_returns_501_default_off(
     from grocery_butler.order_service import ORDER_SUBMISSION_DISABLED_MESSAGE
 
     monkeypatch.delenv("SAFEWAY_ORDER_SUBMISSION_ENABLED", raising=False)
-    headers = signed_headers()
-    action_id = _stage_order(client, headers, seed_recipe.name)
+    action_id = _stage_order(signed_request, seed_recipe.name)
 
-    confirmed = client.post(
-        "/api/v1/actions/confirm",
-        json={"action_id": action_id},
-        headers=headers,
+    confirmed = signed_request(
+        "POST", "/api/v1/actions/confirm", {"action_id": action_id}
     )
 
     assert confirmed.status_code == 501
@@ -195,26 +170,16 @@ def test_disabled_submission_returns_501_default_off(
 
 
 def test_confirming_same_action_twice_returns_409(
-    client: FlaskClient,
-    signed_headers: Callable[..., dict[str, str]],
+    signed_request: Callable[..., Any],
     seed_recipe: ParsedMeal,
     no_claude: None,
     safeway_mock: SafewayMockState,
 ) -> None:
     """A second confirm call for an already-resolved action is rejected."""
-    headers = signed_headers()
-    action_id = _stage_order(client, headers, seed_recipe.name)
+    action_id = _stage_order(signed_request, seed_recipe.name)
 
-    first = client.post(
-        "/api/v1/actions/confirm",
-        json={"action_id": action_id},
-        headers=headers,
-    )
+    first = signed_request("POST", "/api/v1/actions/confirm", {"action_id": action_id})
     assert first.status_code == 200
 
-    second = client.post(
-        "/api/v1/actions/confirm",
-        json={"action_id": action_id},
-        headers=headers,
-    )
+    second = signed_request("POST", "/api/v1/actions/confirm", {"action_id": action_id})
     assert second.status_code == 409

--- a/tests/e2e/test_brands.py
+++ b/tests/e2e/test_brands.py
@@ -9,14 +9,12 @@ the preference's real database id instead of ``loop.index``).
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-
-    from flask.testing import FlaskClient
 
 pytestmark = pytest.mark.e2e
 
@@ -37,49 +35,39 @@ def _brand_body() -> dict[str, str]:
 
 
 def test_brands_set_then_confirm_is_applied(
-    client: FlaskClient,
-    signed_headers: Callable[..., dict[str, str]],
+    signed_request: Callable[..., Any],
     no_claude: None,
 ) -> None:
     """Confirming a staged brand rule persists it to the real RecipeStore."""
-    headers = signed_headers()
-    staged = client.post("/api/v1/brands/set", json=_brand_body(), headers=headers)
+    staged = signed_request("POST", "/api/v1/brands/set", _brand_body())
     assert staged.status_code == 200
     body = staged.get_json()
     assert body["status"] == "pending_confirmation"
     action_id = body["action_id"]
 
-    confirmed = client.post(
-        "/api/v1/actions/confirm",
-        json={"action_id": action_id},
-        headers=headers,
+    confirmed = signed_request(
+        "POST", "/api/v1/actions/confirm", {"action_id": action_id}
     )
     assert confirmed.status_code == 200
     assert confirmed.get_json()["status"] == "approved"
 
-    listed = client.get("/api/v1/brands", headers=headers)
+    listed = signed_request("GET", "/api/v1/brands")
     brands = [b["brand"] for b in listed.get_json()["brands"]]
     assert "Organic Valley" in brands
 
 
 def test_brands_set_then_deny_is_not_applied(
-    client: FlaskClient,
-    signed_headers: Callable[..., dict[str, str]],
+    signed_request: Callable[..., Any],
     no_claude: None,
 ) -> None:
     """Denying a staged brand rule leaves the RecipeStore untouched."""
-    headers = signed_headers()
-    staged = client.post("/api/v1/brands/set", json=_brand_body(), headers=headers)
+    staged = signed_request("POST", "/api/v1/brands/set", _brand_body())
     action_id = staged.get_json()["action_id"]
 
-    denied = client.post(
-        "/api/v1/actions/deny",
-        json={"action_id": action_id},
-        headers=headers,
-    )
+    denied = signed_request("POST", "/api/v1/actions/deny", {"action_id": action_id})
     assert denied.status_code == 200
     assert denied.get_json()["status"] == "denied"
 
-    listed = client.get("/api/v1/brands", headers=headers)
+    listed = signed_request("GET", "/api/v1/brands")
     brands = [b["brand"] for b in listed.get_json()["brands"]]
     assert "Organic Valley" not in brands

--- a/tests/e2e/test_inventory.py
+++ b/tests/e2e/test_inventory.py
@@ -6,78 +6,62 @@ real temporary SQLite database.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from flask.testing import FlaskClient
-
 pytestmark = pytest.mark.e2e
 
 
 def test_stock_add_then_inventory_then_duplicate_conflicts(
-    client: FlaskClient,
-    signed_headers: Callable[..., dict[str, str]],
+    signed_request: Callable[..., Any],
 ) -> None:
     """Adding a new item succeeds once; a duplicate add returns 409."""
-    headers = signed_headers()
     body = {"item": "oat milk", "category": "dairy"}
 
-    created = client.post("/api/v1/stock/add", json=body, headers=headers)
+    created = signed_request("POST", "/api/v1/stock/add", body)
     assert created.status_code == 201
     assert created.get_json()["ingredient"] == "oat milk"
 
-    listed = client.get("/api/v1/inventory", headers=headers)
+    listed = signed_request("GET", "/api/v1/inventory")
     assert listed.status_code == 200
     ingredients = [item["ingredient"] for item in listed.get_json()["items"]]
     assert "oat milk" in ingredients
 
-    duplicate = client.post("/api/v1/stock/add", json=body, headers=headers)
+    duplicate = signed_request("POST", "/api/v1/stock/add", body)
     assert duplicate.status_code == 409
 
 
 def test_restock_queue_lifecycle_and_untracked_update_404(
-    client: FlaskClient,
-    signed_headers: Callable[..., dict[str, str]],
+    signed_request: Callable[..., Any],
 ) -> None:
     """Restock queue reflects low/out status and clears; unknown items 404."""
-    headers = signed_headers()
-    client.post(
-        "/api/v1/stock/add",
-        json={"item": "eggs", "category": "dairy"},
-        headers=headers,
-    )
+    signed_request("POST", "/api/v1/stock/add", {"item": "eggs", "category": "dairy"})
 
-    low = client.post(
-        "/api/v1/stock/update",
-        json={"item": "eggs", "status": "low"},
-        headers=headers,
+    low = signed_request(
+        "POST", "/api/v1/stock/update", {"item": "eggs", "status": "low"}
     )
     assert low.status_code == 200
-    restock_low = client.get("/api/v1/restock", headers=headers)
+    restock_low = signed_request("GET", "/api/v1/restock")
     assert "eggs" in [i["ingredient"] for i in restock_low.get_json()["items"]]
 
-    out = client.post(
-        "/api/v1/stock/update",
-        json={"item": "eggs", "status": "out"},
-        headers=headers,
+    out = signed_request(
+        "POST", "/api/v1/stock/update", {"item": "eggs", "status": "out"}
     )
     assert out.status_code == 200
-    restock_out = client.get("/api/v1/restock", headers=headers)
+    restock_out = signed_request("GET", "/api/v1/restock")
     assert "eggs" in [i["ingredient"] for i in restock_out.get_json()["items"]]
 
-    cleared = client.post("/api/v1/restock/clear", headers=headers)
+    cleared = signed_request("POST", "/api/v1/restock/clear")
     assert cleared.status_code == 200
     assert cleared.get_json()["cleared"] >= 1
-    restock_after = client.get("/api/v1/restock", headers=headers)
+    restock_after = signed_request("GET", "/api/v1/restock")
     assert restock_after.get_json()["items"] == []
 
-    missing = client.post(
-        "/api/v1/stock/update",
-        json={"item": "unobtainium", "status": "low"},
-        headers=headers,
+    missing = signed_request(
+        "POST", "/api/v1/stock/update", {"item": "unobtainium", "status": "low"}
     )
     assert missing.status_code == 404

--- a/tests/e2e/test_ordering.py
+++ b/tests/e2e/test_ordering.py
@@ -7,7 +7,7 @@ real; only the httpx transport inside ``SafewayClient`` is mocked.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -15,8 +15,6 @@ from grocery_butler.safeway_client import OKTA_CLIENT_ID
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-
-    from flask.testing import FlaskClient
 
     from tests.e2e.conftest import SafewayMockState
 
@@ -49,17 +47,13 @@ def _shopping_list_body(ingredients: list[str]) -> dict[str, object]:
 
 
 def test_order_preview_happy_path_traverses_full_pipeline(
-    client: FlaskClient,
-    signed_headers: Callable[..., dict[str, str]],
+    signed_request: Callable[..., Any],
     no_claude: None,
     safeway_mock: SafewayMockState,
 ) -> None:
     """A clean shopping list builds a cart and hits every pipeline stage."""
-    headers = signed_headers()
-    response = client.post(
-        "/api/v1/order/preview",
-        json=_shopping_list_body(["milk", "bread"]),
-        headers=headers,
+    response = signed_request(
+        "POST", "/api/v1/order/preview", _shopping_list_body(["milk", "bread"])
     )
     assert response.status_code == 200
     body = response.get_json()
@@ -77,8 +71,7 @@ def test_order_preview_happy_path_traverses_full_pipeline(
 
 
 def test_order_preview_substitution_reflected_in_response(
-    client: FlaskClient,
-    signed_headers: Callable[..., dict[str, str]],
+    signed_request: Callable[..., Any],
     no_claude: None,
     safeway_mock: SafewayMockState,
 ) -> None:
@@ -94,7 +87,6 @@ def test_order_preview_substitution_reflected_in_response(
     substitution), while ``substituted_items`` continues to carry the
     same provenance record as before.
     """
-    headers = signed_headers()
     safeway_mock.oos_once.add("bell pepper")
     safeway_mock.available_products["bell pepper"] = [
         {
@@ -106,10 +98,8 @@ def test_order_preview_substitution_reflected_in_response(
         },
     ]
 
-    response = client.post(
-        "/api/v1/order/preview",
-        json=_shopping_list_body(["bell pepper"]),
-        headers=headers,
+    response = signed_request(
+        "POST", "/api/v1/order/preview", _shopping_list_body(["bell pepper"])
     )
     assert response.status_code == 200
     cart = response.get_json()["cart"]
@@ -132,19 +122,15 @@ def test_order_preview_substitution_reflected_in_response(
 
 
 def test_order_preview_empty_search_yields_failed_item(
-    client: FlaskClient,
-    signed_headers: Callable[..., dict[str, str]],
+    signed_request: Callable[..., Any],
     no_claude: None,
     safeway_mock: SafewayMockState,
 ) -> None:
     """An ingredient with no search results ends up in failed_items."""
-    headers = signed_headers()
     safeway_mock.force_search_empty = True
 
-    response = client.post(
-        "/api/v1/order/preview",
-        json=_shopping_list_body(["unobtainium"]),
-        headers=headers,
+    response = signed_request(
+        "POST", "/api/v1/order/preview", _shopping_list_body(["unobtainium"])
     )
     assert response.status_code == 200
     cart = response.get_json()["cart"]
@@ -153,44 +139,36 @@ def test_order_preview_empty_search_yields_failed_item(
 
 
 def test_order_preview_auth_failure_returns_503(
-    client: FlaskClient,
-    signed_headers: Callable[..., dict[str, str]],
+    signed_request: Callable[..., Any],
     no_claude: None,
     safeway_mock: SafewayMockState,
 ) -> None:
     """A failing Okta authn step surfaces as a 503, not a 500."""
-    headers = signed_headers()
     safeway_mock.force_auth_fail = True
 
-    response = client.post(
-        "/api/v1/order/preview",
-        json=_shopping_list_body(["milk"]),
-        headers=headers,
+    response = signed_request(
+        "POST", "/api/v1/order/preview", _shopping_list_body(["milk"])
     )
     assert response.status_code == 503
     assert "safeway" in response.get_json()["error"].lower()
 
 
 def test_order_submit_confirm_hits_orders_endpoint_with_confirmation(
-    client: FlaskClient,
-    signed_headers: Callable[..., dict[str, str]],
+    signed_request: Callable[..., Any],
     no_claude: None,
     safeway_mock: SafewayMockState,
 ) -> None:
     """Confirming a staged, non-substituted cart really submits the order."""
-    headers = signed_headers()
-    preview = client.post(
-        "/api/v1/order/preview",
-        json=_shopping_list_body(["milk", "eggs"]),
-        headers=headers,
+    preview = signed_request(
+        "POST", "/api/v1/order/preview", _shopping_list_body(["milk", "eggs"])
     )
     body = preview.get_json()
     assert body["cart"]["substituted_items"] == []
 
-    submitted = client.post(
+    submitted = signed_request(
+        "POST",
         "/api/v1/order/submit",
-        json={"cart": body["cart"], "total": body["total"]},
-        headers=headers,
+        {"cart": body["cart"], "total": body["total"]},
     )
     submit_body = submitted.get_json()
     action_id = submit_body["action_id"]
@@ -206,10 +184,8 @@ def test_order_submit_confirm_hits_orders_endpoint_with_confirmation(
     assert "eggs" in staged_message
     assert "incomparable_units" in staged_message
 
-    confirmed = client.post(
-        "/api/v1/actions/confirm",
-        json={"action_id": action_id},
-        headers=headers,
+    confirmed = signed_request(
+        "POST", "/api/v1/actions/confirm", {"action_id": action_id}
     )
     assert confirmed.status_code == 200
     result = confirmed.get_json()["result"]

--- a/tests/e2e/test_pantry.py
+++ b/tests/e2e/test_pantry.py
@@ -7,7 +7,7 @@ a bearer token; the read-back goes through the real bearer-protected
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -19,55 +19,51 @@ if TYPE_CHECKING:
 pytestmark = pytest.mark.e2e
 
 
-def _staple_names(client: FlaskClient, headers: dict[str, str]) -> list[str]:
+def _staple_names(signed_request: Callable[..., Any]) -> list[str]:
     """Return the ingredient names of all tracked pantry staples.
 
     Args:
-        client: The Flask test client.
-        headers: Bearer auth headers for the API request.
+        signed_request: The bound-token request-sending fixture.
 
     Returns:
         List of ingredient name strings currently tracked as staples.
     """
-    response = client.get("/api/v1/pantry", headers=headers)
+    response = signed_request("GET", "/api/v1/pantry")
     return [s["ingredient"] for s in response.get_json()["staples"]]
 
 
 def test_pantry_add_form_reflected_in_api_and_duplicate_is_safe(
     client: FlaskClient,
-    signed_headers: Callable[..., dict[str, str]],
+    signed_request: Callable[..., Any],
 ) -> None:
     """Adding a staple via the web form shows up through the API; dup is safe."""
-    headers = signed_headers()
-
     added = client.post(
         "/pantry/add",
         data={"ingredient": "cumin", "category": "pantry_dry"},
     )
     assert added.status_code in (302, 303)
-    assert "cumin" in _staple_names(client, headers)
+    assert "cumin" in _staple_names(signed_request)
 
     duplicate = client.post(
         "/pantry/add",
         data={"ingredient": "cumin", "category": "pantry_dry"},
     )
     assert duplicate.status_code in (302, 303)
-    assert _staple_names(client, headers).count("cumin") == 1
+    assert _staple_names(signed_request).count("cumin") == 1
 
 
 def test_pantry_remove_form_no_longer_listed(
     client: FlaskClient,
-    signed_headers: Callable[..., dict[str, str]],
+    signed_request: Callable[..., Any],
 ) -> None:
     """Removing a staple via its web form drops it from the API listing."""
-    headers = signed_headers()
     client.post("/pantry/add", data={"ingredient": "cumin", "category": "pantry_dry"})
 
-    response = client.get("/api/v1/pantry", headers=headers)
+    response = signed_request("GET", "/api/v1/pantry")
     staple = next(
         s for s in response.get_json()["staples"] if s["ingredient"] == "cumin"
     )
 
     removed = client.post(f"/pantry/{staple['id']}/remove")
     assert removed.status_code in (302, 303)
-    assert "cumin" not in _staple_names(client, headers)
+    assert "cumin" not in _staple_names(signed_request)

--- a/tests/e2e/test_recipes.py
+++ b/tests/e2e/test_recipes.py
@@ -9,14 +9,12 @@ attempted.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-
-    from flask.testing import FlaskClient
 
 pytestmark = pytest.mark.e2e
 
@@ -53,44 +51,36 @@ def _save_body(name: str = "e2e taco night") -> dict[str, object]:
 
 
 def test_save_list_detail_then_duplicate_conflicts(
-    client: FlaskClient,
-    signed_headers: Callable[..., dict[str, str]],
+    signed_request: Callable[..., Any],
     no_claude: None,
 ) -> None:
     """Saving a recipe makes it listable and fetchable; duplicates 409."""
-    headers = signed_headers()
     body = _save_body()
 
-    created = client.post("/api/v1/recipes/save", json=body, headers=headers)
+    created = signed_request("POST", "/api/v1/recipes/save", body)
     assert created.status_code == 201
     recipe_id = created.get_json()["id"]
 
-    listed = client.get("/api/v1/recipes", headers=headers)
+    listed = signed_request("GET", "/api/v1/recipes")
     names = [r["display_name"] for r in listed.get_json()["recipes"]]
     assert "e2e taco night" in names
 
-    detail = client.get(f"/api/v1/recipes/{recipe_id}", headers=headers)
+    detail = signed_request("GET", f"/api/v1/recipes/{recipe_id}")
     assert detail.status_code == 200
     assert detail.get_json()["name"] == "e2e taco night"
 
-    duplicate = client.post("/api/v1/recipes/save", json=body, headers=headers)
+    duplicate = signed_request("POST", "/api/v1/recipes/save", body)
     assert duplicate.status_code == 409
 
 
 def test_meals_parse_reuses_saved_recipe_without_claude(
-    client: FlaskClient,
-    signed_headers: Callable[..., dict[str, str]],
+    signed_request: Callable[..., Any],
     no_claude: None,
 ) -> None:
     """Parsing a saved recipe's name returns its stored ingredients."""
-    headers = signed_headers()
-    client.post("/api/v1/recipes/save", json=_save_body(), headers=headers)
+    signed_request("POST", "/api/v1/recipes/save", _save_body())
 
-    response = client.post(
-        "/api/v1/meals/parse",
-        json={"text": "e2e taco night"},
-        headers=headers,
-    )
+    response = signed_request("POST", "/api/v1/meals/parse", {"text": "e2e taco night"})
     assert response.status_code == 200
     meals = response.get_json()["meals"]
     assert len(meals) == 1
@@ -101,21 +91,15 @@ def test_meals_parse_reuses_saved_recipe_without_claude(
 
 
 def test_delete_recipe_then_detail_404(
-    client: FlaskClient,
-    signed_headers: Callable[..., dict[str, str]],
+    signed_request: Callable[..., Any],
     no_claude: None,
 ) -> None:
     """Deleting a recipe removes it; its detail page then 404s."""
-    headers = signed_headers()
-    created = client.post(
-        "/api/v1/recipes/save",
-        json=_save_body("e2e one-off"),
-        headers=headers,
-    )
+    created = signed_request("POST", "/api/v1/recipes/save", _save_body("e2e one-off"))
     recipe_id = created.get_json()["id"]
 
-    deleted = client.delete(f"/api/v1/recipes/{recipe_id}", headers=headers)
+    deleted = signed_request("DELETE", f"/api/v1/recipes/{recipe_id}")
     assert deleted.status_code == 204
 
-    detail = client.get(f"/api/v1/recipes/{recipe_id}", headers=headers)
+    detail = signed_request("GET", f"/api/v1/recipes/{recipe_id}")
     assert detail.status_code == 404

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,11 @@
-"""Tests for the /api/v1 read endpoints (grocery_butler.api blueprint)."""
+"""Tests for the /api/v1 read endpoints (grocery_butler.api blueprint).
+
+Issue #74: every bearer token minted in this module is now bound to the
+exact (method, path, body) of the request it authorizes, via the shared
+``tests.conftest.bearer_header`` helper. A single static header cannot
+cover the many different GET requests exercised here, so ``auth_headers``
+is a per-request minting factory rather than a static header dict.
+"""
 
 from __future__ import annotations
 
@@ -9,13 +16,16 @@ from unittest.mock import patch
 import pytest
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
     from flask import Flask
     from flask.testing import FlaskClient
 
+    AuthHeaderFactory = Callable[[str, str, bytes], dict[str, str]]
+
 from grocery_butler.app import create_app
-from grocery_butler.auth_middleware import SECRET_ENV_VAR, mint_token
+from grocery_butler.auth_middleware import SECRET_ENV_VAR
 from grocery_butler.models import (
     BrandMatchType,
     BrandPreference,
@@ -28,6 +38,7 @@ from grocery_butler.models import (
 )
 from grocery_butler.pantry_manager import PantryManager
 from grocery_butler.recipe_store import RecipeStore
+from tests.conftest import bearer_header
 
 TEST_SECRET = "test-shared-secret"
 SECRET_ENV = {SECRET_ENV_VAR: TEST_SECRET}
@@ -80,11 +91,26 @@ def recipe_store(db_path: str) -> RecipeStore:
 
 
 @pytest.fixture()
-def auth_headers() -> dict[str, str]:
-    """Return a valid Authorization header minted with the test secret."""
-    with patch.dict(os.environ, SECRET_ENV):
-        token = mint_token("rubotpaul")
-    return {"Authorization": f"Bearer {token}"}
+def auth_headers() -> AuthHeaderFactory:
+    """Return a factory that mints a bearer header for one exact request.
+
+    A single static header cannot authorize every GET request exercised
+    in this module -- each read endpoint has its own path, and the
+    request-bound token contract (issue #74) signs method, path, and
+    body together. Callers invoke the returned factory once per
+    request, e.g. ``auth_headers("GET", "/api/v1/inventory")``.
+
+    Returns:
+        A callable ``(method, path, body=b"") -> {"Authorization": ...}``
+        that mints tokens under the test shared secret.
+    """
+
+    def _make(method: str, path: str, body: bytes = b"") -> dict[str, str]:
+        """Mint a bearer header bound to the given method/path/body."""
+        with patch.dict(os.environ, SECRET_ENV):
+            return bearer_header("rubotpaul", method, path, body)
+
+    return _make
 
 
 @pytest.fixture()
@@ -159,23 +185,27 @@ class TestInventoryEndpoint:
     """GET /api/v1/inventory."""
 
     def test_empty_inventory(
-        self, client: FlaskClient, auth_headers: dict[str, str]
+        self, client: FlaskClient, auth_headers: AuthHeaderFactory
     ) -> None:
         """An empty database yields an empty items list."""
-        response = client.get("/api/v1/inventory", headers=auth_headers)
+        response = client.get(
+            "/api/v1/inventory", headers=auth_headers("GET", "/api/v1/inventory")
+        )
         assert response.status_code == 200
         assert response.get_json() == {"items": []}
 
     def test_returns_seeded_items(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
         pantry_mgr: PantryManager,
         sample_item: InventoryItem,
     ) -> None:
         """Seeded inventory items come back with full field shape."""
         pantry_mgr.add_item(sample_item)
-        response = client.get("/api/v1/inventory", headers=auth_headers)
+        response = client.get(
+            "/api/v1/inventory", headers=auth_headers("GET", "/api/v1/inventory")
+        )
         assert response.status_code == 200
         items = response.get_json()["items"]
         assert len(items) == 1
@@ -192,12 +222,14 @@ class TestPantryEndpoint:
     def test_returns_staples(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
         recipe_store: RecipeStore,
     ) -> None:
         """Seeded pantry staples come back with id/ingredient/category."""
         recipe_store.add_pantry_staple("dragonfruit powder", "pantry_dry")
-        response = client.get("/api/v1/pantry", headers=auth_headers)
+        response = client.get(
+            "/api/v1/pantry", headers=auth_headers("GET", "/api/v1/pantry")
+        )
         assert response.status_code == 200
         staples = response.get_json()["staples"]
         added = [s for s in staples if s["ingredient"] == "dragonfruit powder"]
@@ -214,13 +246,15 @@ class TestRecipeEndpoints:
     def test_list_recipes(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
         recipe_store: RecipeStore,
         sample_meal: ParsedMeal,
     ) -> None:
         """Recipe list returns summary rows with ids."""
         recipe_id = recipe_store.save_recipe(sample_meal)
-        response = client.get("/api/v1/recipes", headers=auth_headers)
+        response = client.get(
+            "/api/v1/recipes", headers=auth_headers("GET", "/api/v1/recipes")
+        )
         assert response.status_code == 200
         recipes = response.get_json()["recipes"]
         assert len(recipes) == 1
@@ -230,13 +264,14 @@ class TestRecipeEndpoints:
     def test_get_recipe_full(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
         recipe_store: RecipeStore,
         sample_meal: ParsedMeal,
     ) -> None:
         """Recipe detail returns the full parsed meal with ingredients."""
         recipe_id = recipe_store.save_recipe(sample_meal)
-        response = client.get(f"/api/v1/recipes/{recipe_id}", headers=auth_headers)
+        recipe_path = f"/api/v1/recipes/{recipe_id}"
+        response = client.get(recipe_path, headers=auth_headers("GET", recipe_path))
         assert response.status_code == 200
         body = response.get_json()
         assert body["id"] == recipe_id
@@ -246,10 +281,12 @@ class TestRecipeEndpoints:
         assert body["pantry_items"][0]["ingredient"] == "salt"
 
     def test_get_recipe_unknown_id_returns_404(
-        self, client: FlaskClient, auth_headers: dict[str, str]
+        self, client: FlaskClient, auth_headers: AuthHeaderFactory
     ) -> None:
         """An unknown recipe id yields a JSON 404."""
-        response = client.get("/api/v1/recipes/999", headers=auth_headers)
+        response = client.get(
+            "/api/v1/recipes/999", headers=auth_headers("GET", "/api/v1/recipes/999")
+        )
         assert response.status_code == 404
         assert response.get_json() == {"error": "recipe not found"}
 
@@ -261,7 +298,7 @@ class TestBrandsEndpoint:
     def test_returns_preferences(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
         recipe_store: RecipeStore,
     ) -> None:
         """Seeded brand preferences come back with full field shape."""
@@ -274,7 +311,9 @@ class TestBrandsEndpoint:
                 notes="organic",
             )
         )
-        response = client.get("/api/v1/brands", headers=auth_headers)
+        response = client.get(
+            "/api/v1/brands", headers=auth_headers("GET", "/api/v1/brands")
+        )
         assert response.status_code == 200
         brands = response.get_json()["brands"]
         assert len(brands) == 1
@@ -293,13 +332,15 @@ class TestPreferencesEndpoint:
     def test_returns_all_preferences(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
         recipe_store: RecipeStore,
     ) -> None:
         """Stored preference keys come back as a flat JSON object."""
         recipe_store.set_preference("default_servings", "4")
         recipe_store.set_preference("default_units", "imperial")
-        response = client.get("/api/v1/preferences", headers=auth_headers)
+        response = client.get(
+            "/api/v1/preferences", headers=auth_headers("GET", "/api/v1/preferences")
+        )
         assert response.status_code == 200
         body = response.get_json()
         assert body["default_servings"] == "4"
@@ -313,14 +354,16 @@ class TestRestockEndpoint:
     def test_returns_low_and_out_items(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
         pantry_mgr: PantryManager,
         sample_item: InventoryItem,
     ) -> None:
         """Items marked out show up in the restock queue."""
         pantry_mgr.add_item(sample_item)
         pantry_mgr.update_status("milk", InventoryStatus.OUT)
-        response = client.get("/api/v1/restock", headers=auth_headers)
+        response = client.get(
+            "/api/v1/restock", headers=auth_headers("GET", "/api/v1/restock")
+        )
         assert response.status_code == 200
         items = response.get_json()["items"]
         assert len(items) == 1
@@ -330,13 +373,15 @@ class TestRestockEndpoint:
     def test_on_hand_items_excluded(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
         pantry_mgr: PantryManager,
         sample_item: InventoryItem,
     ) -> None:
         """Items still on hand do not show up in the restock queue."""
         pantry_mgr.add_item(sample_item)
-        response = client.get("/api/v1/restock", headers=auth_headers)
+        response = client.get(
+            "/api/v1/restock", headers=auth_headers("GET", "/api/v1/restock")
+        )
         assert response.status_code == 200
         assert response.get_json() == {"items": []}
 

--- a/tests/test_api_compute.py
+++ b/tests/test_api_compute.py
@@ -3,24 +3,34 @@
 Covers POST /api/v1/meals/parse, /api/v1/shopping-list/preview, and
 /api/v1/order/preview. The Claude / Safeway pipelines are mocked — no
 live API calls happen here.
+
+Issue #74: every bearer token minted in this module is now bound to the
+exact (method, path, body) of the request it authorizes, via the shared
+``tests.conftest.bearer_header`` helper and the ``_post`` helper below,
+which serializes each JSON body exactly once and binds the token to
+those same bytes.
 """
 
 from __future__ import annotations
 
+import json
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
     from flask import Flask
     from flask.testing import FlaskClient
 
+    AuthHeaderFactory = Callable[[str, str, bytes], dict[str, str]]
+
 from grocery_butler.app import create_app
-from grocery_butler.auth_middleware import SECRET_ENV_VAR, mint_token
+from grocery_butler.auth_middleware import SECRET_ENV_VAR
 from grocery_butler.models import (
     CartItem,
     CartSummary,
@@ -37,6 +47,7 @@ from grocery_butler.models import (
 from grocery_butler.pantry_manager import PantryManager
 from grocery_butler.recipe_store import RecipeStore
 from grocery_butler.safeway_pipeline import SafewayPipelineError
+from tests.conftest import bearer_header
 
 TEST_SECRET = "test-shared-secret"
 SECRET_ENV = {SECRET_ENV_VAR: TEST_SECRET}
@@ -85,11 +96,56 @@ def recipe_store(db_path: str) -> RecipeStore:
 
 
 @pytest.fixture()
-def auth_headers() -> dict[str, str]:
-    """Return a valid Authorization header minted with the test secret."""
-    with patch.dict(os.environ, SECRET_ENV):
-        token = mint_token("rubotpaul")
-    return {"Authorization": f"Bearer {token}"}
+def auth_headers() -> AuthHeaderFactory:
+    """Return a factory that mints a bearer header for one exact request.
+
+    A single static header cannot authorize every request exercised in
+    this module -- each compute endpoint call has its own body, and the
+    request-bound token contract (issue #74) signs method, path, and
+    body together. Callers invoke the returned factory once per
+    request, typically via the ``_post`` helper below.
+
+    Returns:
+        A callable ``(method, path, body=b"") -> {"Authorization": ...}``
+        that mints tokens under the test shared secret.
+    """
+
+    def _make(method: str, path: str, body: bytes = b"") -> dict[str, str]:
+        """Mint a bearer header bound to the given method/path/body."""
+        with patch.dict(os.environ, SECRET_ENV):
+            return bearer_header("rubotpaul", method, path, body)
+
+    return _make
+
+
+def _post(
+    client: FlaskClient,
+    auth_headers: AuthHeaderFactory,
+    path: str,
+    body: Any,
+) -> Any:
+    """POST a JSON-serializable body with a token bound to the exact bytes sent.
+
+    Serializes ``body`` exactly once so the identical bytes are both
+    sent as the request payload and hashed into the bearer token's
+    binding -- the two must match byte-for-byte for the server's HMAC
+    verification to succeed (issue #74).
+
+    Args:
+        client: Flask test client.
+        auth_headers: Factory fixture minting a bearer header for one
+            exact (method, path, body) triple.
+        path: Request path to POST to.
+        body: JSON-serializable request payload.
+
+    Returns:
+        The Flask test client's response.
+    """
+    serialized = json.dumps(body).encode()
+    headers = auth_headers("POST", path, serialized)
+    return client.post(
+        path, data=serialized, content_type="application/json", headers=headers
+    )
 
 
 def _make_meal(name: str = "test pasta") -> ParsedMeal:
@@ -195,46 +251,45 @@ class TestMealsParse:
 
     @pytest.mark.parametrize("body", [{}, {"text": ""}, {"text": "   "}])
     def test_empty_text_returns_400(
-        self, client: FlaskClient, auth_headers: dict[str, str], body: dict[str, str]
+        self, client: FlaskClient, auth_headers: AuthHeaderFactory, body: dict[str, str]
     ) -> None:
         """Missing or blank text is a 400 with a JSON error."""
-        response = client.post("/api/v1/meals/parse", json=body, headers=auth_headers)
+        response = _post(client, auth_headers, "/api/v1/meals/parse", body)
         assert response.status_code == 400
         assert "error" in response.get_json()
 
     def test_non_object_body_returns_400(
-        self, client: FlaskClient, auth_headers: dict[str, str]
+        self, client: FlaskClient, auth_headers: AuthHeaderFactory
     ) -> None:
         """A non-object JSON body is a 400."""
-        response = client.post(
-            "/api/v1/meals/parse", json=["tacos"], headers=auth_headers
-        )
+        response = _post(client, auth_headers, "/api/v1/meals/parse", ["tacos"])
         assert response.status_code == 400
 
     def test_parses_comma_and_newline_separated_meals(
-        self, client: FlaskClient, auth_headers: dict[str, str]
+        self, client: FlaskClient, auth_headers: AuthHeaderFactory
     ) -> None:
         """Meal names split on commas and newlines reach parse_meals."""
         parser = MagicMock()
         parser.parse_meals.return_value = [_make_meal("tacos"), _make_meal("pasta")]
         with patch("grocery_butler.api._meal_parser", return_value=parser):
-            response = client.post(
+            response = _post(
+                client,
+                auth_headers,
                 "/api/v1/meals/parse",
-                json={"text": "tacos, pasta\nchili"},
-                headers=auth_headers,
+                {"text": "tacos, pasta\nchili"},
             )
         assert response.status_code == 200
         parser.parse_meals.assert_called_once_with(["tacos", "pasta", "chili"])
 
     def test_serializes_parsed_meals(
-        self, client: FlaskClient, auth_headers: dict[str, str]
+        self, client: FlaskClient, auth_headers: AuthHeaderFactory
     ) -> None:
         """The parsed meals come back JSON-serialized."""
         parser = MagicMock()
         parser.parse_meals.return_value = [_make_meal("tacos")]
         with patch("grocery_butler.api._meal_parser", return_value=parser):
-            response = client.post(
-                "/api/v1/meals/parse", json={"text": "tacos"}, headers=auth_headers
+            response = _post(
+                client, auth_headers, "/api/v1/meals/parse", {"text": "tacos"}
             )
         assert response.status_code == 200
         meals = response.get_json()["meals"]
@@ -253,32 +308,31 @@ class TestShoppingListPreview:
     """POST /api/v1/shopping-list/preview."""
 
     def test_invalid_meals_returns_400(
-        self, client: FlaskClient, auth_headers: dict[str, str]
+        self, client: FlaskClient, auth_headers: AuthHeaderFactory
     ) -> None:
         """Meals that fail ParsedMeal validation are a 400."""
-        response = client.post(
+        response = _post(
+            client,
+            auth_headers,
             "/api/v1/shopping-list/preview",
-            json={"meals": [{"name": "incomplete"}]},
-            headers=auth_headers,
+            {"meals": [{"name": "incomplete"}]},
         )
         assert response.status_code == 400
         assert "error" in response.get_json()
 
     def test_meals_must_be_a_list(
-        self, client: FlaskClient, auth_headers: dict[str, str]
+        self, client: FlaskClient, auth_headers: AuthHeaderFactory
     ) -> None:
         """A non-list meals field is a 400."""
-        response = client.post(
-            "/api/v1/shopping-list/preview",
-            json={"meals": "tacos"},
-            headers=auth_headers,
+        response = _post(
+            client, auth_headers, "/api/v1/shopping-list/preview", {"meals": "tacos"}
         )
         assert response.status_code == 400
 
     def test_consolidates_with_restock_and_staples(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
         pantry_mgr: PantryManager,
         recipe_store: RecipeStore,
     ) -> None:
@@ -298,10 +352,11 @@ class TestShoppingListPreview:
         consolidator.consolidate.return_value = [_make_shopping_item()]
         meal = _make_meal("tacos")
         with patch("grocery_butler.api._consolidator", return_value=consolidator):
-            response = client.post(
+            response = _post(
+                client,
+                auth_headers,
                 "/api/v1/shopping-list/preview",
-                json={"meals": [meal.model_dump(mode="json")]},
-                headers=auth_headers,
+                {"meals": [meal.model_dump(mode="json")]},
             )
 
         assert response.status_code == 200
@@ -316,7 +371,7 @@ class TestShoppingListPreview:
     def test_include_restock_false_skips_restock_queue(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
         pantry_mgr: PantryManager,
     ) -> None:
         """include_restock=false keeps the restock queue out of the call."""
@@ -333,13 +388,14 @@ class TestShoppingListPreview:
         consolidator = MagicMock()
         consolidator.consolidate.return_value = []
         with patch("grocery_butler.api._consolidator", return_value=consolidator):
-            response = client.post(
+            response = _post(
+                client,
+                auth_headers,
                 "/api/v1/shopping-list/preview",
-                json={
+                {
                     "meals": [_make_meal().model_dump(mode="json")],
                     "include_restock": False,
                 },
-                headers=auth_headers,
             )
 
         assert response.status_code == 200
@@ -359,37 +415,39 @@ class TestOrderPreview:
     def test_empty_shopping_list_returns_400(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
         body: dict[str, object],
     ) -> None:
         """A missing or empty shopping_list is a 400."""
-        response = client.post("/api/v1/order/preview", json=body, headers=auth_headers)
+        response = _post(client, auth_headers, "/api/v1/order/preview", body)
         assert response.status_code == 400
         assert "error" in response.get_json()
 
     def test_invalid_shopping_list_item_returns_400(
-        self, client: FlaskClient, auth_headers: dict[str, str]
+        self, client: FlaskClient, auth_headers: AuthHeaderFactory
     ) -> None:
         """Items that fail ShoppingListItem validation are a 400."""
-        response = client.post(
+        response = _post(
+            client,
+            auth_headers,
             "/api/v1/order/preview",
-            json={"shopping_list": [{"ingredient": "pasta"}]},
-            headers=auth_headers,
+            {"shopping_list": [{"ingredient": "pasta"}]},
         )
         assert response.status_code == 400
 
     def test_builds_cart_and_returns_decimal_safe_total(
-        self, client: FlaskClient, auth_headers: dict[str, str]
+        self, client: FlaskClient, auth_headers: AuthHeaderFactory
     ) -> None:
         """0.1 + 0.2 comes back as exactly "0.3", not a float artifact."""
         pipeline = MagicMock()
         pipeline.build_cart_only.return_value = _make_cart({"pasta": 0.1, "beans": 0.2})
         item = _make_shopping_item()
         with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
-            response = client.post(
+            response = _post(
+                client,
+                auth_headers,
                 "/api/v1/order/preview",
-                json={"shopping_list": [item.model_dump(mode="json")]},
-                headers=auth_headers,
+                {"shopping_list": [item.model_dump(mode="json")]},
             )
 
         assert response.status_code == 200
@@ -400,7 +458,7 @@ class TestOrderPreview:
         assert len(body["cart"]["items"]) == 2
 
     def test_restock_items_count_toward_total(
-        self, client: FlaskClient, auth_headers: dict[str, str]
+        self, client: FlaskClient, auth_headers: AuthHeaderFactory
     ) -> None:
         """Restock cart items are part of the Decimal-safe total."""
         cart = _make_cart({"pasta": 1.25})
@@ -410,42 +468,45 @@ class TestOrderPreview:
         pipeline = MagicMock()
         pipeline.build_cart_only.return_value = cart
         with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
-            response = client.post(
+            response = _post(
+                client,
+                auth_headers,
                 "/api/v1/order/preview",
-                json={"shopping_list": [_make_shopping_item().model_dump(mode="json")]},
-                headers=auth_headers,
+                {"shopping_list": [_make_shopping_item().model_dump(mode="json")]},
             )
 
         assert response.status_code == 200
         assert response.get_json()["total"] == "3.75"
 
     def test_pipeline_error_returns_503(
-        self, client: FlaskClient, auth_headers: dict[str, str]
+        self, client: FlaskClient, auth_headers: AuthHeaderFactory
     ) -> None:
         """Safeway pipeline failures surface as a JSON 503."""
         with patch(
             "grocery_butler.api._safeway_pipeline",
             side_effect=SafewayPipelineError("no credentials"),
         ):
-            response = client.post(
+            response = _post(
+                client,
+                auth_headers,
                 "/api/v1/order/preview",
-                json={"shopping_list": [_make_shopping_item().model_dump(mode="json")]},
-                headers=auth_headers,
+                {"shopping_list": [_make_shopping_item().model_dump(mode="json")]},
             )
         assert response.status_code == 503
         assert "error" in response.get_json()
 
     def test_pipeline_closed_even_when_build_fails(
-        self, client: FlaskClient, auth_headers: dict[str, str]
+        self, client: FlaskClient, auth_headers: AuthHeaderFactory
     ) -> None:
         """The Safeway client is cleaned up when cart building raises."""
         pipeline = MagicMock()
         pipeline.build_cart_only.side_effect = SafewayPipelineError("auth failed")
         with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
-            response = client.post(
+            response = _post(
+                client,
+                auth_headers,
                 "/api/v1/order/preview",
-                json={"shopping_list": [_make_shopping_item().model_dump(mode="json")]},
-                headers=auth_headers,
+                {"shopping_list": [_make_shopping_item().model_dump(mode="json")]},
             )
         assert response.status_code == 503
         pipeline.close.assert_called_once_with()

--- a/tests/test_api_destructive.py
+++ b/tests/test_api_destructive.py
@@ -5,11 +5,19 @@ Covers the highest-stakes flow in the stack: ``/order/submit``,
 and execute only through ``/actions/confirm`` (chat-based draft →
 confirm → execute per PIVOT.md). No test may ever reach a real Safeway
 client — the pipeline factory is mocked everywhere it could execute.
+
+Issue #74: every bearer token minted in this module is now bound to the
+exact (method, path, body) of the request it authorizes, via the
+shared ``tests.conftest.bearer_header`` helper. A single static header
+cannot cover the many different requests exercised here, so the
+``auth_headers`` fixture is a per-request minting factory rather than a
+static header dict.
 """
 
 from __future__ import annotations
 
 import datetime as dt
+import json
 import os
 import uuid
 from typing import TYPE_CHECKING, Any
@@ -18,13 +26,17 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
     from flask import Flask
     from flask.testing import FlaskClient
 
+    AuthHeaderFactory = Callable[[str, str, bytes], dict[str, str]]
+
+from grocery_butler.api import api_v1
 from grocery_butler.app import create_app
-from grocery_butler.auth_middleware import SECRET_ENV_VAR, mint_token
+from grocery_butler.auth_middleware import SECRET_ENV_VAR
 from grocery_butler.config import ConfigError
 from grocery_butler.models import (
     BrandMatchType,
@@ -42,6 +54,7 @@ from grocery_butler.models import (
 from grocery_butler.order_service import OrderConfirmation, OrderResult
 from grocery_butler.pending_actions import PendingActionsStore
 from grocery_butler.recipe_store import RecipeStore
+from tests.conftest import bearer_header
 
 TEST_SECRET = "test-shared-secret"
 SECRET_ENV = {SECRET_ENV_VAR: TEST_SECRET}
@@ -53,6 +66,27 @@ DESTRUCTIVE_ENDPOINTS = [
     "/api/v1/actions/confirm",
     "/api/v1/actions/deny",
 ]
+
+#: Issue #74 AC#2: a view that never calls require_bearer() itself, used
+#: to prove the api_v1 blueprint's before_request hook enforces auth
+#: even when a route forgets the per-route check. Registered once, at
+#: import time -- Flask blueprints only accept new routes before
+#: they've been applied to an app via register_blueprint, and api_v1 is
+#: a process-wide singleton reused by every create_app() call in this
+#: suite, so this must be added before any test in the suite calls
+#: create_app().
+UNAUTHENTICATED_THROWAWAY_PATH = "/api/v1/_test_unauthenticated_view_issue_74"
+
+
+@api_v1.get("/_test_unauthenticated_view_issue_74")
+def _unauthenticated_throwaway_view() -> dict[str, bool]:
+    """Return a fixed payload without ever calling require_bearer().
+
+    Exists solely so ``TestAuthByDefault`` can prove that unauthenticated
+    requests are still rejected -- by the blueprint's before_request
+    hook, not by this view.
+    """
+    return {"ok": True}
 
 
 # ---------------------------------------------------------------------------
@@ -93,11 +127,57 @@ def recipe_store(db_path: str) -> RecipeStore:
 
 
 @pytest.fixture()
-def auth_headers() -> dict[str, str]:
-    """Return a valid Authorization header minted with the test secret."""
-    with patch.dict(os.environ, SECRET_ENV):
-        token = mint_token("rubotpaul")
-    return {"Authorization": f"Bearer {token}"}
+def auth_headers() -> AuthHeaderFactory:
+    """Return a factory that mints a bearer header for one exact request.
+
+    A single static header cannot authorize every request exercised in
+    this module -- each destructive-endpoint call has its own method,
+    path, and body, and the request-bound token contract (issue #74)
+    signs all three together. Callers invoke the returned factory once
+    per request, e.g.
+    ``auth_headers("POST", "/api/v1/order/submit", serialized_body)``.
+
+    Returns:
+        A callable ``(method, path, body=b"") -> {"Authorization": ...}``
+        that mints tokens under the test shared secret.
+    """
+
+    def _make(method: str, path: str, body: bytes = b"") -> dict[str, str]:
+        """Mint a bearer header bound to the given method/path/body."""
+        with patch.dict(os.environ, SECRET_ENV):
+            return bearer_header("rubotpaul", method, path, body)
+
+    return _make
+
+
+def _post(
+    client: FlaskClient,
+    auth_headers: AuthHeaderFactory,
+    path: str,
+    body: Any,
+) -> Any:
+    """POST a JSON-serializable body with a token bound to the exact bytes sent.
+
+    Serializes ``body`` exactly once so the identical bytes are both
+    sent as the request payload and hashed into the bearer token's
+    binding -- the two must match byte-for-byte for the server's HMAC
+    verification to succeed (issue #74).
+
+    Args:
+        client: Flask test client.
+        auth_headers: Factory fixture minting a bearer header for one
+            exact (method, path, body) triple.
+        path: Request path to POST to.
+        body: JSON-serializable request payload.
+
+    Returns:
+        The Flask test client's response.
+    """
+    serialized = json.dumps(body).encode()
+    headers = auth_headers("POST", path, serialized)
+    return client.post(
+        path, data=serialized, content_type="application/json", headers=headers
+    )
 
 
 def _make_shopping_item(ingredient: str = "pasta") -> ShoppingListItem:
@@ -234,12 +314,12 @@ def _successful_order_result() -> OrderResult:
 
 def _stage_via_api(
     client: FlaskClient,
-    auth_headers: dict[str, str],
+    auth_headers: AuthHeaderFactory,
     path: str,
     body: dict[str, Any],
 ) -> str:
     """Stage an action through the API and return its action_id."""
-    response = client.post(path, json=body, headers=auth_headers)
+    response = _post(client, auth_headers, path, body)
     assert response.status_code == 200
     action_id = response.get_json()["action_id"]
     assert isinstance(action_id, str)
@@ -281,58 +361,60 @@ class TestOrderSubmitStaging:
     """/order/submit stages a pending action and must not touch Safeway."""
 
     def test_missing_cart_returns_400(
-        self, client: FlaskClient, auth_headers: dict[str, str]
+        self, client: FlaskClient, auth_headers: AuthHeaderFactory
     ) -> None:
         """A body without a cart is rejected."""
-        response = client.post(
-            "/api/v1/order/submit", json={"total": "9.99"}, headers=auth_headers
+        response = _post(
+            client, auth_headers, "/api/v1/order/submit", {"total": "9.99"}
         )
         assert response.status_code == 400
         assert "cart" in response.get_json()["error"]
 
     def test_invalid_cart_returns_400(
-        self, client: FlaskClient, auth_headers: dict[str, str]
+        self, client: FlaskClient, auth_headers: AuthHeaderFactory
     ) -> None:
         """A cart that fails CartSummary validation is rejected."""
-        response = client.post(
+        response = _post(
+            client,
+            auth_headers,
             "/api/v1/order/submit",
-            json={"cart": {"items": "nope"}},
-            headers=auth_headers,
+            {"cart": {"items": "nope"}},
         )
         assert response.status_code == 400
         assert "invalid cart" in response.get_json()["error"]
 
     def test_empty_cart_returns_400(
-        self, client: FlaskClient, auth_headers: dict[str, str]
+        self, client: FlaskClient, auth_headers: AuthHeaderFactory
     ) -> None:
         """A structurally valid but empty cart is rejected."""
         empty = _make_cart({})
-        response = client.post(
+        response = _post(
+            client,
+            auth_headers,
             "/api/v1/order/submit",
-            json={"cart": empty.model_dump(mode="json")},
-            headers=auth_headers,
+            {"cart": empty.model_dump(mode="json")},
         )
         assert response.status_code == 400
         assert "empty" in response.get_json()["error"]
 
     def test_non_object_body_returns_400(
-        self, client: FlaskClient, auth_headers: dict[str, str]
+        self, client: FlaskClient, auth_headers: AuthHeaderFactory
     ) -> None:
         """A non-object JSON body is rejected."""
-        response = client.post(
-            "/api/v1/order/submit", json=["not", "a", "dict"], headers=auth_headers
+        response = _post(
+            client, auth_headers, "/api/v1/order/submit", ["not", "a", "dict"]
         )
         assert response.status_code == 400
 
     def test_stages_pending_action_and_returns_confirmation_prompt(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
         pending_store: PendingActionsStore,
     ) -> None:
         """Submitting a cart stages a pending_actions row with the exact cart."""
         body = _order_body()
-        response = client.post("/api/v1/order/submit", json=body, headers=auth_headers)
+        response = _post(client, auth_headers, "/api/v1/order/submit", body)
         assert response.status_code == 200
         data = response.get_json()
         assert data["status"] == "pending_confirmation"
@@ -350,15 +432,16 @@ class TestOrderSubmitStaging:
     def test_total_defaults_to_cart_total_when_omitted(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
         pending_store: PendingActionsStore,
     ) -> None:
         """Without an explicit total, the staged total is computed from the cart."""
         cart = _make_cart({"pasta": 3.50, "sauce": 4.25})
-        response = client.post(
+        response = _post(
+            client,
+            auth_headers,
             "/api/v1/order/submit",
-            json={"cart": cart.model_dump(mode="json")},
-            headers=auth_headers,
+            {"cart": cart.model_dump(mode="json")},
         )
         assert response.status_code == 200
         action = pending_store.get_pending_action(response.get_json()["action_id"])
@@ -366,19 +449,19 @@ class TestOrderSubmitStaging:
         assert action.payload["total"] == "7.75"
 
     def test_staging_never_touches_the_safeway_pipeline(
-        self, client: FlaskClient, auth_headers: dict[str, str]
+        self, client: FlaskClient, auth_headers: AuthHeaderFactory
     ) -> None:
         """Staging an order must not construct or call the Safeway pipeline."""
         factory = MagicMock()
         with patch("grocery_butler.api._safeway_pipeline", factory):
-            response = client.post(
-                "/api/v1/order/submit", json=_order_body(), headers=auth_headers
+            response = _post(
+                client, auth_headers, "/api/v1/order/submit", _order_body()
             )
         assert response.status_code == 200
         factory.assert_not_called()
 
     def test_staged_message_lists_flagged_items_and_reasons(
-        self, client: FlaskClient, auth_headers: dict[str, str]
+        self, client: FlaskClient, auth_headers: AuthHeaderFactory
     ) -> None:
         """The staged message must surface flagged ingredients and reasons.
 
@@ -389,10 +472,11 @@ class TestOrderSubmitStaging:
         must name every flagged ingredient and its reason code.
         """
         cart = _make_cart_with_flagged_item()
-        response = client.post(
+        response = _post(
+            client,
+            auth_headers,
             "/api/v1/order/submit",
-            json={"cart": cart.model_dump(mode="json")},
-            headers=auth_headers,
+            {"cart": cart.model_dump(mode="json")},
         )
         assert response.status_code == 200
         message = response.get_json()["message"]
@@ -400,18 +484,16 @@ class TestOrderSubmitStaging:
         assert "incomparable_units" in message
 
     def test_staged_message_has_no_review_section_for_clean_cart(
-        self, client: FlaskClient, auth_headers: dict[str, str]
+        self, client: FlaskClient, auth_headers: AuthHeaderFactory
     ) -> None:
         """A cart with no flagged items keeps the plain staging message."""
-        response = client.post(
-            "/api/v1/order/submit", json=_order_body(), headers=auth_headers
-        )
+        response = _post(client, auth_headers, "/api/v1/order/submit", _order_body())
         assert response.status_code == 200
         message = response.get_json()["message"]
         assert "review" not in message.lower()
 
     def test_staged_message_includes_unverified_fulfillment_clause(
-        self, client: FlaskClient, auth_headers: dict[str, str]
+        self, client: FlaskClient, auth_headers: AuthHeaderFactory
     ) -> None:
         """The staged message must warn about unverified fulfillment (issue #72).
 
@@ -421,10 +503,11 @@ class TestOrderSubmitStaging:
         of the fulfillment gate (issue #59 precedent).
         """
         cart = _make_cart_with_unverified_fulfillment()
-        response = client.post(
+        response = _post(
+            client,
+            auth_headers,
             "/api/v1/order/submit",
-            json={"cart": cart.model_dump(mode="json")},
-            headers=auth_headers,
+            {"cart": cart.model_dump(mode="json")},
         )
         assert response.status_code == 200
         message = response.get_json()["message"].lower()
@@ -444,14 +527,12 @@ class TestBrandsSetStaging:
     def test_stages_pending_action(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
         pending_store: PendingActionsStore,
         recipe_store: RecipeStore,
     ) -> None:
         """A valid brand rule is staged, not written to brand preferences."""
-        response = client.post(
-            "/api/v1/brands/set", json=_brand_body(), headers=auth_headers
-        )
+        response = _post(client, auth_headers, "/api/v1/brands/set", _brand_body())
         assert response.status_code == 200
         data = response.get_json()
         assert data["status"] == "pending_confirmation"
@@ -464,11 +545,11 @@ class TestBrandsSetStaging:
         assert recipe_store.get_brand_preferences() == []
 
     def test_invalid_brand_payload_returns_400(
-        self, client: FlaskClient, auth_headers: dict[str, str]
+        self, client: FlaskClient, auth_headers: AuthHeaderFactory
     ) -> None:
         """A payload missing required brand fields is rejected."""
-        response = client.post(
-            "/api/v1/brands/set", json={"brand": "Clover"}, headers=auth_headers
+        response = _post(
+            client, auth_headers, "/api/v1/brands/set", {"brand": "Clover"}
         )
         assert response.status_code == 400
         assert "invalid brand" in response.get_json()["error"]
@@ -481,15 +562,13 @@ class TestPreferencesSetStaging:
     def test_stages_pending_action(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
         pending_store: PendingActionsStore,
         recipe_store: RecipeStore,
     ) -> None:
         """Valid preferences are staged, not written to the store."""
         body = {"preferences": {"fulfillment": "pickup", "store_id": "1234"}}
-        response = client.post(
-            "/api/v1/preferences/set", json=body, headers=auth_headers
-        )
+        response = _post(client, auth_headers, "/api/v1/preferences/set", body)
         assert response.status_code == 200
         data = response.get_json()
         assert data["status"] == "pending_confirmation"
@@ -515,13 +594,11 @@ class TestPreferencesSetStaging:
     def test_invalid_preferences_return_400(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
         body: dict[str, Any],
     ) -> None:
         """Missing, empty, or non-string preference payloads are rejected."""
-        response = client.post(
-            "/api/v1/preferences/set", json=body, headers=auth_headers
-        )
+        response = _post(client, auth_headers, "/api/v1/preferences/set", body)
         assert response.status_code == 400
 
 
@@ -535,20 +612,21 @@ class TestActionsConfirm:
     """/actions/confirm resolves staged actions with strict semantics."""
 
     def test_missing_action_id_returns_400(
-        self, client: FlaskClient, auth_headers: dict[str, str]
+        self, client: FlaskClient, auth_headers: AuthHeaderFactory
     ) -> None:
         """A body without action_id is rejected."""
-        response = client.post("/api/v1/actions/confirm", json={}, headers=auth_headers)
+        response = _post(client, auth_headers, "/api/v1/actions/confirm", {})
         assert response.status_code == 400
 
     def test_unknown_action_id_returns_404(
-        self, client: FlaskClient, auth_headers: dict[str, str]
+        self, client: FlaskClient, auth_headers: AuthHeaderFactory
     ) -> None:
         """An unknown action_id gets a JSON 404."""
-        response = client.post(
+        response = _post(
+            client,
+            auth_headers,
             "/api/v1/actions/confirm",
-            json={"action_id": str(uuid.uuid4())},
-            headers=auth_headers,
+            {"action_id": str(uuid.uuid4())},
         )
         assert response.status_code == 404
         assert "error" in response.get_json()
@@ -556,7 +634,7 @@ class TestActionsConfirm:
     def test_expired_action_returns_410_and_marks_expired(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
         pending_store: PendingActionsStore,
     ) -> None:
         """Confirming past the TTL returns 410 and resolves the row as expired."""
@@ -567,10 +645,11 @@ class TestActionsConfirm:
             payload={"preferences": {"fulfillment": "pickup"}},
             expires_at=dt.datetime.now(dt.UTC) - dt.timedelta(seconds=1),
         )
-        response = client.post(
+        response = _post(
+            client,
+            auth_headers,
             "/api/v1/actions/confirm",
-            json={"action_id": action_id},
-            headers=auth_headers,
+            {"action_id": action_id},
         )
         assert response.status_code == 410
         action = pending_store.get_pending_action(action_id)
@@ -581,7 +660,7 @@ class TestActionsConfirm:
     def test_confirm_order_calls_submit_with_exact_staged_cart(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
         pending_store: PendingActionsStore,
     ) -> None:
         """Confirming an order submits the exact staged cart and approves the row."""
@@ -591,10 +670,11 @@ class TestActionsConfirm:
         pipeline = MagicMock()
         pipeline.submit_cart.return_value = _successful_order_result()
         with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
-            response = client.post(
+            response = _post(
+                client,
+                auth_headers,
                 "/api/v1/actions/confirm",
-                json={"action_id": action_id},
-                headers=auth_headers,
+                {"action_id": action_id},
             )
 
         assert response.status_code == 200
@@ -616,7 +696,7 @@ class TestActionsConfirm:
     def test_confirm_order_forwards_allow_review_items_override(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
     ) -> None:
         """Confirming a staged order must override the review gate.
 
@@ -634,10 +714,11 @@ class TestActionsConfirm:
         pipeline = MagicMock()
         pipeline.submit_cart.return_value = _successful_order_result()
         with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
-            response = client.post(
+            response = _post(
+                client,
+                auth_headers,
                 "/api/v1/actions/confirm",
-                json={"action_id": action_id},
-                headers=auth_headers,
+                {"action_id": action_id},
             )
 
         assert response.status_code == 200
@@ -648,7 +729,7 @@ class TestActionsConfirm:
     def test_confirm_order_forwards_allow_unverified_fulfillment_override(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
     ) -> None:
         """Confirming a staged order must override the fulfillment gate.
 
@@ -667,10 +748,11 @@ class TestActionsConfirm:
         pipeline = MagicMock()
         pipeline.submit_cart.return_value = _successful_order_result()
         with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
-            response = client.post(
+            response = _post(
+                client,
+                auth_headers,
                 "/api/v1/actions/confirm",
-                json={"action_id": action_id},
-                headers=auth_headers,
+                {"action_id": action_id},
             )
 
         assert response.status_code == 200
@@ -681,7 +763,7 @@ class TestActionsConfirm:
     def test_failed_order_submission_returns_502(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
         pending_store: PendingActionsStore,
     ) -> None:
         """A failed Safeway submission reports 502; the claim is consumed."""
@@ -693,10 +775,11 @@ class TestActionsConfirm:
             success=False, error_message="Safeway is down"
         )
         with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
-            response = client.post(
+            response = _post(
+                client,
+                auth_headers,
                 "/api/v1/actions/confirm",
-                json={"action_id": action_id},
-                headers=auth_headers,
+                {"action_id": action_id},
             )
         assert response.status_code == 502
         assert "Safeway is down" in response.get_json()["error"]
@@ -707,7 +790,7 @@ class TestActionsConfirm:
     def test_unavailable_pipeline_returns_503_and_keeps_action_pending(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
         pending_store: PendingActionsStore,
     ) -> None:
         """If the pipeline can't start, the action stays pending for retry."""
@@ -718,10 +801,11 @@ class TestActionsConfirm:
             "grocery_butler.api._safeway_pipeline",
             side_effect=ConfigError("SAFEWAY_USERNAME missing"),
         ):
-            response = client.post(
+            response = _post(
+                client,
+                auth_headers,
                 "/api/v1/actions/confirm",
-                json={"action_id": action_id},
-                headers=auth_headers,
+                {"action_id": action_id},
             )
         assert response.status_code == 503
         action = pending_store.get_pending_action(action_id)
@@ -731,7 +815,7 @@ class TestActionsConfirm:
     def test_disabled_submission_returns_501_and_keeps_action_pending(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
         pending_store: PendingActionsStore,
     ) -> None:
         """Issue #60: a disabled pipeline returns 501 and leaves the row pending.
@@ -749,10 +833,11 @@ class TestActionsConfirm:
         pipeline.order_submission_enabled = False
         pipeline.submit_cart.return_value = _successful_order_result()
         with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
-            response = client.post(
+            response = _post(
+                client,
+                auth_headers,
                 "/api/v1/actions/confirm",
-                json={"action_id": action_id},
-                headers=auth_headers,
+                {"action_id": action_id},
             )
 
         assert response.status_code == 501
@@ -767,22 +852,24 @@ class TestActionsConfirm:
     def test_double_confirm_returns_409(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
     ) -> None:
         """Confirming an already-approved action returns 409."""
         action_id = _stage_via_api(
             client, auth_headers, "/api/v1/brands/set", _brand_body()
         )
-        first = client.post(
+        first = _post(
+            client,
+            auth_headers,
             "/api/v1/actions/confirm",
-            json={"action_id": action_id},
-            headers=auth_headers,
+            {"action_id": action_id},
         )
         assert first.status_code == 200
-        second = client.post(
+        second = _post(
+            client,
+            auth_headers,
             "/api/v1/actions/confirm",
-            json={"action_id": action_id},
-            headers=auth_headers,
+            {"action_id": action_id},
         )
         assert second.status_code == 409
         assert "error" in second.get_json()
@@ -790,29 +877,31 @@ class TestActionsConfirm:
     def test_confirm_after_deny_returns_409(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
     ) -> None:
         """Confirming a denied action returns 409."""
         action_id = _stage_via_api(
             client, auth_headers, "/api/v1/brands/set", _brand_body()
         )
-        denied = client.post(
+        denied = _post(
+            client,
+            auth_headers,
             "/api/v1/actions/deny",
-            json={"action_id": action_id},
-            headers=auth_headers,
+            {"action_id": action_id},
         )
         assert denied.status_code == 200
-        response = client.post(
+        response = _post(
+            client,
+            auth_headers,
             "/api/v1/actions/confirm",
-            json={"action_id": action_id},
-            headers=auth_headers,
+            {"action_id": action_id},
         )
         assert response.status_code == 409
 
     def test_confirm_brands_applies_rule(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
         recipe_store: RecipeStore,
         pending_store: PendingActionsStore,
     ) -> None:
@@ -820,10 +909,11 @@ class TestActionsConfirm:
         action_id = _stage_via_api(
             client, auth_headers, "/api/v1/brands/set", _brand_body()
         )
-        response = client.post(
+        response = _post(
+            client,
+            auth_headers,
             "/api/v1/actions/confirm",
-            json={"action_id": action_id},
-            headers=auth_headers,
+            {"action_id": action_id},
         )
         assert response.status_code == 200
         data = response.get_json()
@@ -846,7 +936,7 @@ class TestActionsConfirm:
     def test_confirm_preferences_applies_settings(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
         recipe_store: RecipeStore,
     ) -> None:
         """Confirming a preferences_set action writes every key/value pair."""
@@ -854,10 +944,11 @@ class TestActionsConfirm:
         action_id = _stage_via_api(
             client, auth_headers, "/api/v1/preferences/set", body
         )
-        response = client.post(
+        response = _post(
+            client,
+            auth_headers,
             "/api/v1/actions/confirm",
-            json={"action_id": action_id},
-            headers=auth_headers,
+            {"action_id": action_id},
         )
         assert response.status_code == 200
         assert response.get_json()["result"]["updated"] == 2
@@ -876,27 +967,28 @@ class TestActionsDeny:
     """/actions/deny resolves staged actions as denied."""
 
     def test_missing_action_id_returns_400(
-        self, client: FlaskClient, auth_headers: dict[str, str]
+        self, client: FlaskClient, auth_headers: AuthHeaderFactory
     ) -> None:
         """A body without action_id is rejected."""
-        response = client.post("/api/v1/actions/deny", json={}, headers=auth_headers)
+        response = _post(client, auth_headers, "/api/v1/actions/deny", {})
         assert response.status_code == 400
 
     def test_unknown_action_id_returns_404(
-        self, client: FlaskClient, auth_headers: dict[str, str]
+        self, client: FlaskClient, auth_headers: AuthHeaderFactory
     ) -> None:
         """An unknown action_id gets 404."""
-        response = client.post(
+        response = _post(
+            client,
+            auth_headers,
             "/api/v1/actions/deny",
-            json={"action_id": str(uuid.uuid4())},
-            headers=auth_headers,
+            {"action_id": str(uuid.uuid4())},
         )
         assert response.status_code == 404
 
     def test_denies_pending_action(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
         pending_store: PendingActionsStore,
         recipe_store: RecipeStore,
     ) -> None:
@@ -904,10 +996,11 @@ class TestActionsDeny:
         action_id = _stage_via_api(
             client, auth_headers, "/api/v1/brands/set", _brand_body()
         )
-        response = client.post(
+        response = _post(
+            client,
+            auth_headers,
             "/api/v1/actions/deny",
-            json={"action_id": action_id},
-            headers=auth_headers,
+            {"action_id": action_id},
         )
         assert response.status_code == 200
         data = response.get_json()
@@ -923,22 +1016,24 @@ class TestActionsDeny:
     def test_double_deny_returns_409(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
     ) -> None:
         """Denying an already-denied action returns 409."""
         action_id = _stage_via_api(
             client, auth_headers, "/api/v1/brands/set", _brand_body()
         )
-        first = client.post(
+        first = _post(
+            client,
+            auth_headers,
             "/api/v1/actions/deny",
-            json={"action_id": action_id},
-            headers=auth_headers,
+            {"action_id": action_id},
         )
         assert first.status_code == 200
-        second = client.post(
+        second = _post(
+            client,
+            auth_headers,
             "/api/v1/actions/deny",
-            json={"action_id": action_id},
-            headers=auth_headers,
+            {"action_id": action_id},
         )
         assert second.status_code == 409
 
@@ -960,7 +1055,7 @@ class TestConfirmOrderIdempotency:
     def test_confirm_order_passes_action_id_as_idempotency_key(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
     ) -> None:
         """Test the staged action_id is forwarded as the idempotency key."""
         action_id = _stage_via_api(
@@ -969,10 +1064,11 @@ class TestConfirmOrderIdempotency:
         pipeline = MagicMock()
         pipeline.submit_cart.return_value = _successful_order_result()
         with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
-            response = client.post(
+            response = _post(
+                client,
+                auth_headers,
                 "/api/v1/actions/confirm",
-                json={"action_id": action_id},
-                headers=auth_headers,
+                {"action_id": action_id},
             )
 
         assert response.status_code == 200
@@ -983,7 +1079,7 @@ class TestConfirmOrderIdempotency:
     def test_unknown_outcome_returns_504(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
         pending_store: PendingActionsStore,
     ) -> None:
         """Test an UNKNOWN order outcome surfaces as HTTP 504 with status unknown."""
@@ -999,10 +1095,11 @@ class TestConfirmOrderIdempotency:
             error_message="Order outcome unknown — request timed out",
         )
         with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
-            response = client.post(
+            response = _post(
+                client,
+                auth_headers,
                 "/api/v1/actions/confirm",
-                json={"action_id": action_id},
-                headers=auth_headers,
+                {"action_id": action_id},
             )
 
         assert response.status_code == 504
@@ -1017,7 +1114,7 @@ class TestConfirmOrderIdempotency:
     def test_duplicate_outcome_returns_409(
         self,
         client: FlaskClient,
-        auth_headers: dict[str, str],
+        auth_headers: AuthHeaderFactory,
         pending_store: PendingActionsStore,
     ) -> None:
         """Test a DUPLICATE order outcome surfaces as HTTP 409 duplicate_prevented."""
@@ -1033,10 +1130,11 @@ class TestConfirmOrderIdempotency:
             error_message="Duplicate order blocked — a recent submission is pending",
         )
         with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
-            response = client.post(
+            response = _post(
+                client,
+                auth_headers,
                 "/api/v1/actions/confirm",
-                json={"action_id": action_id},
-                headers=auth_headers,
+                {"action_id": action_id},
             )
 
         assert response.status_code == 409
@@ -1046,3 +1144,92 @@ class TestConfirmOrderIdempotency:
         action = pending_store.get_pending_action(action_id)
         assert action is not None
         assert action.status is PendingActionStatus.APPROVED
+
+
+# ---------------------------------------------------------------------------
+# Issue #74 AC#1: a token bound to one endpoint cannot be replayed on another
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, SECRET_ENV)
+class TestCrossEndpointTokenReplayRejected:
+    """A token minted for a harmless read endpoint cannot confirm actions."""
+
+    def test_inventory_token_replayed_against_confirm_returns_401(
+        self,
+        client: FlaskClient,
+        auth_headers: AuthHeaderFactory,
+        pending_store: PendingActionsStore,
+    ) -> None:
+        """AC#1: a GET /inventory token posted to /actions/confirm is rejected.
+
+        Stages a real action with a correctly-bound token, then attempts
+        to confirm it with a token minted for an unrelated read
+        endpoint. The replay must be rejected, and the staged action
+        must remain untouched -- no action may execute as a side effect
+        of a mismatched token.
+        """
+        action_id = _stage_via_api(
+            client, auth_headers, "/api/v1/brands/set", _brand_body()
+        )
+        stolen_headers = auth_headers("GET", "/api/v1/inventory", b"")
+
+        response = client.post(
+            "/api/v1/actions/confirm",
+            data=json.dumps({"action_id": action_id}).encode(),
+            content_type="application/json",
+            headers=stolen_headers,
+        )
+
+        assert response.status_code == 401
+        action = pending_store.get_pending_action(action_id)
+        assert action is not None
+        assert action.status is PendingActionStatus.PENDING
+
+
+# ---------------------------------------------------------------------------
+# Issue #74 AC#2: auth-by-default via the blueprint's before_request hook
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, SECRET_ENV)
+class TestAuthByDefault:
+    """The api_v1 blueprint enforces auth even without a per-route call.
+
+    ``_unauthenticated_throwaway_view`` (module scope, above) never
+    calls ``require_bearer()`` itself. If the blueprint's
+    ``before_request`` hook is doing its job, unauthenticated requests
+    to it must still 401, and correctly-bound requests must still 200.
+    """
+
+    def test_unauthenticated_request_to_unguarded_view_returns_401(
+        self, db_path: str
+    ) -> None:
+        """An unauthenticated request to the unguarded view is rejected.
+
+        Args:
+            db_path: Temporary database path fixture for test isolation.
+        """
+        application = create_app(db_path=db_path)
+        application.config["TESTING"] = True
+        test_client = application.test_client()
+
+        response = test_client.get(UNAUTHENTICATED_THROWAWAY_PATH)
+
+        assert response.status_code == 401
+
+    def test_bound_token_for_unguarded_view_returns_200(self, db_path: str) -> None:
+        """A correctly bound token still reaches the unguarded view.
+
+        Args:
+            db_path: Temporary database path fixture for test isolation.
+        """
+        application = create_app(db_path=db_path)
+        application.config["TESTING"] = True
+        test_client = application.test_client()
+        headers = bearer_header("rubotpaul", "GET", UNAUTHENTICATED_THROWAWAY_PATH)
+
+        response = test_client.get(UNAUTHENTICATED_THROWAWAY_PATH, headers=headers)
+
+        assert response.status_code == 200
+        assert response.get_json() == {"ok": True}

--- a/tests/test_api_writes.py
+++ b/tests/test_api_writes.py
@@ -1,7 +1,16 @@
-"""Tests for the /api/v1 low-stakes write endpoints (grocery_butler.api)."""
+"""Tests for the /api/v1 low-stakes write endpoints (grocery_butler.api).
+
+Issue #74: every bearer token minted in this module is now bound to the
+exact (method, path, body) of the request it authorizes, via the shared
+``tests.conftest.bearer_header`` helper. A single static header cannot
+cover the many different requests exercised here, so the
+``auth_headers`` fixture is a per-request minting factory rather than a
+static header dict.
+"""
 
 from __future__ import annotations
 
+import json
 import os
 from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
@@ -9,13 +18,16 @@ from unittest.mock import patch
 import pytest
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
     from flask import Flask
     from flask.testing import FlaskClient
 
+    AuthHeaderFactory = Callable[[str, str, bytes], dict[str, str]]
+
 from grocery_butler.app import create_app
-from grocery_butler.auth_middleware import SECRET_ENV_VAR, mint_token
+from grocery_butler.auth_middleware import SECRET_ENV_VAR
 from grocery_butler.models import (
     Ingredient,
     IngredientCategory,
@@ -25,6 +37,7 @@ from grocery_butler.models import (
 )
 from grocery_butler.pantry_manager import PantryManager
 from grocery_butler.recipe_store import RecipeStore
+from tests.conftest import bearer_header
 
 TEST_SECRET = "test-shared-secret"
 SECRET_ENV = {SECRET_ENV_VAR: TEST_SECRET}
@@ -75,11 +88,26 @@ def recipe_store(db_path: str) -> RecipeStore:
 
 
 @pytest.fixture()
-def auth_headers() -> dict[str, str]:
-    """Return a valid Authorization header minted with the test secret."""
-    with patch.dict(os.environ, SECRET_ENV):
-        token = mint_token("rubotpaul")
-    return {"Authorization": f"Bearer {token}"}
+def auth_headers() -> AuthHeaderFactory:
+    """Return a factory that mints a bearer header for one exact request.
+
+    A single static header cannot authorize every request exercised in
+    this module -- each write endpoint call has its own method, path,
+    and body, and the request-bound token contract (issue #74) signs
+    all three together. Callers invoke the returned factory once per
+    request, e.g. ``auth_headers("POST", "/api/v1/stock/add", body)``.
+
+    Returns:
+        A callable ``(method, path, body=b"") -> {"Authorization": ...}``
+        that mints tokens under the test shared secret.
+    """
+
+    def _make(method: str, path: str, body: bytes = b"") -> dict[str, str]:
+        """Mint a bearer header bound to the given method/path/body."""
+        with patch.dict(os.environ, SECRET_ENV):
+            return bearer_header("rubotpaul", method, path, body)
+
+    return _make
 
 
 @pytest.fixture()
@@ -116,11 +144,31 @@ def sample_meal() -> ParsedMeal:
 def _post(
     client: FlaskClient,
     path: str,
-    headers: dict[str, str],
+    auth_headers: AuthHeaderFactory,
     body: dict[str, Any],
 ) -> Any:
-    """POST a JSON body with auth headers."""
-    return client.post(path, json=body, headers=headers)
+    """POST a JSON-serializable body with a token bound to the exact bytes sent.
+
+    Serializes ``body`` exactly once so the identical bytes are both
+    sent as the request payload and hashed into the bearer token's
+    binding -- the two must match byte-for-byte for the server's HMAC
+    verification to succeed (issue #74).
+
+    Args:
+        client: Flask test client.
+        path: Request path to POST to.
+        auth_headers: Factory fixture minting a bearer header for one
+            exact (method, path, body) triple.
+        body: JSON-serializable request payload.
+
+    Returns:
+        The Flask test client's response.
+    """
+    serialized = json.dumps(body).encode()
+    headers = auth_headers("POST", path, serialized)
+    return client.post(
+        path, data=serialized, content_type="application/json", headers=headers
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -156,7 +204,7 @@ def test_write_endpoints_require_bearer(
 def test_stock_update_writes_status(
     client: FlaskClient,
     pantry_mgr: PantryManager,
-    auth_headers: dict[str, str],
+    auth_headers: AuthHeaderFactory,
     sample_item: InventoryItem,
     token: str,
     expected: InventoryStatus,
@@ -180,7 +228,7 @@ def test_stock_update_writes_status(
 def test_stock_update_rejects_bad_status(
     client: FlaskClient,
     pantry_mgr: PantryManager,
-    auth_headers: dict[str, str],
+    auth_headers: AuthHeaderFactory,
     sample_item: InventoryItem,
 ) -> None:
     """A status outside in/out/low/good is a 400 and writes nothing."""
@@ -199,7 +247,7 @@ def test_stock_update_rejects_bad_status(
 
 
 def test_stock_update_rejects_non_string_status(
-    client: FlaskClient, auth_headers: dict[str, str]
+    client: FlaskClient, auth_headers: AuthHeaderFactory
 ) -> None:
     """A non-string status is a 400, not a server error."""
     with patch.dict(os.environ, SECRET_ENV):
@@ -213,7 +261,7 @@ def test_stock_update_rejects_non_string_status(
 
 
 def test_stock_update_requires_item(
-    client: FlaskClient, auth_headers: dict[str, str]
+    client: FlaskClient, auth_headers: AuthHeaderFactory
 ) -> None:
     """A missing item is a 400."""
     with patch.dict(os.environ, SECRET_ENV):
@@ -224,7 +272,7 @@ def test_stock_update_requires_item(
 
 
 def test_stock_update_unknown_item_404(
-    client: FlaskClient, auth_headers: dict[str, str]
+    client: FlaskClient, auth_headers: AuthHeaderFactory
 ) -> None:
     """Updating an untracked item is a JSON 404."""
     with patch.dict(os.environ, SECRET_ENV):
@@ -239,12 +287,16 @@ def test_stock_update_unknown_item_404(
 
 
 def test_stock_update_rejects_non_object_body(
-    client: FlaskClient, auth_headers: dict[str, str]
+    client: FlaskClient, auth_headers: AuthHeaderFactory
 ) -> None:
     """A non-object JSON body is a 400."""
     with patch.dict(os.environ, SECRET_ENV):
+        serialized = json.dumps(["milk"]).encode()
         response = client.post(
-            "/api/v1/stock/update", json=["milk"], headers=auth_headers
+            "/api/v1/stock/update",
+            data=serialized,
+            content_type="application/json",
+            headers=auth_headers("POST", "/api/v1/stock/update", serialized),
         )
     assert response.status_code == 400
 
@@ -255,7 +307,7 @@ def test_stock_update_rejects_non_object_body(
 
 
 def test_stock_add_creates_item(
-    client: FlaskClient, pantry_mgr: PantryManager, auth_headers: dict[str, str]
+    client: FlaskClient, pantry_mgr: PantryManager, auth_headers: AuthHeaderFactory
 ) -> None:
     """A valid add returns 201 and persists the item."""
     with patch.dict(os.environ, SECRET_ENV):
@@ -284,7 +336,7 @@ def test_stock_add_creates_item(
     ],
 )
 def test_stock_add_requires_item_and_category(
-    client: FlaskClient, auth_headers: dict[str, str], body: dict[str, Any]
+    client: FlaskClient, auth_headers: AuthHeaderFactory, body: dict[str, Any]
 ) -> None:
     """Missing item or category is a 400."""
     with patch.dict(os.environ, SECRET_ENV):
@@ -293,7 +345,7 @@ def test_stock_add_requires_item_and_category(
 
 
 def test_stock_add_rejects_unknown_category(
-    client: FlaskClient, auth_headers: dict[str, str]
+    client: FlaskClient, auth_headers: AuthHeaderFactory
 ) -> None:
     """A category outside IngredientCategory is a 400."""
     with patch.dict(os.environ, SECRET_ENV):
@@ -309,7 +361,7 @@ def test_stock_add_rejects_unknown_category(
 def test_stock_add_duplicate_conflict(
     client: FlaskClient,
     pantry_mgr: PantryManager,
-    auth_headers: dict[str, str],
+    auth_headers: AuthHeaderFactory,
     sample_item: InventoryItem,
 ) -> None:
     """Adding an already-tracked ingredient is a 409."""
@@ -332,7 +384,7 @@ def test_stock_add_duplicate_conflict(
 def test_restock_clear_empties_queue(
     client: FlaskClient,
     pantry_mgr: PantryManager,
-    auth_headers: dict[str, str],
+    auth_headers: AuthHeaderFactory,
     sample_item: InventoryItem,
 ) -> None:
     """Clearing the restock queue moves low/out items back to on_hand."""
@@ -376,7 +428,7 @@ def _recipe_body(**overrides: Any) -> dict[str, Any]:
 
 
 def test_recipes_save_persists_recipe(
-    client: FlaskClient, recipe_store: RecipeStore, auth_headers: dict[str, str]
+    client: FlaskClient, recipe_store: RecipeStore, auth_headers: AuthHeaderFactory
 ) -> None:
     """A valid save returns 201 and persists purchase + pantry splits."""
     with patch.dict(os.environ, SECRET_ENV):
@@ -393,7 +445,7 @@ def test_recipes_save_persists_recipe(
 def test_recipes_save_duplicate_conflict(
     client: FlaskClient,
     recipe_store: RecipeStore,
-    auth_headers: dict[str, str],
+    auth_headers: AuthHeaderFactory,
     sample_meal: ParsedMeal,
 ) -> None:
     """Saving a recipe whose name already exists is a 409."""
@@ -422,7 +474,7 @@ def test_recipes_save_duplicate_conflict(
     ],
 )
 def test_recipes_save_requires_name_and_ingredients(
-    client: FlaskClient, auth_headers: dict[str, str], body: dict[str, Any]
+    client: FlaskClient, auth_headers: AuthHeaderFactory, body: dict[str, Any]
 ) -> None:
     """Missing name or ingredients is a 400."""
     with patch.dict(os.environ, SECRET_ENV):
@@ -435,7 +487,7 @@ def test_recipes_save_requires_name_and_ingredients(
     ["penne", [{"ingredient": "penne"}], [42]],
 )
 def test_recipes_save_rejects_invalid_ingredients(
-    client: FlaskClient, auth_headers: dict[str, str], ingredients: Any
+    client: FlaskClient, auth_headers: AuthHeaderFactory, ingredients: Any
 ) -> None:
     """Non-list or non-Ingredient payloads are a 400."""
     with patch.dict(os.environ, SECRET_ENV):
@@ -450,7 +502,7 @@ def test_recipes_save_rejects_invalid_ingredients(
 
 @pytest.mark.parametrize("servings", ["four", 0, -2, True])
 def test_recipes_save_rejects_bad_servings(
-    client: FlaskClient, auth_headers: dict[str, str], servings: Any
+    client: FlaskClient, auth_headers: AuthHeaderFactory, servings: Any
 ) -> None:
     """A non-positive-int servings override is a 400."""
     with patch.dict(os.environ, SECRET_ENV):
@@ -464,7 +516,7 @@ def test_recipes_save_rejects_bad_servings(
 
 
 def test_recipes_save_honors_servings(
-    client: FlaskClient, recipe_store: RecipeStore, auth_headers: dict[str, str]
+    client: FlaskClient, recipe_store: RecipeStore, auth_headers: AuthHeaderFactory
 ) -> None:
     """An explicit servings override is persisted."""
     with patch.dict(os.environ, SECRET_ENV):
@@ -485,23 +537,29 @@ def test_recipes_save_honors_servings(
 def test_recipes_delete_removes_recipe(
     client: FlaskClient,
     recipe_store: RecipeStore,
-    auth_headers: dict[str, str],
+    auth_headers: AuthHeaderFactory,
     sample_meal: ParsedMeal,
 ) -> None:
     """Deleting an existing recipe returns 204 and removes it."""
     recipe_id = recipe_store.save_recipe(sample_meal)
+    recipe_path = f"/api/v1/recipes/{recipe_id}"
     with patch.dict(os.environ, SECRET_ENV):
-        response = client.delete(f"/api/v1/recipes/{recipe_id}", headers=auth_headers)
+        response = client.delete(
+            recipe_path, headers=auth_headers("DELETE", recipe_path)
+        )
     assert response.status_code == 204
     assert response.data == b""
     assert recipe_store.get_recipe_by_id(recipe_id) is None
 
 
 def test_recipes_delete_unknown_404(
-    client: FlaskClient, auth_headers: dict[str, str]
+    client: FlaskClient, auth_headers: AuthHeaderFactory
 ) -> None:
     """Deleting an unknown recipe id is a JSON 404."""
     with patch.dict(os.environ, SECRET_ENV):
-        response = client.delete("/api/v1/recipes/999", headers=auth_headers)
+        response = client.delete(
+            "/api/v1/recipes/999",
+            headers=auth_headers("DELETE", "/api/v1/recipes/999"),
+        )
     assert response.status_code == 404
     assert "error" in response.get_json()

--- a/tests/test_app_boundary.py
+++ b/tests/test_app_boundary.py
@@ -39,9 +39,10 @@ if TYPE_CHECKING:
     from flask.testing import FlaskClient
 
 from grocery_butler.app import create_app
-from grocery_butler.auth_middleware import SECRET_ENV_VAR, mint_token
+from grocery_butler.auth_middleware import SECRET_ENV_VAR
 from grocery_butler.models import IngredientCategory, InventoryItem, InventoryStatus
 from grocery_butler.pantry_manager import PantryManager
+from tests.conftest import bearer_header
 
 #: A source address outside every default and custom-CIDR range used below.
 PUBLIC_ADDR = "203.0.113.7"
@@ -188,6 +189,10 @@ def seeded_item(app: Flask, pantry_mgr: PantryManager) -> InventoryItem:
 def auth_headers(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
     """Return a valid Authorization header minted with a test shared secret.
 
+    Bound to a bodyless ``GET /api/v1/inventory`` -- the only request
+    this fixture is ever attached to in this module (issue #74: bearer
+    tokens are now bound to their exact method/path/body).
+
     Args:
         monkeypatch: Pytest's monkeypatch fixture.
 
@@ -196,8 +201,7 @@ def auth_headers(monkeypatch: pytest.MonkeyPatch) -> dict[str, str]:
         ``TEST_SECRET``.
     """
     monkeypatch.setenv(SECRET_ENV_VAR, TEST_SECRET)
-    token = mint_token("rubotpaul")
-    return {"Authorization": f"Bearer {token}"}
+    return bearer_header("rubotpaul", "GET", "/api/v1/inventory")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_auth_middleware.py
+++ b/tests/test_auth_middleware.py
@@ -1,8 +1,20 @@
-"""Tests for the vendored RubotPaul HMAC bearer auth middleware."""
+"""Tests for the vendored RubotPaul HMAC bearer auth middleware.
+
+Issue #74: tokens are now bound to the exact request they authorize
+(method + path + body hash) via ``RequestBinding``, closing the replay
+window where a token minted for one endpoint/body could be reused
+against any other endpoint within its 5-minute TTL. These tests specify
+that contract; until ``RequestBinding`` and the new ``mint_token`` /
+``_verify_token`` / ``require_bearer`` signatures exist in
+``grocery_butler.auth_middleware``, this module fails to even import
+(the correct Gate 1 RED state for issue #74).
+"""
 
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import hmac
 import os
 import sys
 from types import SimpleNamespace
@@ -10,13 +22,14 @@ from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import patch
 
 import pytest
-from flask import Flask
+from flask import Flask, request
 
 from grocery_butler.auth_middleware import (
     MAX_TOKEN_AGE_SECONDS,
     MAX_TOKEN_FUTURE_SKEW_SECONDS,
     SECRET_ENV_VAR,
     AuthError,
+    RequestBinding,
     _verify_token,
     aiohttp_auth_middleware,
     mint_token,
@@ -32,6 +45,10 @@ TEST_SECRET = "test-shared-secret"
 SECRET_ENV = {SECRET_ENV_VAR: TEST_SECRET}
 NOW = 1_700_000_000.0
 
+#: The binding used by most round-trip tests: a bodyless GET to the
+#: canonical read endpoint that the Flask fixture app protects.
+DEFAULT_BINDING = RequestBinding.of("GET", "/protected", b"")
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -39,43 +56,103 @@ NOW = 1_700_000_000.0
 
 @pytest.fixture()
 def app() -> Flask:
-    """Create a minimal Flask app with one bearer-protected route."""
+    """Create a minimal Flask app with bearer-protected GET and POST routes.
+
+    Returns:
+        A Flask app with a bodyless ``GET /protected`` route and a
+        JSON-body ``POST /protected-post`` route, both guarded by
+        ``require_bearer()``.
+    """
     application = Flask(__name__)
     application.config["TESTING"] = True
 
     @application.get("/protected")
     def protected() -> dict[str, str]:
+        """Return the caller_id for a valid bodyless bearer request."""
         caller_id = require_bearer()
         return {"caller_id": caller_id}
+
+    @application.post("/protected-post")
+    def protected_post() -> dict[str, Any]:
+        """Return the caller_id and echoed JSON body for a bound POST.
+
+        Proves the request body is still readable by the view after
+        ``require_bearer()`` has already consumed it via
+        ``request.get_data()`` to compute the binding.
+        """
+        caller_id = require_bearer()
+        body = request.get_json(silent=True) or {}
+        return {"caller_id": caller_id, "echo": body}
 
     return application
 
 
 @pytest.fixture()
 def client(app: Flask) -> FlaskClient:
-    """Return a Flask test client for the protected app."""
+    """Return a Flask test client for the protected app.
+
+    Args:
+        app: The fixture Flask application.
+
+    Returns:
+        A Flask test client bound to ``app``.
+    """
     return app.test_client()
 
 
-def _fake_aiohttp_request(headers: dict[str, str]) -> Any:
-    """Build a minimal stand-in for an aiohttp request."""
+def _fake_aiohttp_request(
+    headers: dict[str, str],
+    *,
+    method: str = "GET",
+    path: str = "/",
+    body: bytes = b"",
+) -> Any:
+    """Build a minimal stand-in for an aiohttp request.
+
+    Args:
+        headers: Header mapping the fake request exposes.
+        method: HTTP method the fake request reports.
+        path: Request path the fake request reports.
+        body: Raw bytes returned by the fake request's async ``read()``.
+
+    Returns:
+        An object duck-typing the subset of ``aiohttp.web.Request`` the
+        middleware relies on: ``headers``, ``method``, ``path``,
+        ``__setitem__``, and an async ``read()``.
+    """
 
     class FakeRequest:
+        """Duck-typed aiohttp request stand-in."""
+
         def __init__(self) -> None:
+            """Store the fake request's headers, method, path, and body."""
             self.headers = headers
+            self.method = method
+            self.path = path
             self.state: dict[str, str] = {}
+            self._body = body
 
         def __setitem__(self, key: str, value: str) -> None:
+            """Stash a value on the fake request, mirroring aiohttp."""
             self.state[key] = value
+
+        async def read(self) -> bytes:
+            """Return the fake request's raw body bytes."""
+            return self._body
 
     return FakeRequest()
 
 
 @pytest.fixture()
 def fake_aiohttp(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Install a stub aiohttp module so the middleware can import it."""
+    """Install a stub aiohttp module so the middleware can import it.
+
+    Args:
+        monkeypatch: Pytest's monkeypatch fixture.
+    """
 
     def json_response(payload: dict[str, str], status: int = 200) -> SimpleNamespace:
+        """Return a stand-in for ``aiohttp.web.json_response``."""
         return SimpleNamespace(payload=payload, status=status)
 
     web = SimpleNamespace(json_response=json_response)
@@ -106,22 +183,56 @@ class TestAuthError:
 
 
 # ---------------------------------------------------------------------------
+# RequestBinding
+# ---------------------------------------------------------------------------
+
+
+class TestRequestBinding:
+    """Tests for the RequestBinding value object."""
+
+    def test_of_stores_method_and_path_verbatim(self) -> None:
+        """``.of`` stores method and path exactly as given, uncanonicalized."""
+        binding = RequestBinding.of("get", "/api/v1/inventory", b"")
+        assert binding.method == "get"
+        assert binding.path == "/api/v1/inventory"
+
+    def test_of_hashes_body_with_sha256(self) -> None:
+        """``.of`` stores the hex SHA-256 digest of the given body bytes."""
+        body = b'{"a": 1}'
+        binding = RequestBinding.of("POST", "/api/v1/actions/confirm", body)
+        assert binding.body_sha256 == hashlib.sha256(body).hexdigest()
+
+    def test_of_empty_body_hashes_empty_bytes(self) -> None:
+        """An empty body hashes to SHA-256 of the empty byte string."""
+        binding = RequestBinding.of("GET", "/protected", b"")
+        assert binding.body_sha256 == hashlib.sha256(b"").hexdigest()
+
+    def test_is_frozen(self) -> None:
+        """RequestBinding instances are immutable (frozen dataclass)."""
+        binding = RequestBinding.of("GET", "/protected", b"")
+        with pytest.raises(AttributeError):
+            # Issue #74: intentional illegal write to prove runtime
+            # immutability of the frozen dataclass; mypy rightly flags it.
+            binding.method = "POST"  # type: ignore[misc]  # Issue #74
+
+
+# ---------------------------------------------------------------------------
 # mint_token / _verify_token round-trip
 # ---------------------------------------------------------------------------
 
 
 @patch.dict(os.environ, SECRET_ENV, clear=True)
 class TestTokenRoundTrip:
-    """Tests for minting and verifying tokens."""
+    """Tests for minting and verifying request-bound tokens."""
 
     def test_valid_token_returns_caller_id(self) -> None:
-        """A freshly minted token verifies and yields the caller_id."""
-        token = mint_token("rubotpaul", now=NOW)
-        assert _verify_token(token, now=NOW) == "rubotpaul"
+        """A freshly minted token verifies against its own binding."""
+        token = mint_token("rubotpaul", DEFAULT_BINDING, now=NOW)
+        assert _verify_token(token, DEFAULT_BINDING, now=NOW) == "rubotpaul"
 
     def test_token_has_three_dot_separated_parts(self) -> None:
         """Minted tokens follow <caller_id>.<timestamp>.<hmac_hex>."""
-        token = mint_token("rubotpaul", now=NOW)
+        token = mint_token("rubotpaul", DEFAULT_BINDING, now=NOW)
         caller_id, ts, sig = token.split(".")
         assert caller_id == "rubotpaul"
         assert ts == str(int(NOW))
@@ -129,64 +240,186 @@ class TestTokenRoundTrip:
 
     def test_token_at_max_age_is_accepted(self) -> None:
         """A token exactly MAX_TOKEN_AGE_SECONDS old is still valid."""
-        token = mint_token("rubotpaul", now=NOW)
-        assert _verify_token(token, now=NOW + MAX_TOKEN_AGE_SECONDS) == "rubotpaul"
+        token = mint_token("rubotpaul", DEFAULT_BINDING, now=NOW)
+        assert (
+            _verify_token(token, DEFAULT_BINDING, now=NOW + MAX_TOKEN_AGE_SECONDS)
+            == "rubotpaul"
+        )
 
     def test_expired_token_rejected(self) -> None:
         """A token older than MAX_TOKEN_AGE_SECONDS is rejected."""
-        token = mint_token("rubotpaul", now=NOW)
+        token = mint_token("rubotpaul", DEFAULT_BINDING, now=NOW)
         with pytest.raises(AuthError, match="token expired") as excinfo:
-            _verify_token(token, now=NOW + MAX_TOKEN_AGE_SECONDS + 1)
+            _verify_token(token, DEFAULT_BINDING, now=NOW + MAX_TOKEN_AGE_SECONDS + 1)
         assert excinfo.value.status == 401
 
     def test_token_at_max_future_skew_is_accepted(self) -> None:
         """A token exactly MAX_TOKEN_FUTURE_SKEW_SECONDS ahead is tolerated."""
-        token = mint_token("rubotpaul", now=NOW + MAX_TOKEN_FUTURE_SKEW_SECONDS)
-        assert _verify_token(token, now=NOW) == "rubotpaul"
+        token = mint_token(
+            "rubotpaul", DEFAULT_BINDING, now=NOW + MAX_TOKEN_FUTURE_SKEW_SECONDS
+        )
+        assert _verify_token(token, DEFAULT_BINDING, now=NOW) == "rubotpaul"
 
     def test_token_from_future_rejected(self) -> None:
         """A token more than MAX_TOKEN_FUTURE_SKEW_SECONDS ahead is rejected."""
-        token = mint_token("rubotpaul", now=NOW + MAX_TOKEN_FUTURE_SKEW_SECONDS + 1)
+        token = mint_token(
+            "rubotpaul", DEFAULT_BINDING, now=NOW + MAX_TOKEN_FUTURE_SKEW_SECONDS + 1
+        )
         with pytest.raises(AuthError, match="token from future"):
-            _verify_token(token, now=NOW)
+            _verify_token(token, DEFAULT_BINDING, now=NOW)
 
     def test_defaults_to_current_time(self) -> None:
         """Without an explicit now, mint and verify use the wall clock."""
-        token = mint_token("rubotpaul")
-        assert _verify_token(token) == "rubotpaul"
+        token = mint_token("rubotpaul", DEFAULT_BINDING)
+        assert _verify_token(token, DEFAULT_BINDING) == "rubotpaul"
 
     @pytest.mark.parametrize("token", ["", "no-dots", "one.dot", "a.b.c.d"])
     def test_malformed_token_rejected(self, token: str) -> None:
         """Tokens without exactly three dot-separated parts are rejected."""
         with pytest.raises(AuthError, match="malformed token"):
-            _verify_token(token, now=NOW)
+            _verify_token(token, DEFAULT_BINDING, now=NOW)
 
     def test_malformed_timestamp_rejected(self) -> None:
         """A non-integer timestamp is rejected."""
         with pytest.raises(AuthError, match="malformed timestamp"):
-            _verify_token("rubotpaul.not-a-number.deadbeef", now=NOW)
+            _verify_token("rubotpaul.not-a-number.deadbeef", DEFAULT_BINDING, now=NOW)
 
     def test_bad_signature_rejected(self) -> None:
         """A tampered signature is rejected."""
-        token = mint_token("rubotpaul", now=NOW)
+        token = mint_token("rubotpaul", DEFAULT_BINDING, now=NOW)
         caller_id, ts, sig = token.split(".")
         tampered_sig = ("0" if sig[0] != "0" else "1") + sig[1:]
         with pytest.raises(AuthError, match="bad signature"):
-            _verify_token(f"{caller_id}.{ts}.{tampered_sig}", now=NOW)
+            _verify_token(f"{caller_id}.{ts}.{tampered_sig}", DEFAULT_BINDING, now=NOW)
 
     def test_tampered_caller_id_rejected(self) -> None:
         """Changing the caller_id invalidates the signature."""
-        token = mint_token("rubotpaul", now=NOW)
+        token = mint_token("rubotpaul", DEFAULT_BINDING, now=NOW)
         _, ts, sig = token.split(".")
         with pytest.raises(AuthError, match="bad signature"):
-            _verify_token(f"impostor.{ts}.{sig}", now=NOW)
+            _verify_token(f"impostor.{ts}.{sig}", DEFAULT_BINDING, now=NOW)
 
     def test_token_minted_with_other_secret_rejected(self) -> None:
         """A token signed with a different secret is rejected."""
         with patch.dict(os.environ, {SECRET_ENV_VAR: "other-secret"}):
-            token = mint_token("rubotpaul", now=NOW)
+            token = mint_token("rubotpaul", DEFAULT_BINDING, now=NOW)
         with pytest.raises(AuthError, match="bad signature"):
-            _verify_token(token, now=NOW)
+            _verify_token(token, DEFAULT_BINDING, now=NOW)
+
+
+# ---------------------------------------------------------------------------
+# AC#1: a token bound to one request is rejected for a different request
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, SECRET_ENV, clear=True)
+class TestRequestBindingMismatch:
+    """A token's signature is invalid for any request it wasn't minted for."""
+
+    def test_read_token_replayed_against_destructive_endpoint_rejected(self) -> None:
+        """AC#1: a GET /inventory token is rejected for POST /actions/confirm.
+
+        This is the headline vulnerability issue #74 closes: previously
+        an unbound token minted for a harmless read endpoint could be
+        replayed against any destructive endpoint within its 5-minute
+        TTL.
+        """
+        read_binding = RequestBinding.of("GET", "/api/v1/inventory", b"")
+        token = mint_token("rubotpaul", read_binding, now=NOW)
+
+        confirm_binding = RequestBinding.of(
+            "POST", "/api/v1/actions/confirm", b'{"action_id": "x"}'
+        )
+        with pytest.raises(AuthError, match="bad signature"):
+            _verify_token(token, confirm_binding, now=NOW)
+
+    def test_method_only_mismatch_rejected(self) -> None:
+        """Changing only the method invalidates the signature."""
+        token = mint_token(
+            "rubotpaul", RequestBinding.of("GET", "/protected", b""), now=NOW
+        )
+        with pytest.raises(AuthError, match="bad signature"):
+            _verify_token(token, RequestBinding.of("POST", "/protected", b""), now=NOW)
+
+    def test_path_only_mismatch_rejected(self) -> None:
+        """Changing only the path invalidates the signature."""
+        token = mint_token(
+            "rubotpaul", RequestBinding.of("GET", "/protected", b""), now=NOW
+        )
+        with pytest.raises(AuthError, match="bad signature"):
+            _verify_token(token, RequestBinding.of("GET", "/other", b""), now=NOW)
+
+    def test_body_only_mismatch_rejected(self) -> None:
+        """Changing a single byte of the body invalidates the signature."""
+        token = mint_token(
+            "rubotpaul",
+            RequestBinding.of("POST", "/protected", b"payload-a"),
+            now=NOW,
+        )
+        with pytest.raises(AuthError, match="bad signature"):
+            _verify_token(
+                token,
+                RequestBinding.of("POST", "/protected", b"payload-b"),
+                now=NOW,
+            )
+
+    def test_empty_body_distinguished_from_nonempty_body(self) -> None:
+        """A token minted for an empty body is rejected for a non-empty one."""
+        token = mint_token(
+            "rubotpaul", RequestBinding.of("POST", "/protected", b""), now=NOW
+        )
+        with pytest.raises(AuthError, match="bad signature"):
+            _verify_token(
+                token,
+                RequestBinding.of("POST", "/protected", b"not-empty"),
+                now=NOW,
+            )
+
+    def test_method_case_insensitive_at_verification(self) -> None:
+        """Method casing is canonicalized to uppercase in the signing payload.
+
+        Minting against a lowercase method and verifying against the
+        uppercase form of the same method (as Flask/aiohttp always
+        report it) must succeed -- the wire format never transmits the
+        method, so canonicalization has to happen identically on both
+        sides.
+        """
+        token = mint_token(
+            "rubotpaul", RequestBinding.of("get", "/protected", b""), now=NOW
+        )
+        assert (
+            _verify_token(token, RequestBinding.of("GET", "/protected", b""), now=NOW)
+            == "rubotpaul"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Legacy (unbound) tokens are rejected outright
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, SECRET_ENV, clear=True)
+class TestLegacyTokenRejected:
+    """Pre-issue-74 unbound tokens must be rejected, with no compatibility flag."""
+
+    def test_legacy_signature_scheme_rejected(self) -> None:
+        """A hand-crafted legacy-format token fails signature verification.
+
+        The legacy scheme signed only ``f"{caller_id}.{ts}"`` with no
+        method/path/body binding at all. This is a hard cutover: there
+        is no environment flag to keep accepting it.
+        """
+        caller_id = "rubotpaul"
+        ts = int(NOW)
+        legacy_sig = hmac.new(
+            TEST_SECRET.encode(),
+            f"{caller_id}.{ts}".encode(),
+            hashlib.sha256,
+        ).hexdigest()
+        legacy_token = f"{caller_id}.{ts}.{legacy_sig}"
+
+        with pytest.raises(AuthError, match="bad signature"):
+            _verify_token(legacy_token, DEFAULT_BINDING, now=NOW)
 
 
 # ---------------------------------------------------------------------------
@@ -201,23 +434,23 @@ class TestMissingSecret:
     def test_mint_token_raises_when_secret_unset(self) -> None:
         """mint_token fails loud when the shared secret is not set."""
         with pytest.raises(RuntimeError, match=SECRET_ENV_VAR):
-            mint_token("rubotpaul", now=NOW)
+            mint_token("rubotpaul", DEFAULT_BINDING, now=NOW)
 
     @patch.dict(os.environ, {SECRET_ENV_VAR: ""}, clear=True)
     def test_mint_token_raises_when_secret_empty(self) -> None:
         """mint_token treats an empty shared secret as unset."""
         with pytest.raises(RuntimeError, match=SECRET_ENV_VAR):
-            mint_token("rubotpaul", now=NOW)
+            mint_token("rubotpaul", DEFAULT_BINDING, now=NOW)
 
     def test_verify_token_raises_when_secret_unset(self) -> None:
         """_verify_token fails loud when the shared secret is not set."""
         with patch.dict(os.environ, SECRET_ENV, clear=True):
-            token = mint_token("rubotpaul", now=NOW)
+            token = mint_token("rubotpaul", DEFAULT_BINDING, now=NOW)
         with (
             patch.dict(os.environ, {}, clear=True),
             pytest.raises(RuntimeError, match=SECRET_ENV_VAR),
         ):
-            _verify_token(token, now=NOW)
+            _verify_token(token, DEFAULT_BINDING, now=NOW)
 
 
 # ---------------------------------------------------------------------------
@@ -227,7 +460,12 @@ class TestMissingSecret:
 
 @patch.dict(os.environ, SECRET_ENV, clear=True)
 class TestRequireBearerFlask:
-    """Tests for require_bearer via a minimal Flask app."""
+    """Tests for require_bearer via a minimal Flask app.
+
+    ``require_bearer()`` takes no arguments -- it builds the
+    ``RequestBinding`` itself from the live Flask ``request`` (method,
+    path, and raw body bytes).
+    """
 
     def test_missing_header_returns_401(self, client: FlaskClient) -> None:
         """Requests without an Authorization header get 401."""
@@ -253,7 +491,7 @@ class TestRequireBearerFlask:
 
     def test_bad_signature_returns_401(self, client: FlaskClient) -> None:
         """A well-formed token with a bad signature gets 401."""
-        token = mint_token("rubotpaul")
+        token = mint_token("rubotpaul", DEFAULT_BINDING)
         caller_id, ts, sig = token.split(".")
         tampered = f"{caller_id}.{ts}.{'0' * len(sig)}"
         response = client.get(
@@ -267,7 +505,7 @@ class TestRequireBearerFlask:
         import time
 
         stale = time.time() - MAX_TOKEN_AGE_SECONDS - 60
-        token = mint_token("rubotpaul", now=stale)
+        token = mint_token("rubotpaul", DEFAULT_BINDING, now=stale)
         response = client.get(
             "/protected", headers={"Authorization": f"Bearer {token}"}
         )
@@ -275,13 +513,51 @@ class TestRequireBearerFlask:
         assert b"token expired" in response.data
 
     def test_valid_token_returns_caller_id(self, client: FlaskClient) -> None:
-        """A valid token passes and the view receives the caller_id."""
-        token = mint_token("rubotpaul")
+        """A valid bodyless GET token passes and the view gets the caller_id."""
+        token = mint_token("rubotpaul", DEFAULT_BINDING)
         response = client.get(
             "/protected", headers={"Authorization": f"Bearer {token}"}
         )
         assert response.status_code == 200
         assert response.get_json() == {"caller_id": "rubotpaul"}
+
+    def test_valid_bound_post_token_passes_and_body_still_readable(
+        self, client: FlaskClient
+    ) -> None:
+        """A token bound to the exact POST body succeeds; the view reads it.
+
+        Confirms ``require_bearer()`` reading ``request.get_data()`` to
+        build the binding does not consume the body stream out from
+        under the view -- ``request.get_json()`` still works afterward.
+        """
+        body = b'{"greeting": "hi"}'
+        binding = RequestBinding.of("POST", "/protected-post", body)
+        token = mint_token("rubotpaul", binding)
+        response = client.post(
+            "/protected-post",
+            data=body,
+            content_type="application/json",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 200
+        assert response.get_json() == {
+            "caller_id": "rubotpaul",
+            "echo": {"greeting": "hi"},
+        }
+
+    def test_token_bound_to_different_route_returns_401(
+        self, client: FlaskClient
+    ) -> None:
+        """A token minted for GET /protected is rejected on the POST route."""
+        token = mint_token("rubotpaul", DEFAULT_BINDING)
+        response = client.post(
+            "/protected-post",
+            data=b"{}",
+            content_type="application/json",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert response.status_code == 401
+        assert b"bad signature" in response.data
 
 
 # ---------------------------------------------------------------------------
@@ -292,16 +568,43 @@ class TestRequireBearerFlask:
 @patch.dict(os.environ, SECRET_ENV, clear=True)
 @pytest.mark.usefixtures("fake_aiohttp")
 class TestAiohttpMiddleware:
-    """Tests for the aiohttp middleware using a stub aiohttp module."""
+    """Tests for the aiohttp middleware using a stub aiohttp module.
+
+    The middleware builds its ``RequestBinding`` from
+    ``request.method``, ``request.path``, and ``await request.read()``.
+    """
 
     @staticmethod
     async def _handler(request: Any) -> str:
+        """Return a fixed sentinel proving the wrapped handler ran."""
         return "handled"
 
-    def _run(self, headers: dict[str, str]) -> tuple[Any, Any]:
-        request = _fake_aiohttp_request(headers)
+    def _run(
+        self,
+        headers: dict[str, str],
+        *,
+        method: str = "GET",
+        path: str = "/",
+        body: bytes = b"",
+    ) -> tuple[Any, Any]:
+        """Run the middleware against one fake request; return (result, request).
+
+        Args:
+            headers: Header mapping for the fake request.
+            method: HTTP method the fake request reports.
+            path: Path the fake request reports.
+            body: Raw body bytes the fake request's ``read()`` returns.
+
+        Returns:
+            A tuple of the middleware's return value and the fake
+            request object it was given (so tests can inspect stashed
+            state).
+        """
+        fake_request = _fake_aiohttp_request(
+            headers, method=method, path=path, body=body
+        )
         middleware = asyncio.run(aiohttp_auth_middleware(None, self._handler))
-        return asyncio.run(middleware(request)), request
+        return asyncio.run(middleware(fake_request)), fake_request
 
     def test_missing_header_returns_401(self) -> None:
         """Requests without a bearer header get a 401 JSON response."""
@@ -316,8 +619,44 @@ class TestAiohttpMiddleware:
         assert response.payload == {"error": "malformed token"}
 
     def test_valid_token_calls_handler_and_sets_caller_id(self) -> None:
-        """Valid tokens reach the handler and stash caller_id on the request."""
-        token = mint_token("rubotpaul")
-        response, request = self._run({"Authorization": f"Bearer {token}"})
+        """A token bound to the exact fake request reaches the handler.
+
+        The caller_id is stashed on the request for the wrapped handler.
+        """
+        binding = RequestBinding.of("GET", "/", b"")
+        token = mint_token("rubotpaul", binding)
+        response, fake_request = self._run(
+            {"Authorization": f"Bearer {token}"}, method="GET", path="/", body=b""
+        )
         assert response == "handled"
-        assert request.state["caller_id"] == "rubotpaul"
+        assert fake_request.state["caller_id"] == "rubotpaul"
+
+    def test_valid_token_with_body_binds_on_read_bytes(self) -> None:
+        """A token bound to a specific body succeeds when read() matches."""
+        body = b'{"k": "v"}'
+        binding = RequestBinding.of("POST", "/webhook", body)
+        token = mint_token("rubotpaul", binding)
+        response, _ = self._run(
+            {"Authorization": f"Bearer {token}"},
+            method="POST",
+            path="/webhook",
+            body=body,
+        )
+        assert response == "handled"
+
+    def test_cross_endpoint_replay_rejected(self) -> None:
+        """A token minted for one path is rejected when replayed on another.
+
+        This is the aiohttp-side mirror of AC#1: a token bound to
+        ``GET /`` must not authorize a different endpoint.
+        """
+        binding = RequestBinding.of("GET", "/", b"")
+        token = mint_token("rubotpaul", binding)
+        response, _ = self._run(
+            {"Authorization": f"Bearer {token}"},
+            method="POST",
+            path="/webhook",
+            body=b'{"attack": true}',
+        )
+        assert response.status == 401
+        assert response.payload == {"error": "bad signature"}

--- a/tests/test_deployment_wiring.py
+++ b/tests/test_deployment_wiring.py
@@ -25,7 +25,8 @@ if TYPE_CHECKING:
     from flask.testing import FlaskClient
 
 from grocery_butler.app import create_app
-from grocery_butler.auth_middleware import SECRET_ENV_VAR, mint_token
+from grocery_butler.auth_middleware import SECRET_ENV_VAR
+from tests.conftest import bearer_header
 
 TEST_SECRET = "test-shared-secret"
 
@@ -77,11 +78,8 @@ class TestSingleProcessServesBothSurfaces:
         assert html_response.status_code == 200
         assert "text/html" in html_response.content_type
 
-        token = mint_token("rubotpaul")
-        api_response = client.get(
-            "/api/v1/inventory",
-            headers={"Authorization": f"Bearer {token}"},
-        )
+        headers = bearer_header("rubotpaul", "GET", "/api/v1/inventory")
+        api_response = client.get("/api/v1/inventory", headers=headers)
         assert api_response.status_code == 200
         assert api_response.is_json
         assert api_response.get_json() == {"items": []}


### PR DESCRIPTION
## Summary

- **Bind every HMAC bearer token to its exact request** (AC1): a new frozen `RequestBinding` (method, path, SHA-256 of body) is signed into the token via a NUL-delimited payload; method is canonicalized to uppercase in the signature only. A token minted for `GET /api/v1/inventory` now fails with `bad signature` against `POST /api/v1/actions/confirm`. Legacy unbound tokens are hard-rejected — no compatibility flag (RubotPaul must mint with the new bound `mint_token(caller_id, binding)`; wire format `<caller_id>.<ts>.<hmac_hex>` is unchanged).
- **Auth by default on the `api_v1` blueprint** (AC2): a `before_request` hook with an explicit (empty) `_AUTH_EXEMPT_ENDPOINTS` seam is now the single enforcement point; the 20 per-route `require_bearer()` calls were removed. A test registers a route that never calls `require_bearer()` and proves the hook still 401s it. `/health` is app-level and unaffected; the tailnet `network_guard` ordering is unchanged.
- **Replay/second-factor posture documented as an explicit decision** (AC3) in the `auth_middleware` module docstring: cross-endpoint replay CLOSED; same-request replay within the 5-min TTL ACCEPTED (mitigated by the pending-action state machine — 409 on re-confirm — and the `action_id` Safeway idempotency key); a distinct confirm credential is DEFERRED (the product-level stage → human chat review → confirm flow is the operative second factor; a true human-held second factor is follow-up work).
- Whole test suite converted to per-request bound tokens: shared `tests/conftest.py::bearer_header` helper, per-request `auth_headers` factories, and an e2e `signed_request` fixture that serializes each JSON body exactly once so the transmitted bytes and the signed hash always match.

Security review notes (non-blocking, flagged for awareness): `caller_id` is logged unsanitized after successful verification (only a secret-holder can reach that line; cheap hardening candidate), and the aiohttp middleware has no auth logging parity with the Flask path. `RequestBinding` deliberately excludes the query string — no current route reads `request.args`; revisit if query-driven routes are added.

## Test plan

- `./scripts/check-all.sh` — exit 0 (lint, format, mypy strict, bandit + pip-audit, complexity, unit tests, coverage).
- 1615 tests passing, 10 pre-existing Postgres skips; branch coverage 96.08% (threshold 90%); `auth_middleware.py` at 98%.
- AC1 pinned at three levels: unit (`_verify_token` rejects any method/path/body mismatch, incl. GET-inventory→POST-confirm replay), aiohttp middleware mirror, and full-stack Flask (`TestCrossEndpointTokenReplayRejected` — also asserts the staged action stays `PENDING`, no side effects on rejected replay).
- AC2 pinned by `TestAuthByDefault`: an unguarded throwaway view on the real blueprint 401s unauthenticated and 200s with a correctly bound token.
- Legacy-token hard cutover pinned by `TestLegacyTokenRejected` (hand-crafted old-scheme signature → `bad signature`).
- e2e suite (26 tests) converted and green with per-request bound tokens.

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)
