### PR TITLE
fix(cart): merge colliding meal/restock lines and classify restock by provenance

### DIFF
--- a/grocery_butler/cart_builder.py
+++ b/grocery_butler/cart_builder.py
@@ -23,7 +23,7 @@ from grocery_butler.models import (
 )
 from grocery_butler.product_search import ProductSearchError
 from grocery_butler.safeway_client import SafewayAPIError
-from grocery_butler.units import convert, parse_size
+from grocery_butler.units import convert, group_key, parse_size
 
 if TYPE_CHECKING:
     from grocery_butler.product_search import ProductSearchService
@@ -113,6 +113,20 @@ class CartBuilder:
         also remain listed in ``substituted_items`` as a display and
         provenance record.
 
+        A meal item and a restock item that share a
+        :func:`~grocery_butler.units.group_key` (same ingredient name and
+        a compatible unit) are merged into a single consolidated cart
+        line before processing, rather than kept as two separate lines.
+        The merged line is classified as restock so ``mark_restocked``
+        bookkeeping stays correct -- without merging, a colliding pair
+        would both be ordered (a duplicate purchase) and, depending on
+        iteration order, could misfile the meal-sourced copy into
+        ``restock_items`` too, double-updating inventory (issue #80).
+        Items whose group keys don't match (including same-name items
+        with incompatible units) are never merged and are classified
+        purely by provenance -- which list they came from -- never by
+        ingredient name.
+
         Args:
             items: Shopping list items to add to cart.
             restock_items: Optional restock queue items.
@@ -125,16 +139,10 @@ class CartBuilder:
         substituted: list[SubstitutionResult] = []
         restock_cart: list[CartItem] = []
 
-        all_items = list(items)
-        restock_set: set[str] = set()
-        if restock_items:
-            for ri in restock_items:
-                all_items.append(ri)
-                restock_set.add(ri.ingredient)
+        pairs = _merge_cart_inputs(items, restock_items or [])
 
-        for item in all_items:
+        for item, is_restock in pairs:
             result = self._process_item(item)
-            is_restock = item.ingredient in restock_set
 
             if result is None:
                 failed.append(item)
@@ -353,6 +361,121 @@ class CartBuilder:
 #: (or fractionally above, due to floating-point noise) an exact multiple
 #: of the product size don't round up to one unit too many.
 _QUANTITY_EPSILON = 1e-9
+
+
+def _merge_restock_into_meal(
+    meal_item: ShoppingListItem,
+    restock_item: ShoppingListItem,
+) -> ShoppingListItem:
+    """Merge a colliding restock item into its matching meal item's line.
+
+    Callers must only invoke this once :func:`_merge_cart_inputs` has
+    confirmed the two items share a
+    :func:`~grocery_butler.units.group_key`, which guarantees
+    :func:`~grocery_butler.units.convert` returns a non-``None`` result
+    (same dimension, or an identical packaging unit). If that
+    precondition is ever violated and ``convert`` returns ``None``, the
+    raw quantity is added unconverted as a defensive fallback --
+    mirroring :meth:`Consolidator._merge_quantity`. ``restock_item``'s
+    quantity is converted into ``meal_item``'s unit and added; unit,
+    search_term, and category all come from ``meal_item`` so the merged
+    line still resolves to the same product. Provenance is ``meal_item``'s
+    ``from_meals`` with the literal marker ``"restock"`` appended
+    (deduplicated, order-preserving) regardless of ``restock_item``'s own
+    ``from_meals``, so the merged line always records that a restock need
+    was folded in.
+
+    Args:
+        meal_item: The meal-sourced shopping list item.
+        restock_item: The colliding restock-sourced shopping list item.
+
+    Returns:
+        A new ``ShoppingListItem`` for the merged line. Neither input is
+        mutated.
+    """
+    converted = convert(restock_item.quantity, restock_item.unit, meal_item.unit)
+    added = converted if converted is not None else restock_item.quantity
+
+    merged_from_meals = list(meal_item.from_meals)
+    if "restock" not in merged_from_meals:
+        merged_from_meals.append("restock")
+
+    return meal_item.model_copy(
+        update={
+            "quantity": meal_item.quantity + added,
+            "from_meals": merged_from_meals,
+        }
+    )
+
+
+def _match_restock_to_meal(
+    restock_item: ShoppingListItem,
+    pairs: list[tuple[ShoppingListItem, bool]],
+    key_to_index: dict[tuple[str, str], int],
+) -> bool:
+    """Merge a restock item into its matching meal pair, if one is free.
+
+    Updates ``pairs`` in place at the matched index when a compatible,
+    not-yet-merged meal pair is found.
+
+    Args:
+        restock_item: The restock-sourced shopping list item to place.
+        pairs: The in-progress list of (item, is_restock) pairs, indexed
+            by ``key_to_index``. Mutated in place on a successful merge.
+        key_to_index: Maps each meal item's group key to its index in
+            ``pairs``.
+
+    Returns:
+        True if ``restock_item`` was merged into an existing meal pair;
+        False if it should instead be appended as its own restock pair.
+    """
+    index = key_to_index.get(group_key(restock_item.ingredient, restock_item.unit))
+    if index is None or pairs[index][1]:
+        return False
+
+    meal_item, _ = pairs[index]
+    pairs[index] = (_merge_restock_into_meal(meal_item, restock_item), True)
+    return True
+
+
+def _merge_cart_inputs(
+    items: list[ShoppingListItem],
+    restock_items: list[ShoppingListItem],
+) -> list[tuple[ShoppingListItem, bool]]:
+    """Merge meal and restock shopping-list items, resolving name collisions.
+
+    Regular meal items come first, keyed by
+    :func:`~grocery_butler.units.group_key`. Each restock item is checked
+    against those keys: a compatible collision (matching group key, so
+    same ingredient name and dimension, or an identical packaging unit)
+    replaces the meal item's pair with a single merged, restock-classified
+    pair (see :func:`_merge_restock_into_meal`) whose quantity covers both
+    needs. An incompatible collision (matching name but a different group
+    key -- e.g. "milk" in cups vs. "milk" in bottles) or no collision at
+    all leaves the meal pair untouched and appends the restock item as its
+    own ``(item, True)`` pair. Classification is always by provenance --
+    which input list an item came from -- never by ingredient name
+    (issue #80).
+
+    Args:
+        items: Shopping list items sourced from meal plans.
+        restock_items: Shopping list items sourced from the restock queue.
+
+    Returns:
+        Ordered list of ``(item, is_restock)`` pairs. Never mutates the
+        input items.
+    """
+    pairs: list[tuple[ShoppingListItem, bool]] = [(item, False) for item in items]
+    key_to_index: dict[tuple[str, str], int] = {}
+    for index, item in enumerate(items):
+        key_to_index.setdefault(group_key(item.ingredient, item.unit), index)
+
+    extra: list[tuple[ShoppingListItem, bool]] = []
+    for restock in restock_items:
+        if not _match_restock_to_meal(restock, pairs, key_to_index):
+            extra.append((restock, True))
+
+    return pairs + extra
 
 
 def _calculate_quantity(

--- a/grocery_butler/consolidator.py
+++ b/grocery_butler/consolidator.py
@@ -20,7 +20,8 @@ from grocery_butler.models import (
     parse_unit,
 )
 from grocery_butler.prompt_loader import load_prompt
-from grocery_butler.units import convert, dimension_of
+from grocery_butler.units import convert
+from grocery_butler.units import group_key as _units_group_key
 
 if TYPE_CHECKING:
     from grocery_butler.config import Config
@@ -322,11 +323,13 @@ class Consolidator:
     def _ingredient_group_key(ingredient: str, unit: Unit) -> tuple[str, str]:
         """Build the composite merge key for an ingredient/unit pairing.
 
-        Units with a fixed physical dimension (mass, volume, count) are
-        grouped by dimension so compatible units (e.g. cup and gallon) merge
-        into a single line item. Packaging/"other" units with no fixed
-        dimension are grouped by their exact unit instead, so incompatible
-        packaging (e.g. jar vs. can) stays split into separate line items.
+        Delegates to :func:`grocery_butler.units.group_key` (issue #80),
+        which groups units with a fixed physical dimension (mass, volume,
+        count) by dimension so compatible units (e.g. cup and gallon)
+        merge into a single line item, and groups packaging/"other" units
+        with no fixed dimension by their exact unit instead, so
+        incompatible packaging (e.g. jar vs. can) stays split into
+        separate line items.
 
         Args:
             ingredient: Raw ingredient name (not yet lowercased).
@@ -336,10 +339,7 @@ class Consolidator:
             A ``(ingredient_lower, group_token)`` tuple suitable for use as
             a merge dict key.
         """
-        dimension = dimension_of(unit)
-        if dimension is not None:
-            return (ingredient.lower(), f"dim:{dimension.value}")
-        return (ingredient.lower(), f"unit:{unit.value}")
+        return _units_group_key(ingredient, unit)
 
     @staticmethod
     def _merge_quantity(entry: dict[str, object], item: Ingredient) -> None:

--- a/grocery_butler/units.py
+++ b/grocery_butler/units.py
@@ -16,6 +16,11 @@ unit-aware primitives that make quantity calculations dimensionally sound:
   confidently resolve -- unlike
   :func:`grocery_butler.models.parse_unit`, it never falls back to
   :attr:`~grocery_butler.models.Unit.EACH` for unrecognized unit tokens.
+* :func:`group_key` builds the composite merge key used to decide whether
+  two (ingredient, unit) pairs should be combined into a single shopping
+  list / cart line -- introduced to fix issue #80, where classifying a
+  meal/restock ingredient collision by name alone caused duplicate
+  purchases and corrupted inventory updates.
 """
 
 from __future__ import annotations
@@ -119,6 +124,34 @@ def convert(quantity: float, from_unit: Unit, to_unit: Unit) -> float | None:
 
     base_quantity = quantity * from_factor
     return base_quantity / to_factor
+
+
+def group_key(name: str, unit: Unit) -> tuple[str, str]:
+    """Build the composite merge key for a name/unit pairing.
+
+    Units with a fixed physical dimension (mass, volume, count) are
+    grouped by dimension so compatible units (e.g. cup and gallon) merge
+    into a single line item. Packaging/"other" units with no fixed
+    dimension are grouped by their exact unit instead, so incompatible
+    packaging (e.g. jar vs. can) stays split into separate line items.
+
+    Used both to consolidate meal ingredients into a shopping list (see
+    :meth:`grocery_butler.consolidator.Consolidator._ingredient_group_key`,
+    which delegates here) and to resolve meal/restock ingredient
+    collisions when building a cart (issue #80).
+
+    Args:
+        name: Raw ingredient/item name (not yet lowercased).
+        unit: The item's parsed unit.
+
+    Returns:
+        A ``(name_lower, group_token)`` tuple suitable for use as a merge
+        dict key.
+    """
+    dimension = dimension_of(unit)
+    if dimension is not None:
+        return (name.lower(), f"dim:{dimension.value}")
+    return (name.lower(), f"unit:{unit.value}")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cart_builder.py
+++ b/tests/test_cart_builder.py
@@ -15,6 +15,7 @@ from grocery_butler.cart_builder import (
     _calculate_quantity,
     _calculate_subtotal,
     _get_fulfillment_fee,
+    _merge_restock_into_meal,
     _parse_fulfillment_response,
     _recommend_fulfillment,
 )
@@ -28,6 +29,7 @@ from grocery_butler.models import (
     SubstitutionOption,
     SubstitutionResult,
     SubstitutionSuitability,
+    Unit,
 )
 from grocery_butler.product_search import CachedMapping, ProductSearchError
 from grocery_butler.safeway_client import SafewayAPIError, SafewayAuthError
@@ -110,6 +112,34 @@ def _make_cart_item(
         safeway_product=_make_product(price=price),
         quantity_to_order=quantity,
         estimated_cost=round(price * quantity, 2),
+    )
+
+
+def _make_milk_item(
+    quantity: float = 1.0,
+    unit: str = "gal",
+    search_term: str = "whole milk",
+    from_meals: list[str] | None = None,
+) -> ShoppingListItem:
+    """Create a "milk" ShoppingListItem for restock-collision tests (issue #80).
+
+    Args:
+        quantity: Desired quantity.
+        unit: Unit of measurement.
+        search_term: Search term.
+        from_meals: Provenance meal names.
+
+    Returns:
+        ShoppingListItem for testing milk name collisions between a
+        meal-plan item and a restock-queue item.
+    """
+    return ShoppingListItem(
+        ingredient="milk",
+        quantity=quantity,
+        unit=unit,
+        category=IngredientCategory.DAIRY,
+        search_term=search_term,
+        from_meals=from_meals or ["Pancake Breakfast"],
     )
 
 
@@ -1597,3 +1627,261 @@ class TestCartBuilderCacheFlow:
         assert substitute_item.estimated_cost == round(10.99 * 2, 2)
         assert result.subtotal == round(10.99 * 2, 2)
         assert result.substituted_items == [sub_result]
+
+
+# ------------------------------------------------------------------
+# Tests: CartBuilder.build_cart restock/meal ingredient-name collision
+# (issue #80)
+# ------------------------------------------------------------------
+#
+# Reproduction guards for issue #80: build_cart classified restock
+# membership with a `restock_set: set[str]` built from ingredient NAME
+# alone (``is_restock = item.ingredient in restock_set``). When a
+# meal-plan item and a restock item share an ingredient name (e.g.
+# "milk"), the bug has two symptoms: (1) both copies are kept as
+# separate cart lines -- a double order -- and (2) the *regular* meal
+# item is also swept into ``restock_set`` membership and misfiled into
+# ``restock_cart``, corrupting ``_collect_restock_ingredients`` /
+# ``mark_restocked`` inventory bookkeeping in order_service.py. These
+# tests are written to the fixed contract (group-key based merging,
+# provenance/origin-based classification -- see the architecture plan
+# for issue #80) and are expected to FAIL against the current
+# implementation.
+
+
+class TestBuildCartRestockCollision:
+    """Tests for build_cart resolving meal/restock ingredient-name collisions.
+
+    See issue #80.
+    """
+
+    def _make_builder(self, product: SafewayProduct) -> CartBuilder:
+        """Create a CartBuilder that resolves every item to *product*.
+
+        Args:
+            product: The product every search/select call resolves to,
+                regardless of which shopping list item is being
+                processed.
+
+        Returns:
+            CartBuilder wired with fully mocked search, selector,
+            substitution, and Safeway client dependencies.
+        """
+        mock_search = MagicMock()
+        mock_search.get_cached_product.return_value = None
+        mock_search.search_products.return_value = [product]
+
+        mock_selector = MagicMock()
+        mock_selector.select_product.return_value = _MockSelectionResult(
+            item=_make_item(), product=product, reasoning="Test selection"
+        )
+
+        mock_substitution = MagicMock()
+        mock_client = MagicMock()
+        mock_client.store_id = "1234"
+        mock_client.get.return_value = {}
+
+        return CartBuilder(
+            search_service=mock_search,
+            product_selector=mock_selector,
+            substitution_service=mock_substitution,
+            safeway_client=mock_client,
+        )
+
+    def test_collision_same_ingredient_produces_single_cart_line(self) -> None:
+        """Test a meal item and restock item sharing a group key merge to one line.
+
+        Reproduction of issue #80: today the meal "milk 1 gal" and the
+        restock "milk 1 gal" are kept as two separate cart lines
+        instead of merging into a single line.
+        """
+        product = _make_product(price=3.99, size="1 gal")
+        builder = self._make_builder(product)
+        meal = _make_milk_item(quantity=1.0, unit="gal")
+        restock = _make_milk_item(quantity=1.0, unit="gal")
+
+        result = builder.build_cart([meal], restock_items=[restock])
+
+        assert len(result.items) + len(result.restock_items) == 1
+
+    def test_collision_line_is_restock_and_marks_inventory_once(self) -> None:
+        """Test the merged collision line lands in restock_items exactly once.
+
+        Reproduction of issue #80's inventory-corruption consequence:
+        today both the meal and restock copies land in
+        ``restock_items``, so ``mark_restocked`` (via
+        ``_collect_restock_ingredients``) would double-update inventory
+        for what is physically a single restock.
+        """
+        product = _make_product(price=3.99, size="1 gal")
+        builder = self._make_builder(product)
+        meal = _make_milk_item(quantity=1.0, unit="gal")
+        restock = _make_milk_item(quantity=1.0, unit="gal")
+
+        result = builder.build_cart([meal], restock_items=[restock])
+
+        assert len(result.restock_items) == 1
+        assert [
+            item.shopping_list_item.ingredient for item in result.restock_items
+        ] == ["milk"]
+
+    def test_collision_sums_quantities(self) -> None:
+        """Test the merged line's quantity covers both the meal and restock need.
+
+        1 gal (meal) + 1 gal (restock) against a "1 gal" product must
+        order 2 units in the single merged line -- enough to satisfy
+        both needs.
+        """
+        product = _make_product(price=3.99, size="1 gal")
+        builder = self._make_builder(product)
+        meal = _make_milk_item(quantity=1.0, unit="gal")
+        restock = _make_milk_item(quantity=1.0, unit="gal")
+
+        result = builder.build_cart([meal], restock_items=[restock])
+        merged_lines = result.items + result.restock_items
+
+        assert len(merged_lines) == 1
+        assert merged_lines[0].quantity_to_order == 2
+
+    def test_regular_item_sharing_name_not_misfiled_incompatible_units(
+        self,
+    ) -> None:
+        """Test incompatible-unit collisions stay split, classified by origin.
+
+        Reproduction of issue #80's misfiling defect: a meal item
+        "milk 2 cup" and a restock item "milk 1 bottle" have
+        incompatible group keys (dimensioned volume vs. dimensionless
+        packaging), so they must stay as two separate lines -- the
+        meal line in ``cart.items``, the restock line in
+        ``cart.restock_items``. Today, both are misclassified into
+        ``restock_items`` because classification keys on ingredient
+        name alone, regardless of unit compatibility.
+        """
+        product = _make_product(price=3.99, size="1 gal")
+        builder = self._make_builder(product)
+        meal = _make_milk_item(quantity=2.0, unit="cup")
+        restock = _make_milk_item(quantity=1.0, unit="bottle")
+
+        result = builder.build_cart([meal], restock_items=[restock])
+
+        assert len(result.items) == 1
+        assert len(result.restock_items) == 1
+        assert result.items[0].shopping_list_item.unit == Unit.CUP
+        assert result.restock_items[0].shopping_list_item.unit == Unit.BOTTLE
+
+    def test_merged_line_provenance_includes_meal_and_restock(self) -> None:
+        """Test the merged line's from_meals records both the meal and "restock".
+
+        Provenance for a merged collision line must include the
+        originating meal name(s) plus the literal string "restock" so
+        the cart display and any downstream provenance tracking can
+        still tell what was fused together.
+        """
+        product = _make_product(price=3.99, size="1 gal")
+        builder = self._make_builder(product)
+        meal = _make_milk_item(
+            quantity=1.0, unit="gal", from_meals=["Pancake Breakfast"]
+        )
+        restock = _make_milk_item(quantity=1.0, unit="gal")
+
+        result = builder.build_cart([meal], restock_items=[restock])
+        merged_lines = result.items + result.restock_items
+
+        assert len(merged_lines) == 1
+        from_meals = merged_lines[0].shopping_list_item.from_meals
+        assert "Pancake Breakfast" in from_meals
+        assert "restock" in from_meals
+
+    def test_no_collision_preserves_existing_separation(self) -> None:
+        """Test distinct ingredients still split correctly between the two lists.
+
+        A meal item for "eggs" and a restock item for "milk" share no
+        group key. This is not a reproduction of the bug -- today's
+        name-based classification already separates these correctly --
+        it's a regression guard so the issue #80 fix doesn't disturb
+        the existing, already-correct no-collision case.
+        """
+        product = _make_product(price=3.99, size="1 gal")
+        builder = self._make_builder(product)
+        meal = _make_item(ingredient="eggs", search_term="eggs")
+        restock = _make_milk_item(quantity=1.0, unit="gal")
+
+        result = builder.build_cart([meal], restock_items=[restock])
+
+        assert len(result.items) == 1
+        assert result.items[0].shopping_list_item.ingredient == "eggs"
+        assert len(result.restock_items) == 1
+        assert result.restock_items[0].shopping_list_item.ingredient == "milk"
+
+    def test_merged_quantity_exceeding_cap_flags_review(self) -> None:
+        """Test a merged quantity over the cap is capped and flagged for review.
+
+        8 gal (meal) + 8 gal (restock) against a "1 gal" product needs
+        16 units, which exceeds ``MAX_QUANTITY_PER_ITEM`` (10) -- the
+        merged line must be capped at 10 and flagged
+        ``review_reason="quantity_capped"``.
+        """
+        product = _make_product(price=3.99, size="1 gal")
+        builder = self._make_builder(product)
+        meal = _make_milk_item(quantity=8.0, unit="gal")
+        restock = _make_milk_item(quantity=8.0, unit="gal")
+
+        result = builder.build_cart([meal], restock_items=[restock])
+        merged_lines = result.items + result.restock_items
+
+        assert len(merged_lines) == 1
+        merged = merged_lines[0]
+        assert merged.quantity_to_order == MAX_QUANTITY_PER_ITEM
+        assert merged.needs_review is True
+        assert merged.review_reason == "quantity_capped"
+
+
+# ------------------------------------------------------------------
+# Tests: _merge_restock_into_meal (issue #80)
+# ------------------------------------------------------------------
+#
+# Direct test of the pure helper's "restock" marker dedup branch, which
+# isn't exercised through build_cart: build_cart only ever calls the
+# helper with a meal item that hasn't already been merged (see
+# _match_restock_to_meal), so a meal item whose from_meals already
+# contains "restock" only arises when the helper is invoked directly
+# with that precondition -- covered here for branch completeness.
+
+
+class TestMergeRestockIntoMeal:
+    """Direct tests for the _merge_restock_into_meal helper (issue #80)."""
+
+    def test_from_meals_dedup_skips_existing_restock_marker(self) -> None:
+        """Test the "restock" marker isn't duplicated if already present.
+
+        Covers the branch where ``meal_item.from_meals`` already
+        contains the literal ``"restock"`` marker -- it must not be
+        appended a second time.
+        """
+        meal_item = _make_milk_item(
+            quantity=1.0, unit="gal", from_meals=["Pancake Breakfast", "restock"]
+        )
+        restock_item = _make_milk_item(quantity=1.0, unit="gal")
+
+        merged = _merge_restock_into_meal(meal_item, restock_item)
+
+        assert merged.from_meals == ["Pancake Breakfast", "restock"]
+        assert merged.quantity == 2.0
+
+    def test_incompatible_units_fall_back_to_raw_quantity_sum(self) -> None:
+        """Test the defensive fallback when convert returns None.
+
+        The caller (``_merge_cart_inputs``) only pairs items sharing a
+        group key, which guarantees ``convert`` succeeds -- but if the
+        helper is ever invoked outside that precondition (e.g. cups vs.
+        a dimensionless packaging unit), it must degrade gracefully by
+        adding the raw quantity unconverted, mirroring
+        ``Consolidator._merge_quantity``'s defensive fallback.
+        """
+        meal_item = _make_milk_item(quantity=2.0, unit="cup")
+        restock_item = _make_milk_item(quantity=1.0, unit="bottle")
+
+        merged = _merge_restock_into_meal(meal_item, restock_item)
+
+        assert merged.quantity == 3.0
+        assert merged.unit == Unit.CUP

--- a/tests/test_cart_builder.py
+++ b/tests/test_cart_builder.py
@@ -1643,10 +1643,10 @@ class TestCartBuilderCacheFlow:
 # item is also swept into ``restock_set`` membership and misfiled into
 # ``restock_cart``, corrupting ``_collect_restock_ingredients`` /
 # ``mark_restocked`` inventory bookkeeping in order_service.py. These
-# tests are written to the fixed contract (group-key based merging,
-# provenance/origin-based classification -- see the architecture plan
-# for issue #80) and are expected to FAIL against the current
-# implementation.
+# tests were written RED-first to the fixed contract (group-key based
+# merging, provenance/origin-based classification -- see the
+# architecture plan for issue #80) and failed against the pre-fix
+# implementation; they now guard against regressing it.
 
 
 class TestBuildCartRestockCollision:

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 import pytest
 
 # The module itself (rather than a `from ... import group_key`) is imported
-# for TestGroupKey below: `group_key` doesn't exist yet (issue #80), and a
-# direct name import would raise ImportError at collection time, failing
-# every test in this file instead of just the new ones.
+# for TestGroupKey below: during the RED-first phase of issue #80,
+# `group_key` did not exist yet, and a direct name import would have raised
+# ImportError at collection time, failing every test in this file instead
+# of just the new ones. The module-attribute pattern is kept for symmetry.
 from grocery_butler import units
 from grocery_butler.models import Unit
 from grocery_butler.units import Dimension, convert, dimension_of, parse_size
@@ -247,16 +248,16 @@ class TestParseSizeNewUnits:
 # Tests: group_key (issue #80)
 # ------------------------------------------------------------------
 #
-# `units.group_key` doesn't exist yet -- it's a new public helper the
-# issue #80 fix will add, mirroring the semantics of
-# `Consolidator._ingredient_group_key`: units with a fixed physical
-# dimension (mass/volume/count) group by dimension so compatible units
-# merge; packaging/"other" units with no fixed dimension group by their
-# exact unit so incompatible packaging (e.g. jar vs. can) stays split.
-# Referenced via `units.group_key(...)` (not a top-level `from ... import
-# group_key`) so a missing attribute fails only these tests, not
-# collection of the whole module -- same pattern as
-# TestDimensionOfNewUnits above.
+# `units.group_key` is the public helper the issue #80 fix added
+# (written RED-first, before the helper existed), mirroring the
+# semantics of `Consolidator._ingredient_group_key`, which now delegates
+# to it: units with a fixed physical dimension (mass/volume/count) group
+# by dimension so compatible units merge; packaging/"other" units with
+# no fixed dimension group by their exact unit so incompatible packaging
+# (e.g. jar vs. can) stays split. Referenced via `units.group_key(...)`
+# (not a top-level `from ... import group_key`) so a missing attribute
+# would fail only these tests, not collection of the whole module --
+# same pattern as TestDimensionOfNewUnits above.
 
 
 class TestGroupKey:

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -9,6 +9,11 @@ from __future__ import annotations
 
 import pytest
 
+# The module itself (rather than a `from ... import group_key`) is imported
+# for TestGroupKey below: `group_key` doesn't exist yet (issue #80), and a
+# direct name import would raise ImportError at collection time, failing
+# every test in this file instead of just the new ones.
+from grocery_butler import units
 from grocery_butler.models import Unit
 from grocery_butler.units import Dimension, convert, dimension_of, parse_size
 
@@ -236,3 +241,57 @@ class TestParseSizeNewUnits:
     def test_parses_quart_abbreviation(self) -> None:
         """Test '2 qt' parses to (2.0, Unit.QUART)."""
         assert parse_size("2 qt") == (2.0, Unit.QUART)
+
+
+# ------------------------------------------------------------------
+# Tests: group_key (issue #80)
+# ------------------------------------------------------------------
+#
+# `units.group_key` doesn't exist yet -- it's a new public helper the
+# issue #80 fix will add, mirroring the semantics of
+# `Consolidator._ingredient_group_key`: units with a fixed physical
+# dimension (mass/volume/count) group by dimension so compatible units
+# merge; packaging/"other" units with no fixed dimension group by their
+# exact unit so incompatible packaging (e.g. jar vs. can) stays split.
+# Referenced via `units.group_key(...)` (not a top-level `from ... import
+# group_key`) so a missing attribute fails only these tests, not
+# collection of the whole module -- same pattern as
+# TestDimensionOfNewUnits above.
+
+
+class TestGroupKey:
+    """Tests for the new units.group_key helper (issue #80)."""
+
+    def test_dimensioned_units_group_by_dimension_not_exact_unit(self) -> None:
+        """Test cup and gallon (both volume) produce the same group key.
+
+        Dimensioned units must group by physical dimension, not exact
+        unit, so compatible units (e.g. cup and gallon) merge into a
+        single shopping-list/cart line.
+        """
+        assert units.group_key("milk", Unit.CUP) == units.group_key("milk", Unit.GAL)
+
+    def test_group_key_lowercases_ingredient_name(self) -> None:
+        """Test the ingredient name is lowercased for case-insensitive matching."""
+        assert units.group_key("MILK", Unit.CUP) == units.group_key("milk", Unit.CUP)
+
+    def test_dimensioned_group_key_token_is_dimension_prefixed(self) -> None:
+        """Test a dimensioned unit's group token starts with 'dim:'."""
+        _, token = units.group_key("milk", Unit.CUP)
+        assert token == "dim:volume"
+
+    def test_packaging_units_group_by_exact_unit_jar_vs_can(self) -> None:
+        """Test jar and can (both dimensionless packaging) produce different keys.
+
+        Packaging/"other" units have no fixed physical size, so
+        incompatible packaging (e.g. jar vs. can) must stay split into
+        separate line items rather than merging.
+        """
+        assert units.group_key("pickles", Unit.JAR) != units.group_key(
+            "pickles", Unit.CAN
+        )
+
+    def test_packaging_group_key_token_is_unit_prefixed(self) -> None:
+        """Test a packaging unit's group token starts with 'unit:'."""
+        _, token = units.group_key("pickles", Unit.JAR)
+        assert token == "unit:jar"


### PR DESCRIPTION
## Summary

Fixes issue #80: `CartBuilder.build_cart` classified restock membership by ingredient **name** (`restock_set: set[str]`), so a meal-plan item sharing an ingredient name with a restock item was (1) ordered twice as two separate cart lines and (2) misfiled into `restock_items`, corrupting `mark_restocked` inventory bookkeeping.

- **`units.group_key`** (new public helper): extracts the composite merge key previously inlined in `Consolidator._ingredient_group_key` (which now delegates to it) — dimensioned units (mass/volume/count) group by dimension; packaging/"other" units group by exact unit.
- **`_merge_cart_inputs`** in `cart_builder.py`: a restock item whose group key matches a meal item is merged into a single restock-classified cart line before processing, with the restock quantity unit-converted and summed and `"restock"` appended to the merged line's `from_meals` provenance.
- **Provenance-based classification**: `is_restock` is now determined by which input list an item came from, never by ingredient name — so incompatible-unit same-name collisions (e.g. milk in cups vs. milk in bottles) stay split and correctly filed.
- Downstream `_collect_restock_ingredients`/`mark_restocked` now see exactly one restock line per collision, keeping inventory updates correct.

## Test plan

- New `TestBuildCartRestockCollision` (7 tests): single merged line, restock classification + single inventory mark, quantity summing, incompatible-unit split, merged provenance, no-collision separation preserved, `MAX_QUANTITY_PER_ITEM` cap + `quantity_capped` review flag on merged quantities.
- New `TestMergeRestockIntoMeal` (2 tests): `"restock"` marker dedup; defensive raw-quantity fallback when `convert` returns `None` (mirrors `Consolidator._merge_quantity`).
- New `TestGroupKey` (5 tests): dimension grouping, case-insensitivity, `dim:`/`unit:` token forms, jar-vs-can packaging split.
- Tests were written RED-first and verified failing against the pre-fix implementation; full suite green: 1722 passed, coverage 96.33% (branch), `./scripts/check-all.sh` exit 0.
- Gate 2.5 self-review (quality + security) returned CLEAN; two non-blocking notes deferred as follow-ups: restock-queue entries that themselves share a group key still produce separate restock lines (pre-existing semantics), and `build_cart` assumes `items` is pre-deduplicated by the consolidator.

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)