### PR TITLE
fix(db): serialize migration runner across processes and run it once per process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,5 +21,6 @@ htmlcov/
 
 *.db
 *.sqlite3
+*.migratelock
 
 .secrets.baseline

--- a/grocery_butler/bot.py
+++ b/grocery_butler/bot.py
@@ -511,6 +511,7 @@ def create_bot(config: Config) -> discord.Client:
         Configured Discord client ready to run.
     """
     from grocery_butler.consolidator import Consolidator
+    from grocery_butler.db import init_db
     from grocery_butler.meal_parser import MealParser
     from grocery_butler.pantry_manager import PantryManager
     from grocery_butler.recipe_store import RecipeStore
@@ -527,6 +528,10 @@ def create_bot(config: Config) -> discord.Client:
 
     # Initialize backend services
     db_path = config.database_path
+    # Issue #78: explicit schema init before any store is constructed.
+    # init_db() is a run-once guard, so the store constructors' own
+    # init_db() calls below are cheap no-ops.
+    init_db(db_path)
     recipe_store = RecipeStore(db_path)
     pantry_manager = PantryManager(db_path)
     meal_parser = MealParser(recipe_store)

--- a/grocery_butler/cli.py
+++ b/grocery_butler/cli.py
@@ -14,6 +14,7 @@ import sys
 from typing import TYPE_CHECKING
 
 from grocery_butler.consolidator import Consolidator
+from grocery_butler.db import init_db
 from grocery_butler.meal_parser import MealParser
 from grocery_butler.models import (
     CartItem,
@@ -1016,6 +1017,15 @@ def main(argv: list[str] | None = None) -> None:
 def _dispatch(args: argparse.Namespace) -> int:
     """Dispatch a parsed command to the appropriate handler.
 
+    Issue #78: initializes the database schema once, here at the
+    shared dispatch point, before any handler constructs a store.
+    ``init_db()`` is itself a cheap run-once guard (subsequent calls
+    made by handlers' own store constructors are no-ops), so this does
+    not duplicate migration work. The ``bot`` command is excluded: it
+    builds no store directly in this module and instead delegates
+    entirely to :func:`grocery_butler.bot.create_bot`, which performs
+    its own ``init_db()`` call.
+
     Args:
         args: Parsed command-line arguments.
 
@@ -1023,6 +1033,10 @@ def _dispatch(args: argparse.Namespace) -> int:
         Exit code from the handler.
     """
     command: str = args.command
+    if command != "bot":
+        cfg = _load_config_safe()
+        init_db(cfg.database_path if cfg else "mealbot.db")
+
     if command == "plan":
         return _handle_plan(args)
     if command == "order":

--- a/grocery_butler/db/__init__.py
+++ b/grocery_butler/db/__init__.py
@@ -1,7 +1,27 @@
-"""Database initialization and connection utilities for MealBot."""
+"""Database initialization and connection utilities for MealBot.
+
+Issue #78: ``init_db()`` is called from every store constructor
+(``RecipeStore``, ``PantryManager``, ``ShoppingListStore``,
+``OrderSubmissionStore``) as well as at process-startup entry points
+(``cli.py``, ``bot.py``, ``safeway_pipeline.py``, ``app.py``). Without
+a run-once guard, each of those calls re-ran the full migration
+check-then-apply sequence, which is wasteful and — under concurrent
+gunicorn workers or concurrent in-process store construction — a
+source of the migration race reproduced in ``tests/test_migrate.py``.
+``init_db()`` now runs ``migrate()`` at most once per ``db_path`` per
+process: a lock-free fast path short-circuits already-initialized
+paths (opening no connection at all), and a ``threading.Lock``-guarded
+slow path handles the first call for a given path. The per-process
+guard is deliberately layered on top of, not instead of,
+``migrate()``'s own cross-process lock (see
+:mod:`grocery_butler.db.migrate`): the two together cover both
+concurrent threads within one process and concurrent gunicorn worker
+processes.
+"""
 
 from __future__ import annotations
 
+import threading
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -17,6 +37,12 @@ SCHEMA_PG_PATH = Path(__file__).parent / "schema_pg.sql"
 # Without this, the in-memory DB is destroyed when init_db closes its
 # connection and no other connections exist.
 _memory_keepalive: DatabaseConnection | None = None
+
+# Issue #78 run-once guard: serializes the slow (first-call) path of
+# init_db() for a given process, and the set of db_paths that have
+# already completed a successful migrate() call in this process.
+_init_lock = threading.Lock()
+_initialized_paths: set[str] = set()
 
 DEFAULT_PANTRY: list[tuple[str, str]] = [
     ("salt", "pantry_dry"),
@@ -57,8 +83,16 @@ def init_db(db_path: str) -> None:
     """Initialize the database schema and seed data via migrations.
 
     Delegates to the migration runner which applies any pending SQL
-    migrations in version order. Idempotent: safe to call multiple
-    times.
+    migrations in version order.
+
+    Issue #78: runs ``migrate()`` at most once per ``db_path`` per
+    process. A lock-free fast path returns immediately (opening no
+    connection) if ``db_path`` was already initialized. Otherwise, a
+    ``threading.Lock``-guarded slow path double-checks membership,
+    opens the ``:memory:`` keepalive connection on first use, and only
+    records ``db_path`` as initialized *after* ``migrate()`` succeeds —
+    a failed migration must not poison the cache and silently skip
+    retry on the next call.
 
     For ``:memory:`` databases, opens a keepalive connection so that
     the shared in-memory database persists across connections.
@@ -66,10 +100,37 @@ def init_db(db_path: str) -> None:
     Args:
         db_path: Path to the database file or a database URL.
     """
+    if db_path in _initialized_paths:
+        return
+
     global _memory_keepalive
-    if db_path == ":memory:" and _memory_keepalive is None:
-        _memory_keepalive = get_connection(db_path)
+    with _init_lock:
+        if db_path in _initialized_paths:
+            return
 
-    from grocery_butler.db.migrate import migrate
+        if db_path == ":memory:" and _memory_keepalive is None:
+            _memory_keepalive = get_connection(db_path)
 
-    migrate(db_path)
+        from grocery_butler.db.migrate import migrate
+
+        migrate(db_path)
+
+        _initialized_paths.add(db_path)
+
+
+def _reset_init_state() -> None:
+    """Reset the run-once init registry and close the memory keepalive.
+
+    Test-only hook (Issue #78). Module-level run-once state (
+    ``_initialized_paths`` and ``_memory_keepalive``) would otherwise
+    persist for the lifetime of the Python process, including across
+    tests in the same pytest session, letting one test's ``init_db()``
+    call silently short-circuit an unrelated later test's call to the
+    same path. See ``tests/conftest.py``'s autouse fixture, which calls
+    this before and after every test.
+    """
+    global _memory_keepalive
+    _initialized_paths.clear()
+    if _memory_keepalive is not None:
+        _memory_keepalive.close()
+        _memory_keepalive = None

--- a/grocery_butler/db/adapter.py
+++ b/grocery_butler/db/adapter.py
@@ -267,11 +267,27 @@ class SQLiteConnection:
 # ------------------------------------------------------------------
 
 
+# Issue #78: concurrent callers (e.g. several gunicorn workers or
+# in-process threads racing migrate()) open their own SQLite connections
+# before grocery_butler.db.migrate's cross-process fcntl.flock even gets
+# a chance to serialize them -- opening a connection and flipping a
+# fresh database file's journal mode to WAL both briefly need SQLite's
+# own internal lock, independent of that flock. Python's sqlite3 default
+# busy-wait window is only 5 seconds, which is occasionally too short
+# under heavy multi-thread contention (e.g. 8 workers racing a first
+# boot) and surfaces as a transient "database is locked" OperationalError
+# even though the flock-guarded critical section itself is serialized
+# correctly. A longer busy timeout lets SQLite's own busy handler retry
+# for up to 30s instead of failing fast.
+_SQLITE_BUSY_TIMEOUT_SECONDS: float = 30.0
+
+
 def _create_sqlite_connection(db_path: str) -> SQLiteConnection:
     """Create a configured SQLite connection.
 
-    Enables WAL journal mode, foreign key enforcement, and sets
-    the row factory to ``sqlite3.Row`` for dict-like access.
+    Enables WAL journal mode, foreign key enforcement, a generous busy
+    timeout (see :data:`_SQLITE_BUSY_TIMEOUT_SECONDS`), and sets the row
+    factory to ``sqlite3.Row`` for dict-like access.
 
     Args:
         db_path: File path, or ``:memory:`` for in-memory databases.
@@ -280,9 +296,13 @@ def _create_sqlite_connection(db_path: str) -> SQLiteConnection:
         A configured SQLiteConnection.
     """
     if db_path == ":memory:":
-        raw = sqlite3.connect("file::memory:?cache=shared", uri=True)
+        raw = sqlite3.connect(
+            "file::memory:?cache=shared",
+            uri=True,
+            timeout=_SQLITE_BUSY_TIMEOUT_SECONDS,
+        )
     else:
-        raw = sqlite3.connect(db_path)
+        raw = sqlite3.connect(db_path, timeout=_SQLITE_BUSY_TIMEOUT_SECONDS)
     raw.execute("PRAGMA journal_mode=WAL")
     raw.execute("PRAGMA foreign_keys=ON")
     raw.row_factory = sqlite3.Row

--- a/grocery_butler/db/migrate.py
+++ b/grocery_butler/db/migrate.py
@@ -7,6 +7,20 @@ runs only the pending ones in order.
 Supports both SQLite (``NNN_name.sql``) and PostgreSQL
 (``NNN_name_pg.sql``) dialects.
 
+Issue #78: because grocery-butler runs behind multiple gunicorn worker
+processes (and, in-process, every store constructor triggers a schema
+check via :func:`grocery_butler.db.init_db`), several ``migrate()``
+calls can race against a fresh database. :func:`migrate` guards its
+check-then-apply sequence with a cross-process lock, held for the
+duration of table-creation, applied-version reading, and application:
+a PostgreSQL session-level advisory lock (``pg_advisory_lock``) taken
+on the same connection used for the migration work, or — for a
+file-backed SQLite database — an exclusive ``fcntl.flock`` on a
+``<db_path>.migratelock`` sidecar file. ``":memory:"`` databases take
+neither lock: they are process-local, and
+:mod:`grocery_butler.db`'s in-process ``_init_lock`` already prevents
+concurrent callers within a single process.
+
 Usage::
 
     python -m grocery_butler.db.migrate          # uses DATABASE_URL or default
@@ -16,18 +30,22 @@ Usage::
 from __future__ import annotations
 
 import argparse
+import contextlib
+import fcntl
 import importlib
 import logging
 import os
 import re
 import sys
+import zlib
 from pathlib import Path
 from typing import TYPE_CHECKING
 
 from grocery_butler.db import get_connection
+from grocery_butler.db.adapter import IntegrityError
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterator
 
     from grocery_butler.db.adapter import DatabaseConnection
 
@@ -36,6 +54,15 @@ logger = logging.getLogger(__name__)
 MIGRATIONS_DIR = Path(__file__).parent / "migrations"
 
 _MIGRATION_RE = re.compile(r"^(\d{3})_(.+?)(?:_pg)?\.sql$")
+
+# Fixed advisory-lock key for migrate()'s cross-process PostgreSQL lock
+# (Issue #78). Derived once, at import time, from a constant identifier
+# string — never from user input or request data — so every process
+# that imports this module computes the identical key. A 32-bit CRC is
+# more than sufficient: this lock only needs to be unique among locks
+# *this application* takes, not globally unique across every process
+# sharing the database.
+_MIGRATION_LOCK_KEY: int = zlib.crc32(b"grocery_butler:schema_migrations")
 
 
 def _is_postgres(db_path: str) -> bool:
@@ -126,16 +153,37 @@ def _record_migration(conn: DatabaseConnection, version: int, name: str) -> None
     from injecting ``RETURNING id`` (schema_migrations has no ``id``
     column; its primary key is ``version``).
 
+    Issue #78: a caller can lose the migration-lock acquisition race
+    against another process (e.g. a PostgreSQL advisory lock is
+    session-scoped, not visible to a process that hasn't yet opened its
+    connection) and re-read "not yet applied" for a version a concurrent
+    ``migrate()`` call already recorded. A duplicate-version insert then
+    raises :data:`~grocery_butler.db.adapter.IntegrityError` (the
+    ``version`` primary key rejects the second row); that is tolerated
+    here as "already applied" rather than propagated. ``conn.commit()``
+    always runs afterward — for SQLite this simply commits an empty
+    transaction, and for PostgreSQL it clears the aborted-transaction
+    state left by the failed insert (PostgreSQL treats a ``COMMIT`` of
+    an aborted transaction as an implicit rollback, with no error) so
+    the connection remains usable for the rest of ``migrate()``.
+
     Args:
         conn: Active database connection.
         version: Migration version number.
         name: Migration name.
     """
-    result = conn.execute(
-        "INSERT INTO schema_migrations (version, name) VALUES (?, ?) RETURNING version",
-        (version, name),
-    )
-    result.fetchall()  # drain RETURNING so commit sees no open cursor
+    try:
+        result = conn.execute(
+            "INSERT INTO schema_migrations (version, name) VALUES (?, ?) "
+            "RETURNING version",
+            (version, name),
+        )
+        result.fetchall()  # drain RETURNING so commit sees no open cursor
+    except IntegrityError:
+        logger.info(
+            "Migration %03d already recorded by a concurrent process; skipping.",
+            version,
+        )
     conn.commit()
 
 
@@ -189,12 +237,227 @@ def _run_python_hook(version: int, name: str, db_path: str) -> None:
     hook(db_path)
 
 
-def migrate(db_path: str) -> int:
-    """Apply all pending migrations to the database.
+def _acquire_postgres_lock(conn: DatabaseConnection) -> None:
+    """Take the session-level PostgreSQL advisory lock for migrate().
+
+    Args:
+        conn: Active PostgreSQL connection. The lock is session-scoped,
+            so it must be released (see :func:`_release_postgres_lock`)
+            on this same connection.
+    """
+    conn.execute("SELECT pg_advisory_lock(?)", (_MIGRATION_LOCK_KEY,))
+
+
+def _release_postgres_lock(conn: DatabaseConnection) -> None:
+    """Release the session-level PostgreSQL advisory lock for migrate().
+
+    Args:
+        conn: The same connection :func:`_acquire_postgres_lock` was
+            called on.
+    """
+    conn.execute("SELECT pg_advisory_unlock(?)", (_MIGRATION_LOCK_KEY,))
+
+
+def _lock_file_path(db_path: str) -> str:
+    """Return the sidecar lock-file path for a file-backed SQLite database.
+
+    Args:
+        db_path: Path to the SQLite database file.
+
+    Returns:
+        ``db_path`` with a ``.migratelock`` suffix appended.
+    """
+    return f"{db_path}.migratelock"
+
+
+@contextlib.contextmanager
+def _postgres_migration_lock(conn: DatabaseConnection) -> Iterator[None]:
+    """Hold a session-level PostgreSQL advisory lock for migrate().
+
+    The lock is taken and released on ``conn`` itself, since PostgreSQL
+    session-level advisory locks are scoped to the session that
+    acquired them. Always released, including when the guarded block
+    raises.
+
+    Args:
+        conn: The PostgreSQL connection that will perform the migration
+            work.
+
+    Yields:
+        None. Control returns to the caller for the duration of the
+        lock.
+    """
+    _acquire_postgres_lock(conn)
+    try:
+        yield
+    finally:
+        _release_postgres_lock(conn)
+
+
+@contextlib.contextmanager
+def _sqlite_file_lock(db_path: str) -> Iterator[None]:
+    """Hold a cross-process file lock guarding a SQLite database (Issue #78).
+
+    File-backed SQLite: an exclusive ``fcntl.flock`` on a
+    ``<db_path>.migratelock`` sidecar file, released on exit.
+    ``":memory:"``: no lock. It is process-local, and
+    :mod:`grocery_butler.db`'s in-process ``_init_lock`` already
+    prevents concurrent callers within a single process.
+
+    Deliberately takes only ``db_path``, not a connection: unlike the
+    PostgreSQL advisory lock, this lock does not need to be held on the
+    connection that performs the migration work, which lets callers
+    acquire it *before* opening that connection at all. That ordering
+    matters — opening a SQLite connection to a brand-new database file
+    briefly needs SQLite's own internal exclusive lock (e.g. to convert
+    the fresh file to WAL journal mode), and several callers opening
+    connections to the same fresh file at once can transiently contend
+    for that internal lock and raise a spurious "database is locked"
+    error, even though none of them have reached any schema work yet.
+    Acquiring this lock first closes that race entirely: only the
+    caller holding the lock ever has a connection open to ``db_path``.
+
+    Args:
+        db_path: SQLite database file path, or ``":memory:"``.
+
+    Yields:
+        None. Control returns to the caller for the duration of the
+        lock.
+    """
+    if db_path == ":memory:":
+        yield
+        return
+
+    with open(_lock_file_path(db_path), "a", encoding="utf-8") as lock_file:
+        fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
+
+
+def _apply_pending(
+    conn: DatabaseConnection,
+    migrations: list[tuple[int, str, Path]],
+    applied: set[int],
+    db_path: str,
+) -> int:
+    """Apply migrations not yet recorded in ``applied``, in order.
+
+    Args:
+        conn: Active database connection (already holding the
+            migration lock for the duration of the caller's critical
+            section).
+        migrations: All discovered migrations for this dialect, sorted
+            by version.
+        applied: Versions already recorded in schema_migrations.
+        db_path: Database file path or PostgreSQL URL, passed through
+            to Python hooks.
+
+    Returns:
+        Number of migrations applied.
+    """
+    count = 0
+    for version, name, path in migrations:
+        if version in applied:
+            logger.debug("Skipping migration %03d_%s (already applied)", version, name)
+            continue
+
+        logger.info("Applying migration %03d_%s ...", version, name)
+        sql = path.read_text()
+        conn.executescript(sql)
+        _run_python_hook(version, name, db_path)
+        _record_migration(conn, version, name)
+        count += 1
+
+    return count
+
+
+def _run_migrations(conn: DatabaseConnection, db_path: str, *, is_pg: bool) -> int:
+    """Run the full check-then-apply sequence on an already-locked connection.
 
     Creates the schema_migrations tracking table if needed, discovers
     SQL migration files for the appropriate dialect, and applies any
-    that haven't been run yet in version order.
+    that haven't been run yet in version order. Callers are expected to
+    invoke this only while already holding the appropriate migration
+    lock (see :func:`_postgres_migration_lock` /
+    :func:`_sqlite_file_lock`), so that concurrent callers targeting
+    the same database are serialized instead of racing to double-apply
+    a migration.
+
+    Args:
+        conn: Active, lock-protected database connection.
+        db_path: Database file path or PostgreSQL URL.
+        is_pg: Whether ``db_path`` is a PostgreSQL URL.
+
+    Returns:
+        Number of migrations applied.
+    """
+    _ensure_schema_migrations_table(conn)
+    applied = _get_applied_versions(conn)
+    migrations = _discover_migrations(is_pg)
+    count = _apply_pending(conn, migrations, applied, db_path)
+
+    if count == 0:
+        logger.info("Database is up to date.")
+    else:
+        logger.info("Applied %d migration(s).", count)
+
+    return count
+
+
+def _migrate_postgres(db_path: str) -> int:
+    """Run migrate() against a PostgreSQL target.
+
+    Opens the connection first (the advisory lock is scoped to it),
+    then locks and runs the migration sequence on that same connection.
+
+    Args:
+        db_path: PostgreSQL connection URL.
+
+    Returns:
+        Number of migrations applied.
+    """
+    conn = get_connection(db_path)
+    try:
+        with _postgres_migration_lock(conn):
+            return _run_migrations(conn, db_path, is_pg=True)
+    finally:
+        conn.close()
+
+
+def _migrate_sqlite(db_path: str) -> int:
+    """Run migrate() against a SQLite target (file-backed or ``:memory:``).
+
+    Issue #78: acquires :func:`_sqlite_file_lock` *before* opening the
+    database connection, unlike the PostgreSQL path — see that lock's
+    docstring for why connection setup itself must happen under the
+    lock for SQLite.
+
+    Args:
+        db_path: SQLite database file path, or ``":memory:"``.
+
+    Returns:
+        Number of migrations applied.
+    """
+    with _sqlite_file_lock(db_path):
+        conn = get_connection(db_path)
+        try:
+            return _run_migrations(conn, db_path, is_pg=False)
+        finally:
+            conn.close()
+
+
+def migrate(db_path: str) -> int:
+    """Apply all pending migrations to the database.
+
+    Dispatches to a dialect-specific helper (:func:`_migrate_postgres`
+    or :func:`_migrate_sqlite`) that acquires the appropriate
+    cross-process lock — a PostgreSQL session-level advisory lock or a
+    ``fcntl.flock`` on a SQLite sidecar file — around the full
+    check-then-apply sequence, so concurrent callers targeting the same
+    database are serialized instead of racing to double-apply a
+    migration (Issue #78).
 
     Args:
         db_path: Database file path or PostgreSQL URL.
@@ -202,38 +465,9 @@ def migrate(db_path: str) -> int:
     Returns:
         Number of migrations applied.
     """
-    is_pg = _is_postgres(db_path)
-    conn = get_connection(db_path)
-    try:
-        _ensure_schema_migrations_table(conn)
-        applied = _get_applied_versions(conn)
-        migrations = _discover_migrations(is_pg)
-
-        count = 0
-        for version, name, path in migrations:
-            if version in applied:
-                logger.debug(
-                    "Skipping migration %03d_%s (already applied)",
-                    version,
-                    name,
-                )
-                continue
-
-            logger.info("Applying migration %03d_%s ...", version, name)
-            sql = path.read_text()
-            conn.executescript(sql)
-            _run_python_hook(version, name, db_path)
-            _record_migration(conn, version, name)
-            count += 1
-
-        if count == 0:
-            logger.info("Database is up to date.")
-        else:
-            logger.info("Applied %d migration(s).", count)
-
-        return count
-    finally:
-        conn.close()
+    if _is_postgres(db_path):
+        return _migrate_postgres(db_path)
+    return _migrate_sqlite(db_path)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/grocery_butler/safeway_pipeline.py
+++ b/grocery_butler/safeway_pipeline.py
@@ -11,6 +11,7 @@ import uuid
 from typing import TYPE_CHECKING, Any
 
 from grocery_butler.cart_builder import CartBuilder
+from grocery_butler.db import init_db
 from grocery_butler.order_service import (
     ORDER_SUBMISSION_DISABLED_MESSAGE,
     OrderOutcome,
@@ -88,6 +89,11 @@ class SafewayPipeline:
         Raises:
             SafewayPipelineError: If required Safeway config is missing.
         """
+        # Issue #78: explicit schema init before any store is built
+        # below. init_db() is a run-once guard, so the stores'
+        # own init_db() calls are cheap no-ops.
+        init_db(db_path)
+
         if not config.safeway_username or not config.safeway_password:
             raise SafewayPipelineError(
                 "Safeway credentials required: set SAFEWAY_USERNAME "

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,11 +6,49 @@ tokens in tests (issue #74): every test module that needs an
 :func:`bearer_header` rather than hand-rolling ``mint_token`` calls, so
 the whole suite stays in sync with the ``RequestBinding`` contract in
 ``grocery_butler.auth_middleware``.
+
+Also hosts the Issue #78 autouse fixture: ``grocery_butler.db`` has a
+run-once ``init_db`` guard (a module-level ``_initialized_paths``
+registry) that persists for the lifetime of the Python process --
+including across tests within the same pytest session. Without a reset
+between tests, one test's ``init_db(path)`` call could make a later,
+unrelated test's ``init_db(path)`` call silently short-circuit (or vice
+versa for ``:memory:``), producing order-dependent test pollution. The
+``_reset_db_init_state`` fixture resets that state via
+``grocery_butler.db._reset_init_state()`` before and after every test.
 """
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+import pytest
+
+import grocery_butler.db as db_module
 from grocery_butler.auth_middleware import RequestBinding, mint_token
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture(autouse=True)
+def _reset_db_init_state() -> Iterator[None]:
+    """Reset grocery_butler.db's run-once init state around each test.
+
+    Looked up via ``getattr`` so a rename or removal of the test-only
+    ``_reset_init_state`` hook degrades this fixture to a no-op instead
+    of failing test collection (Issue #78).
+
+    Yields:
+        None. Control returns to the test between the pre- and
+        post-test resets.
+    """
+    reset = getattr(db_module, "_reset_init_state", None)
+    if reset is not None:
+        reset()
+    yield
+    if reset is not None:
+        reset()
 
 
 def bearer_header(

--- a/tests/test_db_init.py
+++ b/tests/test_db_init.py
@@ -1,0 +1,260 @@
+"""Tests for grocery_butler.db's run-once init_db guard (Issue #78).
+
+Multiple gunicorn worker processes race to boot against the same
+database, and every store constructor (``RecipeStore``, ``PantryManager``,
+``ShoppingListStore``, ``OrderSubmissionStore``) also calls
+``init_db(db_path)`` at construction time. Before the Issue #78 fix,
+``init_db()`` unconditionally re-runs ``migrate()`` on every call --
+wasteful at best, and a source of the concurrent first-boot race
+reproduced in ``tests/test_migrate.py`` at worst.
+
+These tests pin the run-once guard's contract:
+
+* ``migrate()`` runs at most once per ``db_path`` within a process.
+* The fast path (a ``db_path`` already initialized) opens no database
+  connection at all.
+* ``_reset_init_state()`` (a test-only hook) clears the registry so a
+  ``db_path`` can be reinitialized.
+* The ``:memory:`` keepalive connection is opened exactly once, and
+  ``migrate()`` likewise runs exactly once for ``:memory:`` under the
+  run-once guard.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+import grocery_butler.db as db_module
+import grocery_butler.db.migrate as migrate_module
+from grocery_butler.db import init_db
+from grocery_butler.order_submissions import OrderSubmissionStore
+from grocery_butler.pantry_manager import PantryManager
+from grocery_butler.recipe_store import RecipeStore
+from grocery_butler.shopping_list_store import ShoppingListStore
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from grocery_butler.db.adapter import DatabaseConnection
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def db_path(tmp_path: Path) -> str:
+    """Return a temporary database path for test isolation."""
+    return str(tmp_path / "test_db_init.db")
+
+
+# ---------------------------------------------------------------------------
+# init_db() runs migrate() at most once per db_path
+# ---------------------------------------------------------------------------
+
+
+class TestInitDbRunsOnce:
+    """Tests that init_db() invokes migrate() at most once per db_path."""
+
+    def test_init_db_runs_migrate_only_once_per_path(
+        self, db_path: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test 5 repeated init_db(path) calls invoke migrate() exactly once.
+
+        Guards Issue #78's core defect: init_db() currently has no
+        run-once registry, so it re-runs the full migration check-then-
+        apply sequence on every call -- wasteful at best and a source of
+        the concurrent-boot race at worst.
+        """
+        mock_migrate = MagicMock(return_value=0)
+        monkeypatch.setattr(migrate_module, "migrate", mock_migrate)
+
+        for _ in range(5):
+            init_db(db_path)
+
+        mock_migrate.assert_called_once_with(db_path)
+
+    def test_store_construction_after_init_db_does_not_invoke_migration_runner(
+        self, db_path: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test constructing 4 stores after init_db() never re-invokes migrate().
+
+        This is Issue #78 acceptance criterion #1: once a process has
+        initialized a db_path, every store built against that same path
+        (``RecipeStore``, ``PantryManager``, ``ShoppingListStore``,
+        ``OrderSubmissionStore`` -- each of which calls ``init_db()``
+        itself in its constructor) must not trigger another migration
+        run.
+        """
+        init_db(db_path)
+
+        mock_migrate = MagicMock(return_value=0)
+        monkeypatch.setattr(migrate_module, "migrate", mock_migrate)
+
+        RecipeStore(db_path)
+        PantryManager(db_path)
+        ShoppingListStore(db_path)
+        OrderSubmissionStore(db_path)
+
+        mock_migrate.assert_not_called()
+
+    def test_init_db_fast_path_opens_no_connection(
+        self, db_path: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test a second init_db(path) call opens no database connection.
+
+        After the first (real) init_db() call, every symbol that could
+        open a connection -- ``grocery_butler.db.get_connection`` (used
+        directly by init_db for the ``:memory:`` keepalive) and
+        ``grocery_butler.db.migrate.get_connection`` (used internally by
+        migrate()) -- is replaced with a function that raises. The
+        second call must take the run-once fast path and touch neither.
+        """
+        init_db(db_path)
+
+        def _raise(_path: str) -> None:
+            raise AssertionError("init_db fast path must not open a connection")
+
+        monkeypatch.setattr(db_module, "get_connection", _raise)
+        monkeypatch.setattr(migrate_module, "get_connection", _raise)
+
+        init_db(db_path)
+
+
+# ---------------------------------------------------------------------------
+# Failed migrations must not poison the run-once cache
+# ---------------------------------------------------------------------------
+
+
+class TestInitDbFailurePropagation:
+    """Tests that a failed migrate() does not poison the run-once cache."""
+
+    def test_failed_migration_does_not_poison_run_once_cache(
+        self, db_path: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test a raising migrate() leaves init_db(path) retryable.
+
+        Pins the documented Issue #78 contract that ``db_path`` is
+        recorded as initialized only *after* ``migrate()`` succeeds: if
+        the first ``init_db(path)`` call fails, the failure must
+        propagate, the path must not enter the run-once registry, and a
+        second ``init_db(path)`` call must re-invoke ``migrate()``
+        rather than silently short-circuiting on a broken schema.
+        """
+        calls: list[str] = []
+
+        def _flaky_migrate(path: str) -> int:
+            calls.append(path)
+            if len(calls) == 1:
+                raise RuntimeError("simulated migration failure")
+            return 0
+
+        monkeypatch.setattr(migrate_module, "migrate", _flaky_migrate)
+
+        with pytest.raises(RuntimeError, match="simulated migration failure"):
+            init_db(db_path)
+
+        assert db_path not in db_module._initialized_paths, (
+            "a failed migrate() must not mark the path as initialized"
+        )
+
+        init_db(db_path)
+
+        assert calls == [db_path, db_path], (
+            "the second init_db() call must re-invoke migrate()"
+        )
+        assert db_path in db_module._initialized_paths
+
+
+# ---------------------------------------------------------------------------
+# _reset_init_state() test hook
+# ---------------------------------------------------------------------------
+
+
+class TestResetInitState:
+    """Tests for the ``_reset_init_state()`` test hook."""
+
+    def test_reset_init_state_forces_reinit(
+        self, db_path: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test _reset_init_state() clears the run-once registry.
+
+        After a reset, a previously-initialized db_path is treated as
+        brand new again: the next init_db() call must re-invoke
+        migrate().
+        """
+        calls: list[str] = []
+
+        def _fake_migrate(path: str) -> int:
+            calls.append(path)
+            return 0
+
+        monkeypatch.setattr(migrate_module, "migrate", _fake_migrate)
+
+        init_db(db_path)
+        db_module._reset_init_state()
+        init_db(db_path)
+
+        assert calls == [db_path, db_path]
+
+
+# ---------------------------------------------------------------------------
+# :memory: keepalive + run-once semantics
+# ---------------------------------------------------------------------------
+
+
+class TestMemoryKeepalive:
+    """Tests for :memory: run-once semantics (keepalive + migrate)."""
+
+    def test_memory_keepalive_opened_once(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test repeated init_db(":memory:") opens the keepalive once.
+
+        Forces a clean starting state for the shared
+        ``_memory_keepalive`` global (module-level state that would
+        otherwise leak between tests), then asserts two properties
+        across two ``init_db(":memory:")`` calls: the keepalive
+        connection is opened exactly once (already true on current
+        code -- pre-existing behavior, not itself part of Issue #78),
+        and ``migrate()`` is invoked exactly once (the Issue #78
+        run-once guard; currently invoked on every call). Finally
+        checks the schema is actually usable afterwards.
+        """
+        monkeypatch.setattr(db_module, "_memory_keepalive", None)
+
+        real_get_connection = db_module.get_connection
+        connection_calls: list[str] = []
+
+        def _counting_get_connection(path: str) -> DatabaseConnection:
+            connection_calls.append(path)
+            return real_get_connection(path)
+
+        monkeypatch.setattr(db_module, "get_connection", _counting_get_connection)
+
+        real_migrate = migrate_module.migrate
+        migrate_calls: list[str] = []
+
+        def _counting_migrate(path: str) -> int:
+            migrate_calls.append(path)
+            return real_migrate(path)
+
+        monkeypatch.setattr(migrate_module, "migrate", _counting_migrate)
+
+        init_db(":memory:")
+        init_db(":memory:")
+
+        assert connection_calls == [":memory:"], "keepalive must open exactly once"
+        assert migrate_calls == [":memory:"], "migrate() must run exactly once"
+
+        conn = real_get_connection(":memory:")
+        try:
+            cursor = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='recipes'"
+            )
+            assert cursor.fetchone() is not None
+        finally:
+            conn.close()

--- a/tests/test_migrate.py
+++ b/tests/test_migrate.py
@@ -2,14 +2,22 @@
 
 from __future__ import annotations
 
+import contextlib
+import fcntl
 import importlib
+import threading
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+import grocery_butler.db.migrate as migrate_module
+
 if TYPE_CHECKING:
+    from collections.abc import Callable, Sequence
     from pathlib import Path
+
+    from grocery_butler.db.adapter import DatabaseConnection
 
 from grocery_butler.db import get_connection
 from grocery_butler.db.migrate import (
@@ -24,6 +32,7 @@ from grocery_butler.db.migrate import (
     migrate,
 )
 from grocery_butler.models import Unit
+from grocery_butler.recipe_store import RecipeStore
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -34,6 +43,75 @@ from grocery_butler.models import Unit
 def db_path(tmp_path: Path) -> str:
     """Return a temporary database path for test isolation."""
     return str(tmp_path / "test_migrate.db")
+
+
+# ---------------------------------------------------------------------------
+# Concurrency test helpers (Issue #78)
+# ---------------------------------------------------------------------------
+
+
+def _run_concurrently(action: Callable[[], None], count: int) -> list[BaseException]:
+    """Run ``action`` in ``count`` threads and collect any exceptions raised.
+
+    Args:
+        action: Zero-argument callable invoked once per worker thread.
+        count: Number of worker threads to spawn.
+
+    Returns:
+        Exceptions raised by worker threads, in the order they were
+        caught. Empty if every worker completed without raising.
+    """
+    errors: list[BaseException] = []
+    errors_lock = threading.Lock()
+
+    def _worker() -> None:
+        try:
+            action()
+        except Exception as exc:
+            with errors_lock:
+                errors.append(exc)
+
+    threads = [threading.Thread(target=_worker) for _ in range(count)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=15)
+    return errors
+
+
+def _synchronizing_wrapper(
+    original: Callable[[DatabaseConnection], set[int]],
+    barrier: threading.Barrier,
+    timeout: float = 2.0,
+) -> Callable[[DatabaseConnection], set[int]]:
+    """Wrap ``_get_applied_versions`` so concurrent callers rendezvous first.
+
+    Forces every concurrent ``migrate()`` invocation that reaches the
+    check-then-apply read to arrive at (approximately) the same moment,
+    making the "every caller observes zero applied migrations" race
+    deterministic instead of depending on raw thread-scheduling luck.
+
+    If ``migrate()`` becomes properly serialized (the Issue #78 fix),
+    only one caller at a time ever reaches this point; ``timeout`` lets
+    that lone caller proceed after a brief wait instead of blocking
+    forever for parties that will never arrive. Once the barrier trips
+    or breaks, later calls resolve immediately.
+
+    Args:
+        original: The real ``_get_applied_versions`` to delegate to.
+        barrier: Shared barrier all concurrent callers rendezvous on.
+        timeout: Max seconds to wait for other parties before giving up.
+
+    Returns:
+        A wrapped callable with the same signature as ``original``.
+    """
+
+    def _wrapped(conn: DatabaseConnection) -> set[int]:
+        with contextlib.suppress(threading.BrokenBarrierError):
+            barrier.wait(timeout=timeout)
+        return original(conn)
+
+    return _wrapped
 
 
 # ---------------------------------------------------------------------------
@@ -483,6 +561,121 @@ class TestMigrate:
 
 
 # ---------------------------------------------------------------------------
+# Concurrent first-boot race reproduction (Issue #78)
+#
+# grocery-butler runs behind multiple gunicorn worker processes that can
+# each hit a fresh database at roughly the same instant. Every store
+# constructor also calls migrate() (via init_db) unconditionally, so even
+# single-process multi-threaded callers can race. Both tests below use
+# ``_synchronizing_wrapper`` to force concurrent callers to observe "zero
+# applied migrations" simultaneously, deterministically reproducing the
+# check-then-apply race instead of depending on raw thread timing.
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentFirstBootRace:
+    """Reproduction tests for concurrent first-boot migration races."""
+
+    def test_concurrent_first_boot_applies_each_migration_exactly_once(
+        self, db_path: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test N concurrent migrate() calls on one fresh DB apply cleanly.
+
+        Reproduces the gunicorn multi-worker race from Issue #78: several
+        workers boot against the same fresh database and each calls
+        migrate() before any of them has recorded a single applied
+        version. On current (unguarded) code this causes a duplicate-apply
+        failure -- typically an IntegrityError from the second writer to
+        record the same version, or a "database is locked" error from
+        concurrent unserialized writers. Once migrate() takes a
+        cross-process lock around its check-then-apply sequence (Issue
+        #78 fix), every worker is serialized and this passes cleanly with
+        each migration recorded exactly once.
+        """
+        num_workers = 8
+        barrier = threading.Barrier(num_workers)
+        original = migrate_module._get_applied_versions
+        monkeypatch.setattr(
+            migrate_module,
+            "_get_applied_versions",
+            _synchronizing_wrapper(original, barrier),
+        )
+
+        errors = _run_concurrently(lambda: migrate(db_path), num_workers)
+
+        assert not errors, (
+            f"migrate() raised in {len(errors)}/{num_workers} worker "
+            f"thread(s) under concurrent first boot: {errors!r}"
+        )
+
+        conn = get_connection(db_path)
+        try:
+            rows = conn.execute(
+                "SELECT version FROM schema_migrations ORDER BY version"
+            ).fetchall()
+        finally:
+            conn.close()
+
+        applied_versions = [row["version"] for row in rows]
+        expected_versions = sorted(v for v, _, _ in _discover_migrations(is_pg=False))
+
+        assert applied_versions == expected_versions, (
+            "each migration must be recorded exactly once, in version order"
+        )
+
+
+class TestConcurrentStoreConstructionRace:
+    """Reproduction tests for races triggered via concurrent store construction."""
+
+    def test_concurrent_store_construction_applies_migrations_once(
+        self, db_path: str, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test N concurrent RecipeStore(...) constructions apply cleanly.
+
+        Every store constructor calls init_db() -> migrate() at
+        construction time (Issue #78: "migration runner ... runs inside
+        every store constructor"). Several gunicorn workers constructing a
+        store against the same fresh database concurrently must not race.
+        Uses the same barrier-synchronized ``_get_applied_versions``
+        technique as
+        ``test_concurrent_first_boot_applies_each_migration_exactly_once``.
+        Once Issue #78's run-once ``init_db`` guard lands, only the first
+        construction ever reaches migrate() at all, so later barrier waits
+        harmlessly time out via ``_synchronizing_wrapper`` and this passes.
+        """
+        num_workers = 8
+        barrier = threading.Barrier(num_workers)
+        original = migrate_module._get_applied_versions
+        monkeypatch.setattr(
+            migrate_module,
+            "_get_applied_versions",
+            _synchronizing_wrapper(original, barrier),
+        )
+
+        errors = _run_concurrently(lambda: RecipeStore(db_path), num_workers)
+
+        assert not errors, (
+            f"RecipeStore(...) raised in {len(errors)}/{num_workers} worker "
+            f"thread(s) under concurrent construction: {errors!r}"
+        )
+
+        conn = get_connection(db_path)
+        try:
+            rows = conn.execute(
+                "SELECT version FROM schema_migrations ORDER BY version"
+            ).fetchall()
+        finally:
+            conn.close()
+
+        applied_versions = [row["version"] for row in rows]
+        expected_versions = sorted(v for v, _, _ in _discover_migrations(is_pg=False))
+
+        assert applied_versions == expected_versions, (
+            "each migration must be recorded exactly once, in version order"
+        )
+
+
+# ---------------------------------------------------------------------------
 # CLI (main)
 # ---------------------------------------------------------------------------
 
@@ -567,5 +760,239 @@ class TestCLI:
                 "WHERE type='table' AND name='schema_migrations'"
             )
             assert cursor.fetchone() is not None
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Migration lock tests (Issue #78)
+#
+# migrate() must hold a lock around its check-then-apply sequence so that
+# concurrent callers cannot both observe "nothing applied yet" and both
+# attempt to apply the same migration. PostgreSQL gets a session-level
+# advisory lock on the SAME connection used for the migration work;
+# SQLite (file-backed) gets a cross-process fcntl.flock on a sidecar file;
+# ":memory:" needs neither (Layer 1's in-process lock already covers it).
+#
+# The PostgreSQL tests mock the connection layer entirely (no real
+# PostgreSQL server) so the exact SQL issued can be inspected directly,
+# mirroring the fake-connection pattern in
+# tests/test_order_submissions.py::TestTryRecordAttemptPostgresAdvisoryLock.
+# ---------------------------------------------------------------------------
+
+
+class _FakeCursorResult:
+    """Stub CursorResult reporting an empty result set."""
+
+    def fetchone(self) -> None:
+        """Return None; no test here reads a single result row.
+
+        Returns:
+            None, always.
+        """
+        return None
+
+    def fetchall(self) -> list[object]:
+        """Return an empty list; no pending versions/rows to report.
+
+        Returns:
+            An empty list, always.
+        """
+        return []
+
+
+class _RecordingConnection:
+    """Fake DatabaseConnection recording every statement, in call order."""
+
+    def __init__(self) -> None:
+        """Initialize with an empty ordered call log."""
+        self.calls: list[tuple[str, tuple[object, ...]]] = []
+
+    def execute(self, sql: str, params: Sequence[object] = ()) -> _FakeCursorResult:
+        """Record the statement and params, returning an empty result.
+
+        Args:
+            sql: The SQL statement executed.
+            params: The parameters bound to the statement.
+
+        Returns:
+            A canned empty-result stub.
+        """
+        self.calls.append((sql, tuple(params)))
+        return _FakeCursorResult()
+
+    def executescript(self, sql: str) -> None:
+        """Record the script as a call with no params.
+
+        Args:
+            sql: The multi-statement SQL script executed.
+        """
+        self.calls.append((sql, ()))
+
+    def commit(self) -> None:
+        """No-op commit."""
+
+    def close(self) -> None:
+        """No-op close."""
+
+
+class TestPostgresMigrateAdvisoryLock:
+    """Tests for the PostgreSQL advisory-lock branch of migrate()'s lock."""
+
+    def test_postgres_migrate_takes_advisory_lock_before_apply(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test migrate() locks a PostgreSQL connection before touching schema.
+
+        No real PostgreSQL server is involved: ``get_connection`` is
+        mocked to return a recording fake so the exact SQL issued by
+        migrate() can be inspected. Migration discovery is mocked to
+        report no pending migrations so this test isolates the lock
+        sequencing from migration-application concerns entirely. A
+        ``pg_advisory_lock`` statement must be executed on the connection
+        strictly before the first ``schema_migrations``-touching
+        statement (table creation / applied-versions read).
+        """
+        conn = _RecordingConnection()
+        monkeypatch.setattr(migrate_module, "get_connection", lambda _path: conn)
+        monkeypatch.setattr(migrate_module, "_discover_migrations", lambda is_pg: [])
+
+        migrate_module.migrate("postgresql://example/db")
+
+        lock_index = next(
+            i
+            for i, (sql, _params) in enumerate(conn.calls)
+            if "pg_advisory_lock" in sql and "unlock" not in sql.lower()
+        )
+        schema_migrations_index = next(
+            i
+            for i, (sql, _params) in enumerate(conn.calls)
+            if "schema_migrations" in sql
+        )
+
+        assert lock_index < schema_migrations_index, (
+            "advisory lock must be acquired before touching schema_migrations"
+        )
+
+    def test_postgres_migrate_releases_advisory_lock_even_on_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test migrate() releases its advisory lock even when apply fails.
+
+        ``_get_applied_versions`` (invoked inside the locked
+        check-then-apply section) is forced to raise, simulating a
+        failure partway through migrate(). The advisory lock taken on
+        the connection must still be released via ``pg_advisory_unlock``
+        despite the failure.
+        """
+        conn = _RecordingConnection()
+        monkeypatch.setattr(migrate_module, "get_connection", lambda _path: conn)
+
+        def _boom(_conn: object) -> set[int]:
+            raise RuntimeError("boom")
+
+        monkeypatch.setattr(migrate_module, "_get_applied_versions", _boom)
+
+        with pytest.raises(RuntimeError, match="boom"):
+            migrate_module.migrate("postgresql://example/db")
+
+        unlock_calls = [
+            sql for sql, _params in conn.calls if "pg_advisory_unlock" in sql
+        ]
+
+        assert unlock_calls, "advisory lock must be released even when migrate() fails"
+
+
+class TestSQLiteMigrateFileLock:
+    """Tests for the SQLite file-lock branch of migrate()'s lock."""
+
+    def test_sqlite_migrate_acquires_and_releases_file_lock(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test migrate() takes an exclusive flock around a file-backed DB.
+
+        ``fcntl.flock`` is monkeypatched (on the shared ``fcntl`` module,
+        so it intercepts calls regardless of how migrate.py imports it)
+        to record every call. A real migrate() run against a fresh
+        on-disk SQLite database must acquire ``LOCK_EX`` and later
+        release it with ``LOCK_UN``.
+        """
+        flock_calls: list[int] = []
+
+        def _fake_flock(_fd: int, operation: int) -> None:
+            flock_calls.append(operation)
+
+        monkeypatch.setattr(fcntl, "flock", _fake_flock)
+
+        db_path = str(tmp_path / "sqlite_lock.db")
+        migrate_module.migrate(db_path)
+
+        assert fcntl.LOCK_EX in flock_calls, "expected an exclusive lock acquisition"
+        ex_index = flock_calls.index(fcntl.LOCK_EX)
+        un_index = next(
+            i
+            for i, op in enumerate(flock_calls)
+            if op == fcntl.LOCK_UN and i > ex_index
+        )
+
+        assert un_index > ex_index, (
+            "the exclusive lock must be released after acquisition"
+        )
+
+    def test_memory_migrate_skips_file_lock(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Test migrate(":memory:") never touches fcntl.flock.
+
+        ``":memory:"`` is process-local (Layer 1's in-process
+        ``_init_lock`` already covers it), so it needs no cross-process
+        file lock. Note: because no flock call is issued anywhere in the
+        codebase yet, this negative assertion also holds true before the
+        Issue #78 fix lands -- it is a regression guard for the fixed
+        behavior rather than a reproduction of a current bug.
+        """
+        flock_calls: list[int] = []
+
+        def _fake_flock(_fd: int, operation: int) -> None:
+            flock_calls.append(operation)
+
+        monkeypatch.setattr(fcntl, "flock", _fake_flock)
+
+        migrate_module.migrate(":memory:")
+
+        assert flock_calls == []
+
+
+class TestRecordMigrationDuplicateTolerance:
+    """Tests for _record_migration's duplicate-version tolerance (Issue #78).
+
+    Under the fixed migrate(), a caller can lose a lock-acquisition race
+    against another process and re-read "not yet applied" for a version
+    that a concurrent migrate() call is in the process of recording.
+    ``_record_migration`` must treat a duplicate-version IntegrityError as
+    "already applied" rather than propagating it.
+    """
+
+    def test_record_migration_tolerates_duplicate_version(self, db_path: str) -> None:
+        """Test recording the same version twice does not raise.
+
+        Exactly one row for the version must exist afterwards -- the
+        second call is a no-op, not a second insert.
+        """
+        conn = get_connection(db_path)
+        try:
+            _ensure_schema_migrations_table(conn)
+            _record_migration(conn, 1, "x")
+
+            _record_migration(conn, 1, "x")
+
+            applied = _get_applied_versions(conn)
+            assert applied == {1}
+
+            cursor = conn.execute(
+                "SELECT COUNT(*) as cnt FROM schema_migrations WHERE version = ?",
+                (1,),
+            )
+            assert cursor.fetchone()["cnt"] == 1
         finally:
             conn.close()


### PR DESCRIPTION
## Summary

- Serializes the migration runner's check-then-apply sequence with a cross-process lock inside `migrate()`: a session-level `pg_advisory_lock` (fixed `zlib.crc32` key, taken and released on the migration connection) on PostgreSQL, and an exclusive `fcntl.flock` on a `<db_path>.migratelock` sidecar file — acquired *before* opening the connection — for file-backed SQLite. `_record_migration` now tolerates a duplicate-version `IntegrityError` as "already applied", so a worker that loses the lock race can never 500 a boot.
- Adds a per-process run-once guard to `init_db()`: a lock-free fast path (no connection opened) for already-initialized paths and a `threading.Lock`-guarded slow path that records a path as initialized only *after* `migrate()` succeeds, so a failed migration stays retryable. Entry points (`create_app` — pre-existing — plus `create_bot`, the CLI dispatch, and `SafewayPipeline`) init the schema up front, so the API blueprint's per-request store construction never re-runs the migration check.
- Raises the SQLite busy timeout to 30s for all connections so first-boot contention on a fresh database file (connection open + WAL conversion need SQLite's internal lock before any `flock` is reachable) degrades to a brief wait instead of a spurious "database is locked" error. Production (PostgreSQL) is unaffected.

## Acceptance-criteria interpretation

Criterion 1 ("store constructors no longer invoke the migration runner") is met as *constructors never (re-)run the migration runner in steady state*: the constructors retain their `init_db()` calls, but those are run-once no-ops after process init — pinned by `tests/test_db_init.py::test_store_construction_after_init_db_does_not_invoke_migration_runner`. Removing the calls outright was considered and deliberately rejected (chief-architect review): it would break the lazy-initialization contract that the test suite and direct library/CLI store users rely on, a far larger behavior change than the bug. The first-ever construction of a fresh path still initializes the schema — safely, behind the cross-process lock, which is what actually fixes the concurrent-boot 500s (criterion 2). `docker-entrypoint.sh` (PR #101) remains the primary pre-gunicorn migration step; the in-process lock is the backstop for bypassed-entrypoint and dev flows.

## Test plan

- New `tests/test_db_init.py` (6 tests): `migrate()` runs at most once per path per process; store construction after init never re-invokes the runner; the fast path opens no connection; a failed `migrate()` propagates and does not poison the run-once cache (retryable); `_reset_init_state()` forces reinit; `:memory:` keepalive + migrate run exactly once.
- `tests/test_migrate.py` additions: 8-thread barrier-synchronized concurrent first-boot and concurrent `RecipeStore` construction against a fresh DB apply every migration exactly once with zero errors; PostgreSQL advisory lock is acquired before any `schema_migrations` access and released even when apply fails (recording fake connection, no PG server needed); SQLite path acquires and releases the exclusive `flock`; `:memory:` skips the file lock; `_record_migration` tolerates a duplicate version with exactly one row recorded.
- RED provenance verified: all 11 new behavior tests fail on the pre-fix implementation (checked by stashing the fix) and pass with it.
- `./scripts/check-all.sh` exits 0: 1741 unit tests passed, coverage 96.34% (threshold 90%), lint/format/mypy strict/complexity/security/docstrings all green.

Closes #78
