### PR TITLE
fix(pantry): parse fenced Claude inventory responses; 409 on raced recipe save

### DIFF
--- a/grocery_butler/api.py
+++ b/grocery_butler/api.py
@@ -452,7 +452,10 @@ def post_recipes_save() -> tuple[Response, int]:
         purchase_items=[i for i in ingredients if not i.is_pantry_item],
         pantry_items=[i for i in ingredients if i.is_pantry_item],
     )
-    recipe_id = store.save_recipe(meal)
+    try:
+        recipe_id = store.save_recipe(meal)
+    except IntegrityError:
+        abort(409, description="recipe with that name exists")
     return jsonify(id=recipe_id, **meal.model_dump(mode="json")), 201
 
 

--- a/grocery_butler/pantry_manager.py
+++ b/grocery_butler/pantry_manager.py
@@ -15,6 +15,7 @@ import logging
 from datetime import UTC, datetime
 from typing import Any, Protocol
 
+from grocery_butler.claude_utils import extract_json_text
 from grocery_butler.db import get_connection, init_db
 from grocery_butler.models import (
     InventoryItem,
@@ -388,7 +389,9 @@ def _format_inventory_context(items: list[InventoryItem]) -> str:
 def _parse_claude_response(text: str) -> list[InventoryUpdate]:
     """Parse Claude's JSON response into InventoryUpdate objects.
 
-    Filters out low-confidence matches (< 0.8).
+    Strips markdown code fences (e.g. ```json ... ```) before parsing,
+    since Claude sometimes wraps its JSON output that way. Filters out
+    low-confidence matches (< 0.8).
 
     Args:
         text: Raw text response from Claude API.
@@ -400,7 +403,7 @@ def _parse_claude_response(text: str) -> list[InventoryUpdate]:
         json.JSONDecodeError: If the response is not valid JSON.
         ValueError: If the JSON structure is invalid.
     """
-    data = json.loads(text)
+    data = json.loads(extract_json_text(text))
     if not isinstance(data, list):
         raise ValueError("Expected a JSON array")
 

--- a/tests/test_api_writes.py
+++ b/tests/test_api_writes.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import sqlite3
 from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
@@ -405,6 +406,43 @@ def test_recipes_save_duplicate_conflict(
             auth_headers,
             _recipe_body(name="Test Pasta"),
         )
+    assert response.status_code == 409
+
+
+def test_recipes_save_raced_duplicate_returns_409(
+    client: FlaskClient,
+    app: Flask,
+    auth_headers: dict[str, str],
+) -> None:
+    """A concurrent insert that races the pre-check is a 409, not a 500.
+
+    Regression test for issue #79: `post_recipes_save` checks
+    `store.get_recipe(name)` for None, then calls `store.save_recipe(meal)`.
+    If another request inserts the same name in between (or the pre-check
+    is otherwise stale), `save_recipe` raises
+    `grocery_butler.db.adapter.IntegrityError` because `recipes.name` is
+    UNIQUE, and today that propagates as an unhandled 500 instead of being
+    translated to a 409 the way `post_stock_add` handles its own
+    `IntegrityError` case.
+
+    PROPAGATE_EXCEPTIONS is explicitly disabled (see
+    TestInternalServerErrorContract in test_api_errors.py) so the test
+    client exercises the request pipeline the way it behaves in
+    production instead of TESTING=True re-raising the exception.
+    """
+    app.config["PROPAGATE_EXCEPTIONS"] = False
+    with (
+        patch.object(RecipeStore, "get_recipe", return_value=None),
+        patch.object(
+            RecipeStore,
+            "save_recipe",
+            side_effect=sqlite3.IntegrityError(
+                "UNIQUE constraint failed: recipes.name"
+            ),
+        ),
+        patch.dict(os.environ, SECRET_ENV),
+    ):
+        response = _post(client, "/api/v1/recipes/save", auth_headers, _recipe_body())
     assert response.status_code == 409
 
 

--- a/tests/test_pantry_manager.py
+++ b/tests/test_pantry_manager.py
@@ -658,6 +658,48 @@ class TestParseInventoryIntent:
         assert result[1].ingredient == "eggs"
         assert result[1].new_status == InventoryStatus.LOW
 
+    def test_valid_json_response_wrapped_in_markdown_fence_parses(
+        self, db_path: str
+    ) -> None:
+        """Test parse succeeds when Claude wraps JSON in ```json fences.
+
+        Regression test for issue #79: `_call_claude_with_retry` calls
+        `_parse_claude_response`, which calls `json.loads` directly on the
+        raw response text instead of stripping markdown fences via
+        `grocery_butler.claude_utils.extract_json_text` first. A fenced
+        response should still parse into the same updates a bare JSON
+        array would, not silently drop them.
+        """
+        mock_client = MagicMock()
+        mock_response = MagicMock()
+        mock_content = MagicMock()
+        payload = json.dumps(
+            [
+                {
+                    "ingredient": "milk",
+                    "new_status": "out",
+                    "confidence": 0.95,
+                },
+                {
+                    "ingredient": "eggs",
+                    "new_status": "low",
+                    "confidence": 0.90,
+                },
+            ]
+        )
+        mock_content.text = f"```json\n{payload}\n```"
+        mock_response.content = [mock_content]
+        mock_client.messages.create.return_value = mock_response
+
+        pm = PantryManager(db_path, anthropic_client=mock_client)
+        result = pm.parse_inventory_intent("we're out of milk and low on eggs")
+
+        assert len(result) == 2
+        assert result[0].ingredient == "milk"
+        assert result[0].new_status == InventoryStatus.OUT
+        assert result[1].ingredient == "eggs"
+        assert result[1].new_status == InventoryStatus.LOW
+
     def test_filters_low_confidence(self, db_path: str) -> None:
         """Test parse filters out results with confidence < 0.8."""
         mock_client = MagicMock()


### PR DESCRIPTION
## Summary
- `pantry_manager._parse_claude_response` now routes the Claude response through `claude_utils.extract_json_text` before `json.loads`, so ```` ```json ````-fenced replies parse instead of silently returning `[]` and dropping natural-language inventory updates ("we're out of milk"). This matches the existing pattern in `meal_parser` and `consolidator`.
- `POST /api/v1/recipes/save` now catches `IntegrityError` around `save_recipe` and returns 409 (mirroring `post_stock_add`), closing the check-then-insert race that previously surfaced as an unhandled 500 on a concurrent duplicate save.
- Regression tests added for both paths: a fenced-response fixture through the mocked Claude client, and a raced-duplicate save asserting 409.

## Test plan
- `tests/test_pantry_manager.py::TestParseInventoryIntent::test_valid_json_response_wrapped_in_markdown_fence_parses` — RED before the fix (returned `[]`), GREEN after.
- `tests/test_api_writes.py::test_recipes_save_raced_duplicate_returns_409` — RED before the fix (500), GREEN after.
- `./scripts/check-all.sh` exits 0: 1655 passed / 10 skipped, 96.25% branch coverage, ruff, mypy strict, bandit + pip-audit, interrogate, radon all green.

Closes #79
