### PR TITLE
fix(api): JSON error contract for /api/v1 (404/405/500) and scrub internal detail from error bodies

### DIFF
--- a/grocery_butler/api.py
+++ b/grocery_butler/api.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import dataclasses
 import datetime as dt
+import logging
 import os
 import uuid
 from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
@@ -53,10 +54,35 @@ if TYPE_CHECKING:
 
     from grocery_butler.models import PendingAction
 
+logger = logging.getLogger(__name__)
+
 api_v1 = Blueprint("api_v1", __name__, url_prefix="/api/v1")
 
 #: How long a staged destructive action stays confirmable.
 CONFIRMATION_TTL = dt.timedelta(minutes=5)
+
+# ---------------------------------------------------------------------------
+# Sanitized error messages (Issue #77)
+#
+# These sites can be reached with internal exception/config detail in the
+# message (env var names, vendor error text, stack-trace fragments). The
+# response body must stay terse and stable; the raw detail is logged
+# server-side instead so operators keep it without leaking it to clients.
+# ---------------------------------------------------------------------------
+_SAFEWAY_PIPELINE_UNAVAILABLE_MESSAGE = "safeway pipeline unavailable"
+_CART_BUILD_FAILED_MESSAGE = "cart build failed"
+_ORDER_CONFIG_INVALID_MESSAGE = "order configuration invalid"
+_ORDER_SUBMISSION_FAILED_MESSAGE = "order submission failed"
+
+#: Terse, stable "error" text for each mapped OrderOutcome status string
+#: (see ``_OUTCOME_RESPONSES`` below). Replaces the raw ``error_message``
+#: from the OrderResult, which is logged but never relayed verbatim.
+_OUTCOME_ERROR_MESSAGES: dict[str, str] = {
+    "unknown": (
+        "order outcome unknown — do not resubmit; verify recent Safeway orders"
+    ),
+    "duplicate_prevented": "a recent identical submission is pending or completed",
+}
 
 
 @api_v1.errorhandler(400)
@@ -291,17 +317,26 @@ def post_shopping_list_preview() -> Response:
 
 @api_v1.post("/order/preview")
 def post_order_preview() -> Response | tuple[Response, int]:
-    """Build a Safeway cart for review without submitting an order."""
+    """Build a Safeway cart for review without submitting an order.
+
+    Returns:
+        The built cart and its computed total, or a terse 503 JSON error
+        if the Safeway pipeline could not be constructed or the cart
+        could not be built. The underlying exception detail is logged
+        server-side but never relayed to the client (Issue #77).
+    """
     require_bearer()
     shopping_list = _parse_shopping_list_payloads(_json_body().get("shopping_list"))
     try:
         pipeline = _safeway_pipeline()
-    except (ConfigError, SafewayPipelineError) as exc:
-        return jsonify(error=f"safeway pipeline unavailable: {exc}"), 503
+    except (ConfigError, SafewayPipelineError):
+        logger.warning("Safeway pipeline unavailable for order preview", exc_info=True)
+        return jsonify(error=_SAFEWAY_PIPELINE_UNAVAILABLE_MESSAGE), 503
     try:
         cart = pipeline.build_cart_only(shopping_list)
-    except SafewayPipelineError as exc:
-        return jsonify(error=f"cart build failed: {exc}"), 503
+    except SafewayPipelineError:
+        logger.exception("Cart build failed for order preview")
+        return jsonify(error=_CART_BUILD_FAILED_MESSAGE), 503
     finally:
         pipeline.close()
     total = order_service.compute_cart_total(cart)
@@ -644,8 +679,9 @@ def post_order_submit() -> Response | tuple[Response, int]:
     override_cap = bool(body.get("override_cap"))
     try:
         _enforce_order_cap(server_total, override_cap)
-    except ConfigError as exc:
-        return jsonify(error=f"order-value cap configuration invalid: {exc}"), 503
+    except ConfigError:
+        logger.exception("Order-value cap configuration invalid")
+        return jsonify(error=_ORDER_CONFIG_INVALID_MESSAGE), 503
     total = str(server_total)
     action_id = _stage_pending(
         "safeway_order_submit",
@@ -759,21 +795,43 @@ def _order_failure_response(
 ) -> tuple[Response, int]:
     """Render the appropriate error response for a failed order submission.
 
+    The raw ``error_message`` surfaced from deep inside the Safeway
+    client/pipeline is logged server-side for operators but never
+    relayed to the client verbatim -- it can carry internal detail
+    (vendor error text, stack-trace fragments) that must not leak into
+    the RubotPaul-facing response body (Issue #77). The response always
+    keeps a stable ``error`` key, and mapped outcomes additionally keep
+    their ``status``/``action_id`` keys so RubotPaul can still route the
+    reply.
+
     Args:
         action: The staged (already-claimed) pending action.
-        error_message: Error message from the OrderResult.
+        error_message: Error message from the OrderResult. Logged, but
+            never relayed verbatim in the response body.
         outcome: The order's OrderOutcome, if known.
 
     Returns:
         A (Response, status_code) tuple: 504 for an unknown (timed-out)
         outcome, 409 for a blocked duplicate, or 502 for any other
-        failure.
+        failure. The ``error`` field is always a terse, stable message.
     """
     mapped = _OUTCOME_RESPONSES.get(outcome) if outcome is not None else None
     if mapped is None:
-        return jsonify(error=error_message), 502
+        logger.error(
+            "Order submission failed for action %s: %s",
+            action.action_id,
+            error_message,
+        )
+        return jsonify(error=_ORDER_SUBMISSION_FAILED_MESSAGE), 502
     status, code = mapped
-    response = jsonify(status=status, action_id=action.action_id, error=error_message)
+    logger.warning(
+        "Order submission failed (%s) for action %s: %s",
+        status,
+        action.action_id,
+        error_message,
+    )
+    terse_message = _OUTCOME_ERROR_MESSAGES[status]
+    response = jsonify(status=status, action_id=action.action_id, error=terse_message)
     return response, code
 
 
@@ -799,10 +857,11 @@ def _confirm_order_submit(
     cart = CartSummary.model_validate(action.payload["cart"])
     try:
         pipeline = _safeway_pipeline()
-    except (ConfigError, SafewayPipelineError) as exc:
+    except (ConfigError, SafewayPipelineError):
         # Not claimed yet: the action stays pending so it can be retried
         # (until it expires) once configuration is fixed.
-        return jsonify(error=f"safeway pipeline unavailable: {exc}"), 503
+        logger.exception("Safeway pipeline unavailable while confirming order")
+        return jsonify(error=_SAFEWAY_PIPELINE_UNAVAILABLE_MESSAGE), 503
     if not pipeline.order_submission_enabled:
         # Issue #60: order submission is descoped for v1.0. Not claimed —
         # the action stays pending so it can be retried once the flag is
@@ -828,8 +887,9 @@ def _confirm_order_submit(
             allow_unverified_fulfillment=True,
             allow_over_cap=bool(action.payload.get("allow_over_cap", False)),
         )
-    except SafewayPipelineError as exc:
-        return jsonify(error=f"order submission failed: {exc}"), 502
+    except SafewayPipelineError:
+        logger.exception("Order submission failed")
+        return jsonify(error=_ORDER_SUBMISSION_FAILED_MESSAGE), 502
     finally:
         pipeline.close()
     if not result.success:

--- a/grocery_butler/app.py
+++ b/grocery_butler/app.py
@@ -279,51 +279,111 @@ def _register_teardown(app: Flask) -> None:
     app.teardown_appcontext(_close_db)
 
 
+#: Path prefix of the RubotPaul-facing JSON API blueprint. Requests under
+#: this prefix must always get a terse JSON error body -- never Flask's
+#: HTML error page -- even for errors that occur before or outside the
+#: blueprint's own routing (unmatched paths, wrong methods, uncaught
+#: exceptions), which is why this is checked here rather than relying
+#: solely on the blueprint's own ``@api_v1.errorhandler`` handlers
+#: (Issue #77).
+_API_PATH_PREFIX = "/api/v1"
+
+
+def _wants_json_error() -> bool:
+    """Return whether the current request expects a JSON error body.
+
+    Returns:
+        True if the current request path is under ``/api/v1``, else
+        False.
+    """
+    return request.path.startswith(_API_PATH_PREFIX)
+
+
+def _api_or_html_error(
+    code: int, json_message: str, html_message: str
+) -> tuple[Response, int] | tuple[str, int]:
+    """Render a terse JSON error for ``/api/v1`` requests, else the HTML page.
+
+    Args:
+        code: HTTP status code for the error.
+        json_message: Terse message for the ``/api/v1`` JSON body.
+        html_message: Message rendered into the HTML ``error.html`` page.
+
+    Returns:
+        Tuple of (response, status code): a terse JSON body for
+        ``/api/v1`` requests, or the rendered ``error.html`` template
+        for everything else.
+    """
+    if _wants_json_error():
+        return jsonify(error=json_message), code
+    return render_template("error.html", code=code, message=html_message), code
+
+
 def _register_error_handlers(app: Flask) -> None:
     """Register HTTP error handler pages.
+
+    ``/api/v1`` requests get a terse JSON body; every other route keeps
+    rendering the existing ``error.html`` page. This applies to app-level
+    handlers only -- the blueprint's own ``@api_v1.errorhandler`` handlers
+    (400/401/404/409/410) still fire first for in-route aborts, per
+    Flask's most-specific-handler-wins rule, and keep their descriptive
+    JSON bodies unchanged (Issue #77).
 
     Args:
         app: Flask application instance.
     """
 
     @app.errorhandler(400)
-    def bad_request(error: Exception) -> tuple[str, int]:
+    def bad_request(error: Exception) -> tuple[Response, int] | tuple[str, int]:
         """Handle 400 Bad Request errors.
 
         Args:
             error: The exception that triggered the error.
 
         Returns:
-            Tuple of rendered template and HTTP status code.
+            Tuple of (response, status code): terse JSON for
+            ``/api/v1`` requests, rendered HTML otherwise.
         """
-        return render_template("error.html", code=400, message="Bad Request"), 400
+        return _api_or_html_error(400, "bad request", "Bad Request")
 
     @app.errorhandler(404)
-    def not_found(error: Exception) -> tuple[str, int]:
+    def not_found(error: Exception) -> tuple[Response, int] | tuple[str, int]:
         """Handle 404 Not Found errors.
 
         Args:
             error: The exception that triggered the error.
 
         Returns:
-            Tuple of rendered template and HTTP status code.
+            Tuple of (response, status code): terse JSON for
+            ``/api/v1`` requests, rendered HTML otherwise.
         """
-        return render_template("error.html", code=404, message="Page Not Found"), 404
+        return _api_or_html_error(404, "not found", "Page Not Found")
+
+    @app.errorhandler(405)
+    def method_not_allowed(error: Exception) -> tuple[Response, int] | tuple[str, int]:
+        """Handle 405 Method Not Allowed errors.
+
+        Args:
+            error: The exception that triggered the error.
+
+        Returns:
+            Tuple of (response, status code): terse JSON for
+            ``/api/v1`` requests, rendered HTML otherwise.
+        """
+        return _api_or_html_error(405, "method not allowed", "Method Not Allowed")
 
     @app.errorhandler(500)
-    def server_error(error: Exception) -> tuple[str, int]:
+    def server_error(error: Exception) -> tuple[Response, int] | tuple[str, int]:
         """Handle 500 Internal Server Error.
 
         Args:
             error: The exception that triggered the error.
 
         Returns:
-            Tuple of rendered template and HTTP status code.
+            Tuple of (response, status code): terse JSON for
+            ``/api/v1`` requests, rendered HTML otherwise.
         """
-        return (
-            render_template("error.html", code=500, message="Internal Server Error"),
-            500,
-        )
+        return _api_or_html_error(500, "internal server error", "Internal Server Error")
 
 
 def _register_context_processors(app: Flask) -> None:

--- a/tests/e2e/test_ordering.py
+++ b/tests/e2e/test_ordering.py
@@ -158,7 +158,13 @@ def test_order_preview_auth_failure_returns_503(
     no_claude: None,
     safeway_mock: SafewayMockState,
 ) -> None:
-    """A failing Okta authn step surfaces as a 503, not a 500."""
+    """A failing Okta authn step surfaces as a 503, not a 500.
+
+    Issue #77: the body is the terse, stable "cart build failed"
+    message rather than one echoing the underlying Okta/auth exception
+    text -- that detail is logged server-side instead of relayed to the
+    client.
+    """
     headers = signed_headers()
     safeway_mock.force_auth_fail = True
 
@@ -168,7 +174,7 @@ def test_order_preview_auth_failure_returns_503(
         headers=headers,
     )
     assert response.status_code == 503
-    assert "safeway" in response.get_json()["error"].lower()
+    assert response.get_json()["error"] == "cart build failed"
 
 
 def test_order_submit_confirm_hits_orders_endpoint_with_confirmation(

--- a/tests/test_api_destructive.py
+++ b/tests/test_api_destructive.py
@@ -579,7 +579,10 @@ class TestOrderSubmitTotalValidationAndCap:
 
         The cap gate reads the env var at staging time; if an operator
         has set it to garbage the request must fail with a clean JSON
-        503 naming the configuration problem, not an unhandled 500.
+        503, not an unhandled 500. Issue #77: the body is a terse,
+        stable "order configuration invalid" message rather than one
+        naming the offending env var or its raw value -- that detail is
+        logged server-side instead of relayed to the client.
         """
         body = _order_body()
         del body["total"]
@@ -588,7 +591,10 @@ class TestOrderSubmitTotalValidationAndCap:
                 "/api/v1/order/submit", json=body, headers=auth_headers
             )
         assert response.status_code == 503
-        assert "cap" in response.get_json()["error"].lower()
+        assert response.get_json()["error"] == "order configuration invalid"
+        text = response.get_data(as_text=True)
+        assert "SAFEWAY_ORDER_VALUE_CAP_USD" not in text
+        assert "garbage" not in text
 
     def test_order_submit_accepts_matching_client_total(
         self,
@@ -969,7 +975,14 @@ class TestActionsConfirm:
         auth_headers: dict[str, str],
         pending_store: PendingActionsStore,
     ) -> None:
-        """A failed Safeway submission reports 502; the claim is consumed."""
+        """A failed Safeway submission reports a terse 502; the claim is consumed.
+
+        Issue #77: the raw ``error_message`` from an unmapped-outcome
+        OrderResult failure must not be relayed verbatim into the
+        response body — "Safeway is down" is a stand-in for text that,
+        in production, could carry internal detail. The body must use
+        the fixed, terse "order submission failed" message instead.
+        """
         action_id = _stage_via_api(
             client, auth_headers, "/api/v1/order/submit", _order_body()
         )
@@ -984,7 +997,8 @@ class TestActionsConfirm:
                 headers=auth_headers,
             )
         assert response.status_code == 502
-        assert "Safeway is down" in response.get_json()["error"]
+        assert response.get_json()["error"] == "order submission failed"
+        assert "Safeway is down" not in response.get_data(as_text=True)
         action = pending_store.get_pending_action(action_id)
         assert action is not None
         assert action.status is PendingActionStatus.APPROVED
@@ -1271,7 +1285,14 @@ class TestConfirmOrderIdempotency:
         auth_headers: dict[str, str],
         pending_store: PendingActionsStore,
     ) -> None:
-        """Test an UNKNOWN order outcome surfaces as HTTP 504 with status unknown."""
+        """Test an UNKNOWN order outcome surfaces as HTTP 504 with status unknown.
+
+        Issue #77: the mapped-outcome response must keep ``status`` and
+        ``action_id`` (RubotPaul needs those to route the reply) but
+        must not relay the raw ``error_message`` free text verbatim —
+        this OrderResult's message is a stand-in for text that could
+        carry internal detail in production.
+        """
         from grocery_butler.order_service import OrderOutcome
 
         action_id = _stage_via_api(
@@ -1293,7 +1314,9 @@ class TestConfirmOrderIdempotency:
         assert response.status_code == 504
         data = response.get_json()
         assert data["status"] == "unknown"
+        assert data["action_id"] == action_id
         assert "error" in data
+        assert "request timed out" not in data["error"]
 
         action = pending_store.get_pending_action(action_id)
         assert action is not None
@@ -1305,7 +1328,13 @@ class TestConfirmOrderIdempotency:
         auth_headers: dict[str, str],
         pending_store: PendingActionsStore,
     ) -> None:
-        """Test a DUPLICATE order outcome surfaces as HTTP 409 duplicate_prevented."""
+        """Test a DUPLICATE order outcome surfaces as HTTP 409 duplicate_prevented.
+
+        Issue #77: the mapped-outcome response must keep ``status`` and
+        ``action_id`` but must not relay the raw ``error_message`` free
+        text verbatim — this OrderResult's message is a stand-in for
+        text that could carry internal detail in production.
+        """
         from grocery_butler.order_service import OrderOutcome
 
         action_id = _stage_via_api(
@@ -1327,6 +1356,9 @@ class TestConfirmOrderIdempotency:
         assert response.status_code == 409
         data = response.get_json()
         assert data["status"] == "duplicate_prevented"
+        assert data["action_id"] == action_id
+        assert "error" in data
+        assert "Duplicate order blocked" not in data["error"]
 
         action = pending_store.get_pending_action(action_id)
         assert action is not None

--- a/tests/test_api_errors.py
+++ b/tests/test_api_errors.py
@@ -1,0 +1,422 @@
+"""Tests for the /api/v1 error contract (Issue #77).
+
+Pins down that ``/api/v1`` never leaks an HTML error page or internal
+exception detail to a JSON client: unknown paths, wrong HTTP methods,
+and uncaught exceptions must all render terse JSON, and the
+sanitized-but-mapped error sites in ``grocery_butler.api`` (Safeway
+pipeline / order-value cap / order submission failures) must never
+echo the underlying exception text or config value into the response
+body. Every scenario here is RED against today's implementation and
+is expected to go GREEN once the error contract is fixed.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from flask import Flask
+    from flask.testing import FlaskClient
+
+from grocery_butler.app import create_app
+from grocery_butler.auth_middleware import SECRET_ENV_VAR, mint_token
+from grocery_butler.config import ConfigError
+from grocery_butler.models import (
+    CartItem,
+    CartSummary,
+    FulfillmentType,
+    IngredientCategory,
+    SafewayProduct,
+    ShoppingListItem,
+    Unit,
+)
+from grocery_butler.order_service import OrderOutcome, OrderResult
+from grocery_butler.safeway_pipeline import SafewayPipelineError
+
+TEST_SECRET = "test-shared-secret"
+SECRET_ENV = {SECRET_ENV_VAR: TEST_SECRET}
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> str:
+    """Return a temporary database path for test isolation."""
+    return str(tmp_path / "test_api_errors.db")
+
+
+@pytest.fixture()
+def app(db_path: str) -> Flask:
+    """Create a Flask test app with a temporary database."""
+    application = create_app(db_path=db_path)
+    application.config["TESTING"] = True
+    return application
+
+
+@pytest.fixture()
+def client(app: Flask) -> FlaskClient:
+    """Return a Flask test client."""
+    return app.test_client()
+
+
+@pytest.fixture()
+def auth_headers() -> dict[str, str]:
+    """Return a valid Authorization header minted with the test secret."""
+    with patch.dict(os.environ, SECRET_ENV):
+        token = mint_token("rubotpaul")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _make_shopping_item(ingredient: str = "pasta") -> ShoppingListItem:
+    """Return a ShoppingListItem for order preview/submit payloads."""
+    return ShoppingListItem(
+        ingredient=ingredient,
+        quantity=1.0,
+        unit=Unit.LB,
+        category=IngredientCategory.PANTRY_DRY,
+        search_term=ingredient,
+        from_meals=["test pasta"],
+    )
+
+
+def _make_cart_item(ingredient: str, cost: float) -> CartItem:
+    """Return a CartItem with the given estimated cost."""
+    return CartItem(
+        shopping_list_item=_make_shopping_item(ingredient),
+        safeway_product=SafewayProduct(
+            product_id=f"prod-{ingredient}",
+            name=f"Brand {ingredient}",
+            price=cost,
+            size="1 lb",
+        ),
+        quantity_to_order=1,
+        estimated_cost=cost,
+    )
+
+
+def _make_cart(costs: dict[str, float]) -> CartSummary:
+    """Return a CartSummary with one item per (ingredient, cost) pair."""
+    items = [_make_cart_item(name, cost) for name, cost in costs.items()]
+    return CartSummary(
+        items=items,
+        failed_items=[],
+        substituted_items=[],
+        restock_items=[],
+        subtotal=sum(costs.values()),
+        fulfillment_options=[],
+        recommended_fulfillment=FulfillmentType.PICKUP,
+        estimated_total=sum(costs.values()),
+    )
+
+
+def _order_body() -> dict[str, Any]:
+    """Return a valid /order/submit request body totalling $7.75."""
+    cart = _make_cart({"pasta": 3.50, "sauce": 4.25})
+    return {"cart": cart.model_dump(mode="json"), "total": "7.75"}
+
+
+def _stage_via_api(
+    client: FlaskClient, auth_headers: dict[str, str], body: dict[str, Any]
+) -> str:
+    """Stage an order through /order/submit and return its action_id."""
+    response = client.post("/api/v1/order/submit", json=body, headers=auth_headers)
+    assert response.status_code == 200
+    action_id = response.get_json()["action_id"]
+    assert isinstance(action_id, str)
+    return action_id
+
+
+# ---------------------------------------------------------------------------
+# Unknown paths under /api/v1 must render JSON, not Flask's HTML 404 page
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownPathContract:
+    """GET on an unmatched /api/v1 path must return a terse JSON 404."""
+
+    def test_unknown_path_returns_json_404_not_html(self, client: FlaskClient) -> None:
+        """An unmatched /api/v1 path returns JSON, never Flask's HTML page.
+
+        Today Flask cannot associate an unmatched URL with any
+        blueprint's error handlers, so it falls through to the app-level
+        404 handler in grocery_butler.app, which renders error.html —
+        an HTML page to a JSON-only API client.
+        """
+        response = client.get("/api/v1/nonexistent")
+        assert response.status_code == 404
+        assert response.is_json
+        assert response.get_json() == {"error": "not found"}
+        assert response.content_type.startswith("application/json")
+        assert "<!doctype html" not in response.get_data(as_text=True).lower()
+
+
+# ---------------------------------------------------------------------------
+# Wrong HTTP method on a known /api/v1 route must render JSON, not HTML
+# ---------------------------------------------------------------------------
+
+
+class TestMethodNotAllowedContract:
+    """A wrong HTTP method on a known /api/v1 route must return JSON 405."""
+
+    def test_wrong_method_returns_json_405_not_html(self, client: FlaskClient) -> None:
+        """DELETE on the GET-only /api/v1/inventory route returns JSON 405.
+
+        No 405 handler is registered on the blueprint today (only 400,
+        401, 404, 409, 410 are), so werkzeug's default HTML method-not-
+        allowed page leaks through instead.
+        """
+        response = client.delete("/api/v1/inventory")
+        assert response.status_code == 405
+        assert response.is_json
+        assert response.get_json() == {"error": "method not allowed"}
+        assert "<!doctype html" not in response.get_data(as_text=True).lower()
+
+
+# ---------------------------------------------------------------------------
+# Uncaught exceptions inside a route must render JSON, not HTML, and must
+# never leak the exception text
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, SECRET_ENV)
+class TestInternalServerErrorContract:
+    """Uncaught exceptions inside /api/v1 routes render a terse JSON 500."""
+
+    def test_uncaught_exception_returns_json_500_without_leaking_text(
+        self,
+        client: FlaskClient,
+        app: Flask,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """A RuntimeError inside the route body becomes a generic JSON 500.
+
+        TESTING=True makes Flask propagate exceptions by default, which
+        would bypass any 500 handler and hide this bug entirely — so
+        PROPAGATE_EXCEPTIONS is explicitly disabled here to exercise the
+        request pipeline the way it behaves in production. The injected
+        RuntimeError carries a secret-shaped marker to prove the
+        eventual fix's generic body doesn't echo it back.
+        """
+        app.config["PROPAGATE_EXCEPTIONS"] = False
+        with patch(
+            "grocery_butler.api.PantryManager.get_inventory",
+            side_effect=RuntimeError("ANTHROPIC_API_KEY=sk-secret-marker"),
+        ):
+            response = client.get("/api/v1/inventory", headers=auth_headers)
+        assert response.status_code == 500
+        assert response.is_json
+        assert response.get_json() == {"error": "internal server error"}
+        body_text = response.get_data(as_text=True)
+        assert "sk-secret" not in body_text
+        assert "ANTHROPIC_API_KEY" not in body_text
+        assert "<!doctype html" not in body_text.lower()
+
+
+# ---------------------------------------------------------------------------
+# Leak-scrub: the sanitized 503/502/504 sites in grocery_butler/api.py must
+# use terse, stable messages and must never echo exception/config detail
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, SECRET_ENV)
+class TestLeakScrubbedErrorBodies:
+    """503/502/504 responses must be terse and free of internal detail."""
+
+    def test_order_preview_pipeline_configerror_is_scrubbed(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """A ConfigError building the pipeline for /order/preview is scrubbed.
+
+        Today's handler interpolates the raw exception into the 503
+        body (``f"safeway pipeline unavailable: {exc}"``), so
+        ``ConfigError``'s message — which can name missing env var
+        details — reaches the client verbatim.
+        """
+        with patch(
+            "grocery_butler.api._safeway_pipeline",
+            side_effect=ConfigError("SECRET_MARKER_ENV_DETAIL"),
+        ):
+            response = client.post(
+                "/api/v1/order/preview",
+                json={"shopping_list": [_make_shopping_item().model_dump(mode="json")]},
+                headers=auth_headers,
+            )
+        assert response.status_code == 503
+        assert response.get_json()["error"] == "safeway pipeline unavailable"
+        assert "SECRET_MARKER_ENV_DETAIL" not in response.get_data(as_text=True)
+
+    def test_order_preview_cart_build_error_is_scrubbed(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """A SafewayPipelineError building the cart for /order/preview is scrubbed.
+
+        Today's handler interpolates the raw exception into the 503
+        body (``f"cart build failed: {exc}"``).
+        """
+        pipeline = MagicMock()
+        pipeline.build_cart_only.side_effect = SafewayPipelineError(
+            "SECRET_MARKER_AUTH"
+        )
+        with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
+            response = client.post(
+                "/api/v1/order/preview",
+                json={"shopping_list": [_make_shopping_item().model_dump(mode="json")]},
+                headers=auth_headers,
+            )
+        assert response.status_code == 503
+        assert response.get_json()["error"] == "cart build failed"
+        assert "SECRET_MARKER_AUTH" not in response.get_data(as_text=True)
+
+    def test_order_submit_invalid_cap_config_is_scrubbed(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """An unparseable order-value cap env var yields a terse 503.
+
+        Today's handler interpolates the raw ``ConfigError`` into the
+        503 body (``f"order-value cap configuration invalid: {exc}"``),
+        which names the offending env var and its invalid raw value.
+        """
+        with patch.dict(os.environ, {"SAFEWAY_ORDER_VALUE_CAP_USD": "not-a-number"}):
+            response = client.post(
+                "/api/v1/order/submit", json=_order_body(), headers=auth_headers
+            )
+        assert response.status_code == 503
+        assert response.get_json()["error"] == "order configuration invalid"
+        text = response.get_data(as_text=True)
+        assert "SAFEWAY_ORDER_VALUE_CAP_USD" not in text
+        assert "not-a-number" not in text
+
+    def test_confirm_pipeline_configerror_is_scrubbed(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """ConfigError building the pipeline at confirm time is scrubbed."""
+        action_id = _stage_via_api(client, auth_headers, _order_body())
+        with patch(
+            "grocery_butler.api._safeway_pipeline",
+            side_effect=ConfigError("SECRET_MARKER_CONF"),
+        ):
+            response = client.post(
+                "/api/v1/actions/confirm",
+                json={"action_id": action_id},
+                headers=auth_headers,
+            )
+        assert response.status_code == 503
+        assert response.get_json()["error"] == "safeway pipeline unavailable"
+        assert "SECRET_MARKER_CONF" not in response.get_data(as_text=True)
+
+    def test_confirm_submit_cart_raises_is_scrubbed(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """A SafewayPipelineError raised by submit_cart is scrubbed.
+
+        Today's handler interpolates the raw exception into the 502
+        body (``f"order submission failed: {exc}"``).
+        """
+        action_id = _stage_via_api(client, auth_headers, _order_body())
+        pipeline = MagicMock()
+        pipeline.submit_cart.side_effect = SafewayPipelineError("SECRET_MARKER_SUBMIT")
+        with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
+            response = client.post(
+                "/api/v1/actions/confirm",
+                json={"action_id": action_id},
+                headers=auth_headers,
+            )
+        assert response.status_code == 502
+        assert response.get_json()["error"] == "order submission failed"
+        assert "SECRET_MARKER_SUBMIT" not in response.get_data(as_text=True)
+
+    def test_confirm_unmapped_failure_result_is_scrubbed(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """An unmapped-outcome OrderResult failure (no ``outcome``) is scrubbed.
+
+        ``_order_failure_response`` relays ``result.error_message``
+        verbatim into the 502 body for any outcome not in
+        ``_OUTCOME_RESPONSES`` — which can include raw text surfaced
+        from deep inside the Safeway client.
+        """
+        action_id = _stage_via_api(client, auth_headers, _order_body())
+        pipeline = MagicMock()
+        pipeline.submit_cart.return_value = OrderResult(
+            success=False, error_message="SECRET_MARKER_RAW_SAFEWAY"
+        )
+        with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
+            response = client.post(
+                "/api/v1/actions/confirm",
+                json={"action_id": action_id},
+                headers=auth_headers,
+            )
+        assert response.status_code == 502
+        assert response.get_json()["error"] == "order submission failed"
+        assert "SECRET_MARKER_RAW_SAFEWAY" not in response.get_data(as_text=True)
+
+    def test_confirm_mapped_outcome_preserves_status_but_scrubs_text(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """A mapped OrderOutcome keeps status/action_id but scrubs free text.
+
+        ``_order_failure_response`` maps ``OrderOutcome.UNKNOWN`` to a
+        504 with ``status="unknown"``, but today still relays
+        ``result.error_message`` verbatim as the ``error`` field. The
+        fixed contract must keep the mapped status code and the
+        ``status``/``action_id`` keys (RubotPaul needs those to route
+        the reply) while replacing the free text with something terse.
+        """
+        action_id = _stage_via_api(client, auth_headers, _order_body())
+        pipeline = MagicMock()
+        pipeline.submit_cart.return_value = OrderResult(
+            success=False,
+            outcome=OrderOutcome.UNKNOWN,
+            error_message="SECRET_MARKER_TIMEOUT_DETAIL",
+        )
+        with patch("grocery_butler.api._safeway_pipeline", return_value=pipeline):
+            response = client.post(
+                "/api/v1/actions/confirm",
+                json={"action_id": action_id},
+                headers=auth_headers,
+            )
+        assert response.status_code == 504
+        body = response.get_json()
+        assert body["status"] == "unknown"
+        assert body["action_id"] == action_id
+        assert "SECRET_MARKER_TIMEOUT_DETAIL" not in response.get_data(as_text=True)
+
+
+# ---------------------------------------------------------------------------
+# Regression guards: behavior that is already correct and must not regress
+# ---------------------------------------------------------------------------
+
+
+@patch.dict(os.environ, SECRET_ENV)
+class TestRegressionGuards:
+    """Already-correct /api/v1 behavior that the #77 fix must not break."""
+
+    def test_recipe_not_found_still_uses_blueprint_json_404(
+        self, client: FlaskClient, auth_headers: dict[str, str]
+    ) -> None:
+        """An in-route abort(404) still renders the blueprint's descriptive JSON.
+
+        Distinct from the unmatched-path case above: this hits a real
+        route whose handler explicitly aborts 404 for an unknown id, so
+        the blueprint's existing ``@api_v1.errorhandler(404)`` already
+        renders JSON correctly and must keep doing so.
+        """
+        response = client.get("/api/v1/recipes/999999", headers=auth_headers)
+        assert response.status_code == 404
+        assert response.get_json() == {"error": "recipe not found"}
+
+    def test_missing_bearer_on_inventory_still_returns_json_401(
+        self, client: FlaskClient
+    ) -> None:
+        """No Authorization header on a real route still returns JSON 401."""
+        response = client.get("/api/v1/inventory")
+        assert response.status_code == 401
+        assert response.is_json

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -624,6 +624,21 @@ class TestErrorHandlers:
         response = client.get("/nonexistent-page")
         assert b"Back to Dashboard" in response.data
 
+    def test_wrong_method_on_html_route_returns_html_405(
+        self, client: FlaskClient
+    ) -> None:
+        """Test a wrong HTTP method on an HTML route stays HTML, not JSON.
+
+        Issue #77's JSON-error contract is scoped to ``/api/v1`` only —
+        this pins that a non-API route (``/`` is GET-only) still gets a
+        werkzeug/Flask HTML error response for a 405, proving the fix
+        doesn't accidentally force JSON errors app-wide.
+        """
+        response = client.delete("/")
+        assert response.status_code == 405
+        assert not response.is_json
+        assert response.content_type.startswith("text/html")
+
 
 # ---------------------------------------------------------------------------
 # TestRecipesPage


### PR DESCRIPTION
## Summary

- App-level error handlers (400/404/405/500) in `grocery_butler/app.py` now branch on the `/api/v1` path prefix: JSON clients get terse JSON error bodies (`{"error": "not found"}` etc.) for routing 404s, wrong-method 405s (new handler — none existed), and uncaught 500s, while HTML routes keep rendering `error.html`. The blueprint's in-route handlers (400/401/404/409/410) are untouched, so descriptive in-route aborts keep their existing JSON per Flask's most-specific-wins rule.
- Scrubbed six internal-detail leak sites in `grocery_butler/api.py`: `ConfigError` text (env-var setup guidance), raw `SafewayPipelineError` text, and relayed `OrderResult.error_message` are replaced with stable terse constants (`safeway pipeline unavailable`, `cart build failed`, `order configuration invalid`, `order submission failed`) and the full detail is logged server-side instead. Mapped order outcomes (504 unknown / 409 duplicate) keep their `status`/`action_id` keys so RubotPaul reply-routing is unchanged.
- Security-specialist audit over the API surface returned CLEAN — no remaining paths relay internal exception/config text to `/api/v1` clients.

## Test plan

- New `tests/test_api_errors.py` (TDD red-first): JSON contract for `GET /api/v1/nonexistent` (404), `DELETE /api/v1/inventory` (405), and a forced 500 (`PROPAGATE_EXCEPTIONS=False` + monkeypatched raise carrying a secret marker); seven leak-scrub tests asserting exact terse bodies and marker absence across order preview/submit/confirm paths; regression guards for in-route blueprint 404 and bearer 401 JSON.
- Updated `tests/test_api_destructive.py` and `tests/e2e/test_ordering.py` assertions that previously pinned the leaked text as correct behavior; added an HTML-405 test to `tests/test_app.py` proving the JSON branch is scoped to `/api/v1`.
- `./scripts/check-all.sh` exit 0: 1647 passed, 10 pre-existing Postgres skips, 96.24% branch coverage; ruff/mypy strict/bandit/pip-audit/radon all green.

Closes #77
