### PR TITLE
chore(money): represent money as Decimal end-to-end, convert at JSON boundary

### DIFF
--- a/grocery_butler/cart_builder.py
+++ b/grocery_butler/cart_builder.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 import logging
 import math
 from dataclasses import dataclass
+from decimal import ROUND_HALF_UP, Decimal
 from typing import TYPE_CHECKING, Any
 
 from grocery_butler.models import (
+    CENTS,
     CartItem,
     CartSummary,
     FulfillmentOption,
@@ -157,7 +159,7 @@ class CartBuilder:
         recommended = _recommend_fulfillment(fulfillment_options)
         subtotal = _calculate_subtotal(cart_items, restock_cart)
         fee = _get_fulfillment_fee(fulfillment_options, recommended)
-        estimated_total = round(subtotal + fee, 2)
+        estimated_total = (subtotal + fee).quantize(CENTS, rounding=ROUND_HALF_UP)
 
         return CartSummary(
             items=cart_items,
@@ -236,7 +238,9 @@ class CartBuilder:
             return self._handle_out_of_stock(item, product)
 
         decision = _calculate_quantity(item, product, cap=self._max_quantity_per_item)
-        cost = round(product.price * decision.quantity, 2)
+        cost = (product.price * decision.quantity).quantize(
+            CENTS, rounding=ROUND_HALF_UP
+        )
         return CartItem(
             shopping_list_item=item,
             safeway_product=product,
@@ -402,7 +406,7 @@ def _calculate_quantity(
 def _calculate_subtotal(
     items: list[CartItem],
     restock_items: list[CartItem],
-) -> float:
+) -> Decimal:
     """Calculate cart subtotal from all items.
 
     Args:
@@ -410,17 +414,17 @@ def _calculate_subtotal(
         restock_items: Restock queue cart items.
 
     Returns:
-        Rounded subtotal.
+        Subtotal quantized to cents (Decimal, issue #81).
     """
-    total = sum(item.estimated_cost for item in items)
-    total += sum(item.estimated_cost for item in restock_items)
-    return round(total, 2)
+    total = sum((item.estimated_cost for item in items), Decimal("0"))
+    total += sum((item.estimated_cost for item in restock_items), Decimal("0"))
+    return total.quantize(CENTS, rounding=ROUND_HALF_UP)
 
 
 def _get_fulfillment_fee(
     options: list[FulfillmentOption],
     recommended: FulfillmentType,
-) -> float:
+) -> Decimal:
     """Get the fee for the recommended fulfillment type.
 
     Args:
@@ -428,12 +432,12 @@ def _get_fulfillment_fee(
         recommended: The recommended fulfillment type.
 
     Returns:
-        Fee amount, or 0.0 if not found.
+        Fee amount (Decimal, issue #81), or ``Decimal("0")`` if not found.
     """
     for option in options:
         if option.type == recommended:
             return option.fee
-    return 0.0
+    return Decimal("0")
 
 
 def _recommend_fulfillment(
@@ -483,7 +487,10 @@ def _parse_fulfillment_response(
             FulfillmentOption(
                 type=ftype,
                 available=bool(entry.get("available", False)),
-                fee=float(entry.get("fee", 0.0)),
+                # float() first preserves the pre-#81 failure mode for
+                # garbage fees (ValueError/TypeError); Decimal(str(...))
+                # then reads the float at its exact decimal form.
+                fee=Decimal(str(float(entry.get("fee", 0.0)))),
                 windows=windows,
                 next_window=next_win,
             )
@@ -519,7 +526,7 @@ def _substitution_to_cart_item(
 
     product = result.selected.product
     decision = _calculate_quantity(result.original_item, product, cap=cap)
-    cost = round(product.price * decision.quantity, 2)
+    cost = (product.price * decision.quantity).quantize(CENTS, rounding=ROUND_HALF_UP)
     return CartItem(
         shopping_list_item=result.original_item,
         safeway_product=product,

--- a/grocery_butler/consolidator.py
+++ b/grocery_butler/consolidator.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import logging
+from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
 from grocery_butler.claude_utils import extract_json_text
@@ -96,9 +97,12 @@ def _parse_shopping_item(data: dict[str, object]) -> ShoppingListItem:
     quantity = float(raw_quantity) if isinstance(raw_quantity, (int, float)) else 0.0
 
     raw_price = data.get("estimated_price")
-    estimated_price: float | None = None
-    if isinstance(raw_price, (int, float)):
-        estimated_price = float(raw_price)
+    estimated_price: Decimal | None = None
+    if isinstance(raw_price, (int, float)) and not isinstance(raw_price, bool):
+        # Decimal(str(...)) reads a JSON float at its exact decimal
+        # representation (issue #81); bool is excluded because a
+        # true/false "price" from the model is garbage, not 1.0/0.0.
+        estimated_price = Decimal(str(raw_price))
 
     raw_from_meals = data.get("from_meals", [])
     from_meals: list[str] = (

--- a/grocery_butler/db/adapter.py
+++ b/grocery_butler/db/adapter.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import re
 import sqlite3
+from decimal import Decimal
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
@@ -162,6 +163,36 @@ class DatabaseConnection(Protocol):
 # ------------------------------------------------------------------
 
 
+def _adapt_sqlite_params(params: Sequence[Any]) -> Sequence[Any]:
+    """Convert parameter values sqlite3 can't bind natively.
+
+    ``sqlite3`` has no built-in adapter for :class:`~decimal.Decimal`
+    (money fields are Decimal end-to-end per issue #81), so Decimal
+    values are bound as their string representation. SQLite's column
+    type affinity then converts the text to the column's declared type
+    (e.g. ``"4.15"`` -> ``4.15`` in a ``REAL`` column). Note ``REAL``
+    is IEEE-754 binary64, not true decimal storage: the read path's
+    ``Decimal(str(...))`` recovers the original digits via Python's
+    shortest-round-trip float repr, which is reliable for cent-level
+    money values but is not an exactness guarantee for arbitrary
+    precision. A local conversion is used instead of the process-global
+    ``sqlite3.register_adapter`` so behavior stays scoped to this
+    adapter.
+
+    Args:
+        params: Parameter values as supplied by business logic.
+
+    Returns:
+        The original sequence if no Decimal is present, otherwise a
+        tuple with each Decimal replaced by ``str(value)``.
+    """
+    if not any(isinstance(value, Decimal) for value in params):
+        return params
+    return tuple(
+        str(value) if isinstance(value, Decimal) else value for value in params
+    )
+
+
 class SQLiteCursorResult:
     """Wraps a ``sqlite3.Cursor`` to satisfy :class:`CursorResult`."""
 
@@ -242,7 +273,7 @@ class SQLiteConnection:
         Returns:
             A SQLiteCursorResult wrapping the cursor.
         """
-        cursor = self._conn.execute(sql, params)
+        cursor = self._conn.execute(sql, _adapt_sqlite_params(params))
         return SQLiteCursorResult(cursor)
 
     def executescript(self, sql: str) -> None:

--- a/grocery_butler/models.py
+++ b/grocery_butler/models.py
@@ -8,12 +8,78 @@ from __future__ import annotations
 
 import datetime as dt
 import logging
+from decimal import Decimal, InvalidOperation
 from enum import StrEnum
-from typing import Any
+from typing import Annotated, Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, BeforeValidator, PlainSerializer, field_validator
 
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Money
+# ---------------------------------------------------------------------------
+
+#: Cent-precision quantum used to round every monetary amount to exactly
+#: two decimal places (issue #81).
+CENTS = Decimal("0.01")
+
+
+def _coerce_money(v: Any) -> Any:
+    """Coerce a raw value into a :class:`~decimal.Decimal` for a Money field.
+
+    ``bool`` is rejected explicitly even though Python treats ``bool`` as a
+    subtype of ``int`` -- ``True``/``False`` are never legitimate monetary
+    values. A :class:`~decimal.Decimal` instance passes through unchanged.
+    ``int``, ``float``, and ``str`` are coerced via ``Decimal(str(v))`` (the
+    ``str()`` round-trip avoids binary-float imprecision leaking into the
+    Decimal representation). Any other type is returned unchanged so
+    Pydantic's own type validation can reject it with its usual error.
+    Non-finite results (``NaN``, ``Infinity``, ``-Infinity``) are rejected
+    to preserve the issue #73 ``allow_inf_nan=False`` semantics that this
+    validator now owns instead of a bare ``Field`` constraint.
+
+    Args:
+        v: The raw value supplied for a Money field.
+
+    Returns:
+        A finite ``Decimal``, or ``v`` unchanged if it isn't a type this
+        coercion understands (letting Pydantic reject it downstream).
+
+    Raises:
+        ValueError: If ``v`` is a ``bool``, an unparseable numeric string,
+            or coerces to a non-finite ``Decimal``.
+    """
+    if isinstance(v, bool):
+        msg = "bool is not a valid monetary value"
+        raise ValueError(msg)
+    if isinstance(v, Decimal):
+        result = v
+    elif isinstance(v, (int, float, str)):
+        try:
+            result = Decimal(str(v))
+        except InvalidOperation as exc:
+            msg = f"{v!r} is not a valid monetary value"
+            raise ValueError(msg) from exc
+    else:
+        return v
+    if not result.is_finite():
+        msg = "monetary value must be finite"
+        raise ValueError(msg)
+    return result
+
+
+#: A monetary amount stored as a finite :class:`~decimal.Decimal` for exact
+#: cent-level arithmetic, coerced from int/float/str/Decimal on input via
+#: :func:`_coerce_money` (rejecting ``bool`` and non-finite values -- issue
+#: #73's semantics live here now) and serialized back to a plain JSON
+#: ``float`` on output, since neither JSON nor most HTTP client libraries
+#: understand ``Decimal`` natively (issue #81).
+Money = Annotated[
+    Decimal,
+    BeforeValidator(_coerce_money),
+    PlainSerializer(float, return_type=float, when_used="json"),
+]
 
 # ---------------------------------------------------------------------------
 # Enums
@@ -330,7 +396,7 @@ class ShoppingListItem(BaseModel):
     category: IngredientCategory
     search_term: str
     from_meals: list[str]
-    estimated_price: float | None = None
+    estimated_price: Money | None = None
 
     @field_validator("unit", mode="before")
     @classmethod
@@ -407,8 +473,8 @@ class SafewayProduct(BaseModel):
 
     product_id: str
     name: str
-    price: float
-    unit_price: float | None = None
+    price: Money
+    unit_price: Money | None = None
     size: str
     in_stock: bool = True
 
@@ -439,10 +505,12 @@ class CartItem(BaseModel):
         shopping_list_item: The originating shopping list item.
         safeway_product: The matched Safeway product.
         quantity_to_order: Number of product units to order.
-        estimated_cost: Estimated cost for ``quantity_to_order`` units.
-            Must be finite — JSON's non-standard ``Infinity``/``NaN``
-            literals are rejected at validation (issue #73), keeping
-            non-finite values out of server-side total computation.
+        estimated_cost: Estimated cost for ``quantity_to_order`` units, as
+            a ``Decimal`` (issue #81). Must be finite — JSON's
+            non-standard ``Infinity``/``NaN`` literals are rejected at
+            validation by the ``Money`` type's coercion validator (issue
+            #73), keeping non-finite values out of server-side total
+            computation.
         needs_review: Whether the item needs human review (e.g. an
             unparseable product size, incomparable units, a quantity
             capped by the per-item maximum, or an auto-selected
@@ -456,7 +524,7 @@ class CartItem(BaseModel):
     shopping_list_item: ShoppingListItem
     safeway_product: SafewayProduct
     quantity_to_order: int
-    estimated_cost: float = Field(allow_inf_nan=False)
+    estimated_cost: Money
     needs_review: bool = False
     review_reason: str = ""
 
@@ -464,14 +532,15 @@ class CartItem(BaseModel):
 class FulfillmentOption(BaseModel):
     """A fulfillment option (pickup or delivery) with scheduling.
 
-    The ``fee`` must be finite — JSON's non-standard ``Infinity``/``NaN``
-    literals are rejected at validation (issue #73), keeping non-finite
-    values out of server-side total computation.
+    The ``fee`` is a ``Decimal`` (issue #81) and must be finite — JSON's
+    non-standard ``Infinity``/``NaN`` literals are rejected at validation
+    by the ``Money`` type's coercion validator (issue #73), keeping
+    non-finite values out of server-side total computation.
     """
 
     type: FulfillmentType
     available: bool
-    fee: float = Field(allow_inf_nan=False)
+    fee: Money
     windows: list[dict[str, Any]]
     next_window: str | None = None
 
@@ -485,14 +554,14 @@ class CartSummary(BaseModel):
         substituted_items: Out-of-stock items with substitution results.
         skipped_items: Items explicitly skipped by the caller.
         restock_items: Restock-queue cart items.
-        subtotal: Sum of all item costs before fulfillment fees. Must
-            be finite (issue #73).
+        subtotal: Sum of all item costs before fulfillment fees, as a
+            ``Decimal`` (issue #81). Must be finite (issue #73).
         fulfillment_options: Fulfillment options fetched from Safeway, or
             an empty list when the fetch failed (see
             ``fulfillment_unverified``).
         recommended_fulfillment: The recommended fulfillment type.
-        estimated_total: Subtotal plus the recommended fulfillment fee.
-            Must be finite (issue #73).
+        estimated_total: Subtotal plus the recommended fulfillment fee,
+            as a ``Decimal`` (issue #81). Must be finite (issue #73).
         fulfillment_unverified: True when Safeway's fulfillment options
             could not be fetched, so ``fulfillment_options`` is empty and
             ``estimated_total`` excludes any fulfillment fee (issue #72).
@@ -507,10 +576,10 @@ class CartSummary(BaseModel):
     substituted_items: list[SubstitutionResult]
     skipped_items: list[ShoppingListItem] = []
     restock_items: list[CartItem]
-    subtotal: float = Field(allow_inf_nan=False)
+    subtotal: Money
     fulfillment_options: list[FulfillmentOption]
     recommended_fulfillment: FulfillmentType
-    estimated_total: float = Field(allow_inf_nan=False)
+    estimated_total: Money
     fulfillment_unverified: bool = False
 
 

--- a/grocery_butler/order_service.py
+++ b/grocery_butler/order_service.py
@@ -10,10 +10,11 @@ from __future__ import annotations
 import logging
 import uuid
 from dataclasses import dataclass
-from decimal import ROUND_HALF_UP, Decimal
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
+from grocery_butler.models import CENTS
 from grocery_butler.safeway_client import SafewayAuthError, SafewayTimeoutError
 
 if TYPE_CHECKING:
@@ -63,7 +64,8 @@ class OrderConfirmation:
         order_id: Safeway order identifier.
         status: Order status string.
         estimated_time: Estimated fulfillment time.
-        total: Final order total.
+        total: Final order total as a cents-quantized ``Decimal``
+            (issue #81).
         fulfillment_type: Selected fulfillment method.
         item_count: Number of items in the order.
     """
@@ -71,7 +73,7 @@ class OrderConfirmation:
     order_id: str
     status: str
     estimated_time: str
-    total: float
+    total: Decimal
     fulfillment_type: FulfillmentType
     item_count: int
 
@@ -396,9 +398,10 @@ def compute_cart_total(cart: CartSummary) -> Decimal:
     ``cart.estimated_total`` — those fields may be stale or supplied by
     an untrusted client, so this is the single source of truth for what
     a cart actually costs (Issue #73). All monetary inputs are
-    guaranteed finite by model validation (``allow_inf_nan=False`` on
-    the ``CartSummary`` field tree), so the cents-quantize below cannot
-    raise ``InvalidOperation`` for a validated cart.
+    guaranteed finite ``Decimal`` values by model validation (the
+    ``Money`` type's coercion validator on the ``CartSummary`` field
+    tree — issues #73/#81), so the cents-quantize below cannot raise
+    ``InvalidOperation`` for a validated cart.
 
     Known residual risk (Issue #120): when the cart itself arrives from
     an API caller (``POST /order/submit``), the per-item
@@ -417,11 +420,11 @@ def compute_cart_total(cart: CartSummary) -> Decimal:
         The fee-inclusive total, quantized to cents with ROUND_HALF_UP.
     """
     items_total = sum(
-        (Decimal(str(item.estimated_cost)) for item in cart.items + cart.restock_items),
+        (item.estimated_cost for item in cart.items + cart.restock_items),
         Decimal("0"),
     )
     total = items_total + _recommended_fulfillment_fee(cart)
-    return total.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+    return total.quantize(CENTS, rounding=ROUND_HALF_UP)
 
 
 def _recommended_fulfillment_fee(cart: CartSummary) -> Decimal:
@@ -442,7 +445,7 @@ def _recommended_fulfillment_fee(cart: CartSummary) -> Decimal:
     """
     for option in cart.fulfillment_options:
         if option.type == cart.recommended_fulfillment:
-            return Decimal(str(option.fee))
+            return option.fee
     return Decimal("0")
 
 
@@ -459,13 +462,16 @@ def _build_order_payload(
             ledger can correlate repeated attempts.
 
     Returns:
-        Dict suitable for JSON submission.
+        Dict suitable for JSON submission. ``estimatedTotal`` is
+        converted from ``Decimal`` to ``float`` here — the JSON
+        boundary — so the wire contract stays a plain JSON number
+        (issue #81).
     """
     items = _serialize_cart_items(cart.items + cart.restock_items)
     return {
         "items": items,
         "fulfillmentType": cart.recommended_fulfillment.value,
-        "estimatedTotal": cart.estimated_total,
+        "estimatedTotal": float(cart.estimated_total),
         "clientOrderId": idempotency_key,
     }
 
@@ -515,28 +521,41 @@ def _parse_order_response(
         order_id=str(order_id),
         status=str(response.get("status", "confirmed")),
         estimated_time=str(response.get("estimatedTime", "Unknown")),
-        total=_safe_float(response.get("total"), cart.estimated_total),
+        total=_safe_money(response.get("total"), cart.estimated_total),
         fulfillment_type=cart.recommended_fulfillment,
         item_count=total_items,
     )
 
 
-def _safe_float(value: Any, fallback: float) -> float:
-    """Safely convert a value to float, returning fallback on failure.
+def _safe_money(value: Any, fallback: Decimal) -> Decimal:
+    """Safely convert a value to a cents-quantized Decimal (issue #81).
+
+    Conversion goes through ``Decimal(str(value))`` so float inputs are
+    read at their shortest decimal representation (``25.97`` becomes
+    exactly ``Decimal("25.97")``) rather than their binary expansion.
+    Non-finite results are rejected explicitly: ``Decimal("NaN")`` and
+    ``Decimal("Infinity")`` construct successfully, so catching
+    ``InvalidOperation`` alone is not enough.
 
     Args:
         value: Value to convert (may be None, str, or numeric).
-        fallback: Default to return if conversion fails.
+        fallback: Default returned when ``value`` is None, unparseable,
+            or non-finite. Assumed to already be cents-quantized (e.g.
+            ``CartSummary.estimated_total``) and returned as-is.
 
     Returns:
-        Converted float or fallback.
+        The converted value quantized to cents with ROUND_HALF_UP, or
+        ``fallback``.
     """
     if value is None:
         return fallback
     try:
-        return float(value)
-    except (TypeError, ValueError):
+        result = Decimal(str(value))
+    except InvalidOperation:
         return fallback
+    if not result.is_finite():
+        return fallback
+    return result.quantize(CENTS, rounding=ROUND_HALF_UP)
 
 
 def review_block_result(cart: CartSummary) -> OrderResult | None:

--- a/grocery_butler/product_search.py
+++ b/grocery_butler/product_search.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -497,33 +498,36 @@ def _parse_single_product(item: dict[str, Any]) -> SafewayProduct | None:
     if not product_id or not name:
         return None
 
-    price = _parse_price(item)
+    unit_price = _safe_float(item.get("unitPrice"))
     return SafewayProduct(
         product_id=str(product_id),
         name=str(name),
-        price=price,
-        unit_price=_safe_float(item.get("unitPrice")),
+        price=_parse_price(item),
+        unit_price=Decimal(str(unit_price)) if unit_price is not None else None,
         size=str(item.get("size", "")),
         in_stock=item.get("inStock", True) is not False,
     )
 
 
-def _parse_price(item: dict[str, Any]) -> float:
+def _parse_price(item: dict[str, Any]) -> Decimal:
     """Extract the best available price from a product entry.
 
-    Prefers ``salePrice`` over ``price`` over ``basePrice``.
+    Prefers ``salePrice`` over ``price`` over ``basePrice``. The value
+    is converted via ``Decimal(str(...))`` so a JSON float is read at
+    its exact decimal representation (issue #81).
 
     Args:
         item: Product dict from the Nimbus response.
 
     Returns:
-        Price as a float, defaulting to 0.0 if unparseable.
+        Price as a ``Decimal``, defaulting to ``Decimal("0")`` if
+        unparseable.
     """
     for key in ("salePrice", "price", "basePrice"):
         value = _safe_float(item.get(key))
         if value is not None and value > 0:
-            return value
-    return 0.0
+            return Decimal(str(value))
+    return Decimal("0")
 
 
 def _safe_float(value: float | int | str | None) -> float | None:
@@ -567,7 +571,12 @@ def _row_to_cached_mapping(row: DictRow) -> CachedMapping:
         product=SafewayProduct(
             product_id=row["safeway_product_id"],
             name=row["safeway_product_name"],
-            price=row["safeway_price"] or 0.0,
+            # SQLite stores the Decimal price in a REAL (float64) column
+            # (see db.adapter._adapt_sqlite_params); Decimal(str(...))
+            # recovers the original digits via Python's shortest
+            # round-trip float repr, which is reliable for cent-level
+            # prices (issue #81).
+            price=Decimal(str(row["safeway_price"] or 0)),
             size=row["safeway_product_size"] or "",
             in_stock=True if in_stock_value is None else bool(in_stock_value),
         ),

--- a/grocery_butler/product_selector.py
+++ b/grocery_butler/product_selector.py
@@ -334,6 +334,11 @@ def _heuristic_select(
 def _product_to_dict(product: SafewayProduct) -> dict[str, Any]:
     """Convert a SafewayProduct to a dict for JSON serialization.
 
+    Monetary fields are ``Decimal`` on the model (issue #81), which
+    stdlib ``json.dumps`` cannot serialize, so they are converted to
+    ``float`` here — this dict only feeds a Claude prompt, where a
+    plain JSON number is expected.
+
     Args:
         product: The product to convert.
 
@@ -343,8 +348,10 @@ def _product_to_dict(product: SafewayProduct) -> dict[str, Any]:
     return {
         "product_id": product.product_id,
         "name": product.name,
-        "price": product.price,
-        "unit_price": product.unit_price,
+        "price": float(product.price),
+        "unit_price": (
+            float(product.unit_price) if product.unit_price is not None else None
+        ),
         "size": product.size,
         "in_stock": product.in_stock,
     }

--- a/grocery_butler/substitution_service.py
+++ b/grocery_butler/substitution_service.py
@@ -171,10 +171,13 @@ class SubstitutionService:
         Returns:
             Formatted prompt string.
         """
+        # ``price`` is a Decimal on the model (issue #81); stdlib
+        # ``json.dumps`` can't serialize Decimal, so convert to float at
+        # this JSON (prompt) boundary.
         alt_dicts = [
             {
                 "name": p.name,
-                "price": p.price,
+                "price": float(p.price),
                 "size": p.size,
                 "product_id": p.product_id,
             }

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import sqlite3
+from decimal import Decimal
 from typing import TYPE_CHECKING
 
 import pytest
@@ -18,11 +19,45 @@ from grocery_butler.db.adapter import (
     IntegrityError,
     PostgresConnection,
     SQLiteConnection,
+    _adapt_sqlite_params,
     _has_executable_sql,
     _inject_returning,
     _translate_placeholders,
     create_connection,
 )
+
+
+class TestAdaptSqliteParams:
+    """Tests for _adapt_sqlite_params Decimal-to-str conversion (issue #81)."""
+
+    def test_no_decimals_returns_params_unchanged(self) -> None:
+        """Test a Decimal-free sequence is returned as the same object."""
+        params = ("alice", 1, 2.5, None)
+        assert _adapt_sqlite_params(params) is params
+
+    def test_decimal_converted_to_exact_string(self) -> None:
+        """Test a Decimal parameter is bound as its exact string form."""
+        assert _adapt_sqlite_params((Decimal("4.15"),)) == ("4.15",)
+
+    def test_mixed_params_only_decimals_converted(self) -> None:
+        """Test non-Decimal values pass through untouched alongside Decimals."""
+        adapted = _adapt_sqlite_params(("milk", Decimal("5.99"), 2, None))
+        assert adapted == ("milk", "5.99", 2, None)
+
+    def test_execute_binds_decimal_via_real_sqlite(self, tmp_path: Path) -> None:
+        """Test a Decimal round-trips through a real SQLite REAL column."""
+        conn = create_connection(str(tmp_path / "money.db"))
+        try:
+            conn.executescript(
+                "CREATE TABLE t (id INTEGER PRIMARY KEY, price REAL);",
+            )
+            conn.execute("INSERT INTO t (price) VALUES (?)", (Decimal("4.15"),))
+            conn.commit()
+            row = conn.execute("SELECT price FROM t WHERE id = ?", (1,)).fetchone()
+            assert row is not None
+            assert Decimal(str(row["price"])) == Decimal("4.15")
+        finally:
+            conn.close()
 
 
 class TestCreateConnection:

--- a/tests/test_cart_builder.py
+++ b/tests/test_cart_builder.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from decimal import Decimal
 from unittest.mock import MagicMock
 
 import pytest
@@ -416,7 +417,9 @@ class TestGetFulfillmentFee:
                 windows=[],
             ),
         ]
-        assert _get_fulfillment_fee(options, FulfillmentType.DELIVERY) == 9.95
+        assert _get_fulfillment_fee(options, FulfillmentType.DELIVERY) == Decimal(
+            "9.95"
+        )
 
     def test_missing_type(self) -> None:
         """Test returns 0 when type not found."""
@@ -453,7 +456,7 @@ class TestParseFulfillmentResponse:
         assert len(result) == 2
         assert result[0].type == FulfillmentType.PICKUP
         assert result[0].next_window == "Today 4-6pm"
-        assert result[1].fee == 9.95
+        assert result[1].fee == Decimal("9.95")
         assert result[1].next_window is None
 
     def test_empty_response(self) -> None:
@@ -536,7 +539,7 @@ class TestBuildCart:
         assert len(result.items) == 1
         assert result.items[0].safeway_product.product_id == "P001"
         assert result.items[0].quantity_to_order == 1
-        assert result.items[0].estimated_cost == 8.99
+        assert result.items[0].estimated_cost == Decimal("8.99")
         assert result.failed_items == []
 
     def test_no_products_found(self) -> None:
@@ -1155,7 +1158,7 @@ class TestBuildCartSubstitutionPricing:
         substitute_item = cart.items[0]
         assert substitute_item.safeway_product.product_id == "ALT1"
         assert substitute_item.quantity_to_order == 2
-        assert substitute_item.estimated_cost == round(10.99 * 2, 2)
+        assert substitute_item.estimated_cost == Decimal("21.98")
 
     def test_substitution_priced_into_subtotal(self) -> None:
         """Test the substitute's cost is included in cart.subtotal."""
@@ -1170,7 +1173,7 @@ class TestBuildCartSubstitutionPricing:
 
         cart = builder.build_cart([_make_item()])
 
-        assert cart.subtotal == round(10.99 * 2, 2)
+        assert cart.subtotal == Decimal("21.98")
 
     def test_substitution_flagged_for_review(self) -> None:
         """Test the substitute CartItem is always flagged for review.
@@ -1226,9 +1229,9 @@ class TestBuildCartSubstitutionPricing:
 
         cart = builder.build_cart([_make_item()])
 
-        expected_subtotal = round(10.99 * 2, 2)
         assert cart.recommended_fulfillment == FulfillmentType.DELIVERY
-        assert cart.estimated_total == round(expected_subtotal + 9.95, 2)
+        # $21.98 substitution subtotal plus the $9.95 delivery fee.
+        assert cart.estimated_total == Decimal("31.93")
 
     def test_substitution_still_listed_in_substituted_items(self) -> None:
         """Test substituted_items still records the substitution (regression).
@@ -1282,7 +1285,7 @@ class TestBuildCartSubstitutionPricing:
         assert substitute_item.safeway_product.product_id == "ALT1"
         assert substitute_item.needs_review is True
         assert substitute_item.review_reason == "substitution"
-        assert cart.subtotal == round(10.99 * 2, 2)
+        assert cart.subtotal == Decimal("21.98")
         assert cart.estimated_total == cart.subtotal
 
     def test_no_alternative_substitution_not_added_to_items(self) -> None:
@@ -1513,7 +1516,7 @@ class TestCartBuilderCacheFlow:
         result = builder.build_cart([item])
 
         assert len(result.items) == 1
-        assert result.items[0].estimated_cost == 5.49
+        assert result.items[0].estimated_cost == Decimal("5.49")
 
     def test_no_product_selected_returns_failed(self) -> None:
         """Test a cache miss with no selected product fails without saving."""
@@ -1594,6 +1597,6 @@ class TestCartBuilderCacheFlow:
         assert substitute_item.needs_review is True
         assert substitute_item.review_reason == "substitution"
         assert substitute_item.quantity_to_order == 2
-        assert substitute_item.estimated_cost == round(10.99 * 2, 2)
-        assert result.subtotal == round(10.99 * 2, 2)
+        assert substitute_item.estimated_cost == Decimal("21.98")
+        assert result.subtotal == Decimal("21.98")
         assert result.substituted_items == [sub_result]

--- a/tests/test_consolidator.py
+++ b/tests/test_consolidator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from decimal import Decimal
 from unittest.mock import MagicMock
 
 import pytest
@@ -365,7 +366,7 @@ class TestParseShoppingItem:
         assert result.category == IngredientCategory.MEAT
         assert result.search_term == "boneless chicken thighs"
         assert result.from_meals == ["Chicken Tacos"]
-        assert result.estimated_price == 8.99
+        assert result.estimated_price == Decimal("8.99")
 
     def test_defaults_for_missing_fields(self):
         """Test default values when fields are missing."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from decimal import Decimal
 
 import pytest
 from pydantic import ValidationError
@@ -555,7 +556,7 @@ class TestShoppingListItem:
             from_meals=["Cereal", "Baking"],
             estimated_price=4.99,
         )
-        assert item.estimated_price == 4.99
+        assert item.estimated_price == Decimal("4.99")
         assert len(item.from_meals) == 2
 
 
@@ -663,7 +664,7 @@ class TestSafewayProduct:
             size="16 oz",
             in_stock=False,
         )
-        assert product.unit_price == 0.28
+        assert product.unit_price == Decimal("0.28")
         assert product.in_stock is False
 
 
@@ -751,7 +752,7 @@ class TestCartItem:
             estimated_cost=5.99,
         )
         assert cart_item.quantity_to_order == 1
-        assert cart_item.estimated_cost == 5.99
+        assert cart_item.estimated_cost == Decimal("5.99")
 
     def test_default_review_fields_are_unset(self) -> None:
         """Test needs_review/review_reason default to False and empty string.

--- a/tests/test_money.py
+++ b/tests/test_money.py
@@ -1,0 +1,720 @@
+"""Tests for money-as-Decimal handling across grocery_butler (issue #81).
+
+Today every monetary field (``SafewayProduct.price``, ``CartItem.
+estimated_cost``, ``FulfillmentOption.fee``, ``CartSummary.subtotal``/
+``estimated_total``, ``OrderConfirmation.total``) is a plain ``float``,
+and arithmetic on those floats uses binary rounding (Python's
+banker's-rounding ``round()``) instead of decimal cents math. This file
+is Gate 1 RED for the fix: a new ``Money`` type
+(``Annotated[Decimal, BeforeValidator(_coerce_money), PlainSerializer(
+float, ...)]``) applied to every monetary field, with arithmetic
+quantized to cents (``ROUND_HALF_UP``) at each producing site.
+
+These tests are written against that not-yet-implemented design, so
+most of them are expected to fail today. Names that don't exist yet
+(``grocery_butler.order_service._safe_money``) are imported locally
+inside the test body that needs them, matching this repo's existing
+convention (see ``tests/test_order_service.py``'s ``compute_cart_total``
+tests) for not breaking collection of the rest of the file with an
+``ImportError``. Tests that already pass today are explicitly labeled
+"pin" in their docstring -- they exist to catch a regression during the
+Money migration (e.g. Pydantic's default JSON serialization of a
+``Decimal`` is a *string*, which would silently break the wire
+contract without the custom ``PlainSerializer``).
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+from pydantic import ValidationError
+
+from grocery_butler.cart_builder import (
+    CartBuilder,
+    _calculate_subtotal,
+    _substitution_to_cart_item,
+)
+from grocery_butler.models import (
+    CartItem,
+    CartSummary,
+    FulfillmentOption,
+    FulfillmentType,
+    IngredientCategory,
+    SafewayProduct,
+    ShoppingListItem,
+    SubstitutionOption,
+    SubstitutionResult,
+    SubstitutionSuitability,
+)
+from grocery_butler.order_service import _build_order_payload, _parse_order_response
+from grocery_butler.product_search import ProductSearchService
+from grocery_butler.safeway_client import SafewayClient
+
+# ------------------------------------------------------------------
+# Fixtures / builders
+# ------------------------------------------------------------------
+
+
+def _make_shopping_item(
+    ingredient: str = "milk",
+    quantity: float = 1.0,
+    unit: str = "lb",
+    search_term: str = "whole milk",
+    estimated_price: float | None = None,
+) -> ShoppingListItem:
+    """Create a test ShoppingListItem.
+
+    Args:
+        ingredient: Ingredient name.
+        quantity: Desired quantity.
+        unit: Unit of measurement.
+        search_term: Search term.
+        estimated_price: Optional estimated price.
+
+    Returns:
+        ShoppingListItem for testing.
+    """
+    return ShoppingListItem(
+        ingredient=ingredient,
+        quantity=quantity,
+        unit=unit,
+        category=IngredientCategory.DAIRY,
+        search_term=search_term,
+        from_meals=["Test Meal"],
+        estimated_price=estimated_price,
+    )
+
+
+def _make_product(
+    product_id: str = "P001",
+    name: str = "Test Product",
+    price: float | str = 5.99,
+    unit_price: float | None = None,
+    size: str = "1 lb",
+    in_stock: bool = True,
+) -> SafewayProduct:
+    """Create a test SafewayProduct.
+
+    Args:
+        product_id: Product ID.
+        name: Product name.
+        price: Product price (float or string, to exercise coercion).
+        unit_price: Optional unit price.
+        size: Product size.
+        in_stock: Whether in stock.
+
+    Returns:
+        SafewayProduct for testing.
+    """
+    return SafewayProduct(
+        product_id=product_id,
+        name=name,
+        price=price,
+        unit_price=unit_price,
+        size=size,
+        in_stock=in_stock,
+    )
+
+
+def _make_cart_item(price: float = 5.99, quantity: int = 1) -> CartItem:
+    """Create a test CartItem priced at *price* for *quantity* units.
+
+    Args:
+        price: Product/item price.
+        quantity: Order quantity.
+
+    Returns:
+        CartItem for testing.
+    """
+    return CartItem(
+        shopping_list_item=_make_shopping_item(),
+        safeway_product=_make_product(price=price),
+        quantity_to_order=quantity,
+        estimated_cost=price,
+    )
+
+
+def _make_fulfillment_option(
+    fee: float = 0.0,
+    ftype: FulfillmentType = FulfillmentType.PICKUP,
+    available: bool = True,
+) -> FulfillmentOption:
+    """Create a test FulfillmentOption.
+
+    Args:
+        fee: Fulfillment fee.
+        ftype: Fulfillment type.
+        available: Whether the option is available.
+
+    Returns:
+        FulfillmentOption for testing.
+    """
+    return FulfillmentOption(
+        type=ftype,
+        available=available,
+        fee=fee,
+        windows=[],
+    )
+
+
+def _make_cart_summary(
+    subtotal: float = 10.0,
+    estimated_total: float = 10.0,
+    items: list[CartItem] | None = None,
+    fulfillment_options: list[FulfillmentOption] | None = None,
+) -> CartSummary:
+    """Create a test CartSummary.
+
+    Args:
+        subtotal: Cart subtotal.
+        estimated_total: Cart estimated total.
+        items: Regular cart items (defaults to a single $5.99 item).
+        fulfillment_options: Fulfillment options (defaults to a single
+            free pickup option).
+
+    Returns:
+        CartSummary for testing.
+    """
+    return CartSummary(
+        items=items if items is not None else [_make_cart_item()],
+        failed_items=[],
+        substituted_items=[],
+        skipped_items=[],
+        restock_items=[],
+        subtotal=subtotal,
+        fulfillment_options=(
+            fulfillment_options
+            if fulfillment_options is not None
+            else [_make_fulfillment_option(fee=0.0)]
+        ),
+        recommended_fulfillment=FulfillmentType.PICKUP,
+        estimated_total=estimated_total,
+    )
+
+
+@dataclass
+class _MockSelectionResult:
+    """Mock selection result matching ProductSelector output."""
+
+    item: ShoppingListItem
+    product: SafewayProduct | None
+    reasoning: str
+
+
+def _make_builder(
+    search_results: list[SafewayProduct] | None = None,
+    selection_product: SafewayProduct | None = None,
+    fulfillment_response: dict[str, Any] | None = None,
+) -> CartBuilder:
+    """Create a CartBuilder with mock dependencies.
+
+    Args:
+        search_results: Products returned by search.
+        selection_product: Product returned by the selector.
+        fulfillment_response: Fulfillment API response.
+
+    Returns:
+        CartBuilder with mocked services.
+    """
+    mock_search = MagicMock()
+    mock_search.get_cached_product.return_value = None
+    mock_search.search_products.return_value = search_results or []
+
+    mock_selector = MagicMock()
+    mock_selector.select_product.return_value = _MockSelectionResult(
+        item=_make_shopping_item(),
+        product=selection_product,
+        reasoning="Test selection",
+    )
+
+    mock_substitution = MagicMock()
+
+    mock_client = MagicMock()
+    mock_client.store_id = "1234"
+    mock_client.get.return_value = fulfillment_response or {}
+
+    return CartBuilder(
+        search_service=mock_search,
+        product_selector=mock_selector,
+        substitution_service=mock_substitution,
+        safeway_client=mock_client,
+    )
+
+
+@pytest.fixture
+def db_path(tmp_path: Any) -> str:
+    """Provide a temporary database path.
+
+    Args:
+        tmp_path: Pytest tmp_path fixture.
+
+    Returns:
+        Path string for the test database.
+    """
+    return str(tmp_path / "money_test.db")
+
+
+# ------------------------------------------------------------------
+# 1. Float-drift regression (headline)
+# ------------------------------------------------------------------
+
+
+class TestFloatDriftRegression:
+    """Regression guards for float binary-rounding drift (issue #81)."""
+
+    def test_half_up_rounding_via_cart_builder_pricing_path(self) -> None:
+        """Test a $1.005 item rounds to $1.01 (half-up), not $1.00.
+
+        ``round(1.005, 2)`` in Python returns ``1.0`` -- the float
+        1.005 is actually stored as 1.00499999999999989..., so binary
+        rounding rounds it *down*. Decimal cents math on the string
+        representation ("1.005") rounds up correctly per ROUND_HALF_UP.
+        This drives the real ``CartBuilder.build_cart`` pricing path
+        (``_build_cart_result``'s ``cost = (product.price *
+        decision.quantity).quantize(CENTS, rounding=ROUND_HALF_UP)``),
+        not a synthetic helper call.
+        """
+        item = _make_shopping_item(quantity=1.0, unit="lb")
+        product = _make_product(price=1.005, size="1 lb")
+        builder = _make_builder(search_results=[product], selection_product=product)
+
+        cart = builder.build_cart([item])
+
+        assert len(cart.items) == 1
+        cost = cart.items[0].estimated_cost
+        assert cost == Decimal("1.01")
+        assert isinstance(cost, Decimal)
+
+    def test_half_up_rounding_via_substitution_pricing_path(self) -> None:
+        """Test a $1.005 substitute also rounds to $1.01 (half-up).
+
+        ``_substitution_to_cart_item`` is the fourth money-producing
+        site in ``cart_builder`` (after ``_build_cart_result``,
+        ``_calculate_subtotal``, and the ``estimated_total`` quantize in
+        ``build_cart``). With Decimal prices, a leftover
+        ``round(Decimal, 2)`` would silently use the decimal context's
+        default ROUND_HALF_EVEN (banker's rounding: $1.005 -> $1.00),
+        so this pins the substitution path to the same
+        ROUND_HALF_UP cents math as the primary pricing path.
+        """
+        substitute = _make_product(product_id="ALT1", price=1.005, size="1 lb")
+        option = SubstitutionOption(
+            product=substitute,
+            suitability=SubstitutionSuitability.GOOD,
+            reasoning="Similar product",
+        )
+        result = SubstitutionResult(
+            status="alternatives_found",
+            original_item=_make_shopping_item(quantity=1.0, unit="lb"),
+            alternatives=[option],
+            selected=option,
+            message="Found 1 alternative(s)",
+        )
+
+        cart_item = _substitution_to_cart_item(result, cap=10)
+
+        assert cart_item is not None
+        assert cart_item.estimated_cost == Decimal("1.01")
+        assert isinstance(cart_item.estimated_cost, Decimal)
+
+    def test_penny_drift_sum_subtotal_exact_decimal(self) -> None:
+        """Test ten $0.10 items plus one $0.20 item sum to exactly $1.20.
+
+        Drives ``cart_builder._calculate_subtotal`` -- the same pure
+        helper ``CartBuilder.build_cart`` calls to compute
+        ``CartSummary.subtotal`` -- directly. Float summation of
+        eleven cent-level values is a classic source of penny drift;
+        the fix must aggregate in cents-quantized Decimal so the sum
+        is exact, not merely "close enough" once rounded for display.
+        """
+        items = [_make_cart_item(price=0.10) for _ in range(10)]
+        items.append(_make_cart_item(price=0.20))
+
+        subtotal = _calculate_subtotal(items, [])
+
+        assert isinstance(subtotal, Decimal)
+        assert subtotal == Decimal("1.20")
+
+
+# ------------------------------------------------------------------
+# 2. Type assertions: money fields are Decimal after validation
+# ------------------------------------------------------------------
+
+
+class TestMoneyFieldTypesAreDecimal:
+    """Money-bearing fields must be ``Decimal`` after model validation."""
+
+    def test_safeway_product_price_is_decimal(self) -> None:
+        """Test SafewayProduct.price is a Decimal instance."""
+        product = _make_product(price=5.99)
+        assert isinstance(product.price, Decimal)
+
+    def test_cart_item_estimated_cost_is_decimal(self) -> None:
+        """Test CartItem.estimated_cost is a Decimal instance."""
+        item = _make_cart_item(price=8.99)
+        assert isinstance(item.estimated_cost, Decimal)
+
+    def test_fulfillment_option_fee_is_decimal(self) -> None:
+        """Test FulfillmentOption.fee is a Decimal instance."""
+        option = _make_fulfillment_option(fee=9.95)
+        assert isinstance(option.fee, Decimal)
+
+    def test_cart_summary_subtotal_and_estimated_total_are_decimal(self) -> None:
+        """Test CartSummary.subtotal and estimated_total are Decimal instances."""
+        cart = _make_cart_summary(subtotal=10.0, estimated_total=10.0)
+        assert isinstance(cart.subtotal, Decimal)
+        assert isinstance(cart.estimated_total, Decimal)
+
+
+# ------------------------------------------------------------------
+# 3. Wire-contract stability: JSON dumps stay numbers, not strings
+# ------------------------------------------------------------------
+
+
+class TestWireContractStabilityJsonNumbers:
+    """Money fields must dump as JSON numbers (floats), never strings.
+
+    These currently PASS -- the fields are still plain ``float`` --
+    which is exactly why they're pinned here. Pydantic's default JSON
+    serialization of a ``Decimal`` is a *string* (to avoid float
+    precision loss), so once the fields become ``Decimal``, the
+    ``Money`` type's ``PlainSerializer(float, ..., when_used="json")``
+    is required to keep the wire contract unchanged. Without it, these
+    tests would start failing the moment the field type flips.
+    """
+
+    def test_cart_dump_money_fields_are_json_numbers(self) -> None:
+        """Test cart.model_dump(mode="json") money fields are floats (pin)."""
+        cart = _make_cart_summary(
+            subtotal=8.99,
+            estimated_total=8.99,
+            fulfillment_options=[_make_fulfillment_option(fee=0.0)],
+        )
+
+        dumped = cart.model_dump(mode="json")
+
+        assert isinstance(dumped["subtotal"], float)
+        assert isinstance(dumped["estimated_total"], float)
+        assert isinstance(dumped["items"][0]["estimated_cost"], float)
+        assert isinstance(dumped["items"][0]["safeway_product"]["price"], float)
+        assert isinstance(dumped["fulfillment_options"][0]["fee"], float)
+        json.dumps(dumped)  # must not raise
+
+    def test_build_order_payload_estimated_total_is_json_number(self) -> None:
+        """Test _build_order_payload's estimatedTotal is a float (pin)."""
+        cart = _make_cart_summary(subtotal=8.99, estimated_total=8.99)
+
+        payload = _build_order_payload(cart)
+
+        assert isinstance(payload["estimatedTotal"], float)
+        json.dumps(payload)  # must not raise
+
+
+# ------------------------------------------------------------------
+# 4. Issue #73 semantics preserved: non-finite rejection, bool rejection
+# ------------------------------------------------------------------
+
+
+class TestIssue73SemanticsPreservedForMoney:
+    """Non-finite money is still rejected; bool must also be rejected.
+
+    Issue #73 (``allow_inf_nan=False``) already guards ``CartItem.
+    estimated_cost``, ``FulfillmentOption.fee``, and ``CartSummary.
+    subtotal``/``estimated_total`` -- those parametrized cases below
+    are pins. ``SafewayProduct.price``/``unit_price`` have no such
+    guard today, so the non-finite cases for those fields are genuine
+    RED. Bool rejection is also genuine RED: nothing today stops
+    ``price=True`` from validating as a truthy "1.0".
+    """
+
+    @pytest.mark.parametrize("bad_value", [float("inf"), float("-inf"), float("nan")])
+    def test_cart_item_estimated_cost_rejects_non_finite_pin(
+        self, bad_value: float
+    ) -> None:
+        """Test CartItem.estimated_cost still rejects inf/-inf/nan (pin)."""
+        with pytest.raises(ValidationError):
+            CartItem(
+                shopping_list_item=_make_shopping_item(),
+                safeway_product=_make_product(),
+                quantity_to_order=1,
+                estimated_cost=bad_value,
+            )
+
+    @pytest.mark.parametrize("bad_value", [float("inf"), float("-inf"), float("nan")])
+    def test_fulfillment_option_fee_rejects_non_finite_pin(
+        self, bad_value: float
+    ) -> None:
+        """Test FulfillmentOption.fee still rejects inf/-inf/nan (pin)."""
+        with pytest.raises(ValidationError):
+            _make_fulfillment_option(fee=bad_value)
+
+    @pytest.mark.parametrize("field", ["subtotal", "estimated_total"])
+    def test_cart_summary_totals_reject_non_finite_pin(self, field: str) -> None:
+        """Test CartSummary subtotal/estimated_total still reject non-finite (pin)."""
+        kwargs: dict[str, float] = {"subtotal": 0.0, "estimated_total": 0.0}
+        kwargs[field] = float("inf")
+        with pytest.raises(ValidationError):
+            _make_cart_summary(**kwargs)
+
+    @pytest.mark.parametrize("bad_value", [float("inf"), float("-inf"), float("nan")])
+    def test_safeway_product_price_rejects_non_finite_new_guard(
+        self, bad_value: float
+    ) -> None:
+        """Test SafewayProduct.price rejects inf/-inf/nan (RED: no guard today)."""
+        with pytest.raises(ValidationError):
+            SafewayProduct(
+                product_id="P1", name="Bad Price", price=bad_value, size="1 lb"
+            )
+
+    @pytest.mark.parametrize("bad_value", [float("inf"), float("-inf"), float("nan")])
+    def test_safeway_product_unit_price_rejects_non_finite_new_guard(
+        self, bad_value: float
+    ) -> None:
+        """Test SafewayProduct.unit_price rejects inf/-inf/nan (RED: no guard today)."""
+        with pytest.raises(ValidationError):
+            SafewayProduct(
+                product_id="P1",
+                name="Bad Unit Price",
+                price=1.0,
+                unit_price=bad_value,
+                size="1 lb",
+            )
+
+    def test_model_validate_json_infinity_literal_rejected_pin(self) -> None:
+        """Test a raw JSON "Infinity" literal for estimated_cost is rejected (pin).
+
+        Python's json parser accepts the non-standard ``Infinity``
+        literal even though it isn't valid JSON, so a hand-built
+        payload is used here rather than ``json.dumps`` (which would
+        never emit an un-quoted bare literal from a normal float in a
+        way that reproduces this).
+        """
+        item = _make_shopping_item()
+        product = _make_product()
+        json_str = (
+            '{"shopping_list_item": '
+            + item.model_dump_json()
+            + ', "safeway_product": '
+            + product.model_dump_json()
+            + ', "quantity_to_order": 1, "estimated_cost": Infinity}'
+        )
+        with pytest.raises(ValidationError):
+            CartItem.model_validate_json(json_str)
+
+    def test_safeway_product_price_rejects_bool(self) -> None:
+        """Test SafewayProduct.price rejects a bare bool (RED: not enforced today).
+
+        ``bool`` is a subclass of ``int`` and would otherwise silently
+        coerce to a nonsensical ``1.0``/``0.0`` price -- the ``Money``
+        type's ``_coerce_money`` must explicitly reject it.
+        """
+        with pytest.raises(ValidationError):
+            SafewayProduct(product_id="P1", name="Bool Price", price=True, size="1 lb")
+
+
+# ------------------------------------------------------------------
+# 5. Money | None: optional monetary fields
+# ------------------------------------------------------------------
+
+
+class TestMoneyOptionalFields:
+    """``Money | None`` fields accept and round-trip ``None``."""
+
+    def test_safeway_product_unit_price_none_valid_and_dumps_none(self) -> None:
+        """Test SafewayProduct.unit_price=None validates and dumps as null."""
+        product = _make_product(unit_price=None)
+        assert product.unit_price is None
+
+        dumped = product.model_dump(mode="json")
+        assert dumped["unit_price"] is None
+
+    def test_shopping_list_item_estimated_price_none_valid_and_dumps_none(
+        self,
+    ) -> None:
+        """Test ShoppingListItem.estimated_price=None validates and dumps as null."""
+        item = _make_shopping_item(estimated_price=None)
+        assert item.estimated_price is None
+
+        dumped = item.model_dump(mode="json")
+        assert dumped["estimated_price"] is None
+
+
+# ------------------------------------------------------------------
+# 6. Coercion fidelity: float/str inputs coerce to exact Decimal
+# ------------------------------------------------------------------
+
+
+class TestCoercionFidelity:
+    """Money coercion must preserve decimal exactness, not binary drift."""
+
+    def test_safeway_product_price_float_coerces_exact_decimal(self) -> None:
+        """Test price=4.15 (float) coerces to exactly Decimal("4.15").
+
+        4.15 as a binary float is not exactly 4.15 in decimal, so this
+        also guards that coercion goes through ``Decimal(str(v))``
+        (exact) rather than ``Decimal(v)`` (binary-exact float
+        conversion, which would produce a long non-round value).
+        """
+        product = SafewayProduct(
+            product_id="P1", name="Coerce Float", price=4.15, size="1 lb"
+        )
+        assert product.price == Decimal("4.15")
+        assert isinstance(product.price, Decimal)
+
+    def test_safeway_product_price_string_coerces_to_decimal(self) -> None:
+        """Test price="4.15" (string) coerces to Decimal("4.15")."""
+        product = SafewayProduct(
+            product_id="P1", name="Coerce String", price="4.15", size="1 lb"
+        )
+        assert product.price == Decimal("4.15")
+        assert isinstance(product.price, Decimal)
+
+    def test_safeway_product_price_rejects_unparseable_string(self) -> None:
+        """Test an unparseable price string raises ValidationError.
+
+        Exercises ``_coerce_money``'s ``InvalidOperation`` branch: the
+        input is a coercible *type* (str) whose value cannot form a
+        Decimal.
+        """
+        with pytest.raises(ValidationError):
+            SafewayProduct(
+                product_id="P1", name="Bad String", price="not-money", size="1 lb"
+            )
+
+    def test_safeway_product_price_rejects_non_numeric_type(self) -> None:
+        """Test a non-coercible type (list) is rejected downstream.
+
+        Exercises ``_coerce_money``'s pass-through branch: values that
+        aren't Decimal/int/float/str are returned unchanged so
+        Pydantic's own type validation rejects them with its usual
+        error.
+        """
+        with pytest.raises(ValidationError):
+            SafewayProduct(product_id="P1", name="Bad Type", price=[4, 15], size="1 lb")
+
+
+# ------------------------------------------------------------------
+# 7. sqlite round-trip through product_search's cache
+# ------------------------------------------------------------------
+
+
+class TestSqliteRoundTripPreservesDecimalPrecision:
+    """A cached product's price must round-trip through sqlite as Decimal."""
+
+    def _make_service(self, db_path: str) -> ProductSearchService:
+        """Create a ProductSearchService over a real sqlite db, mock HTTP.
+
+        Args:
+            db_path: Path to the test database.
+
+        Returns:
+            ProductSearchService instance. No live HTTP calls are made
+            by these tests, so the transport is never asked to respond.
+        """
+        transport = httpx.MockTransport(
+            lambda request: httpx.Response(500, json={"error": "unused"})
+        )
+        http = httpx.Client(transport=transport)
+        client = SafewayClient("user", "pass", "1234", http_client=http)
+        return ProductSearchService(client, db_path)
+
+    def test_product_price_round_trip_preserves_decimal_exactness(
+        self, db_path: str
+    ) -> None:
+        """Test a product priced 4.15 round-trips through the cache as Decimal.
+
+        Regression guard for issue #81: today ``SafewayProduct.price``
+        is a plain float, so ``cached.product.price`` comes back as a
+        float, not a ``Decimal`` -- this fails on the isinstance check
+        even before considering exactness.
+        """
+        service = self._make_service(db_path)
+        product = _make_product(price=4.15)
+
+        service.save_mapping("term", product)
+        cached = service.get_cached_mapping("term")
+
+        assert cached is not None
+        assert cached.product.price == Decimal("4.15")
+        assert isinstance(cached.product.price, Decimal)
+
+
+# ------------------------------------------------------------------
+# 8. order_service._safe_money
+# ------------------------------------------------------------------
+
+
+class TestSafeMoneyOrderService:
+    """Tests for the not-yet-existing ``order_service._safe_money``.
+
+    ``_safe_money`` doesn't exist yet, so it is imported locally inside
+    each test body (matching this file's existing convention for names
+    introduced test-first, e.g. ``compute_cart_total`` in
+    ``tests/test_order_service.py``) rather than at module scope, where
+    the ``ImportError`` would break collection of every other test in
+    this file.
+    """
+
+    def test_safe_money_valid_string_becomes_decimal(self) -> None:
+        """Test a valid numeric string converts to an exact Decimal."""
+        from grocery_butler.order_service import _safe_money
+
+        result = _safe_money("12.34", Decimal("0"))
+        assert result == Decimal("12.34")
+        assert isinstance(result, Decimal)
+
+    def test_safe_money_none_returns_fallback(self) -> None:
+        """Test None returns the given fallback."""
+        from grocery_butler.order_service import _safe_money
+
+        assert _safe_money(None, Decimal("9.99")) == Decimal("9.99")
+
+    def test_safe_money_garbage_string_returns_fallback(self) -> None:
+        """Test a non-numeric string returns the fallback."""
+        from grocery_butler.order_service import _safe_money
+
+        assert _safe_money("not-a-number", Decimal("1.00")) == Decimal("1.00")
+
+    def test_safe_money_nan_string_returns_fallback(self) -> None:
+        """Test the string "NaN" (a valid but non-finite Decimal) returns fallback.
+
+        ``Decimal("NaN")`` does not raise ``InvalidOperation`` -- it's a
+        legitimate non-finite Decimal value -- so ``_safe_money`` must
+        explicitly check finiteness, not merely catch construction
+        errors.
+        """
+        from grocery_butler.order_service import _safe_money
+
+        assert _safe_money("NaN", Decimal("2.50")) == Decimal("2.50")
+
+    def test_safe_money_quantizes_to_cents(self) -> None:
+        """Test a three-decimal-place input quantizes to cents, half-up."""
+        from grocery_butler.order_service import _safe_money
+
+        assert _safe_money("12.345", Decimal("0")) == Decimal("12.35")
+
+
+# ------------------------------------------------------------------
+# 9. OrderConfirmation.total from _parse_order_response
+# ------------------------------------------------------------------
+
+
+class TestOrderConfirmationTotalIsDecimal:
+    """OrderConfirmation.total must be Decimal after response parsing."""
+
+    def test_parse_order_response_total_is_decimal(self) -> None:
+        """Test a response total of 25.97 parses into Decimal("25.97")."""
+        cart = _make_cart_summary(subtotal=25.97, estimated_total=25.97)
+        response = {"orderId": "ORD-1", "status": "confirmed", "total": 25.97}
+
+        confirmation = _parse_order_response(response, cart)
+
+        assert confirmation is not None
+        assert confirmation.total == Decimal("25.97")
+        assert isinstance(confirmation.total, Decimal)

--- a/tests/test_order_service.py
+++ b/tests/test_order_service.py
@@ -20,7 +20,7 @@ from grocery_butler.order_service import (
     _build_order_payload,
     _collect_restock_ingredients,
     _parse_order_response,
-    _safe_float,
+    _safe_money,
     _serialize_cart_items,
 )
 
@@ -228,7 +228,7 @@ class TestBuildOrderPayload:
 
         assert "items" in result
         assert result["fulfillmentType"] == "pickup"
-        assert result["estimatedTotal"] == cart.estimated_total
+        assert result["estimatedTotal"] == float(cart.estimated_total)
 
     def test_includes_restock_items(self) -> None:
         """Test restock items are included in payload."""
@@ -262,7 +262,7 @@ class TestBuildOrderPayload:
 
         product_ids = [i["productId"] for i in result["items"]]
         assert "ALT1" in product_ids
-        assert result["estimatedTotal"] == cart.estimated_total
+        assert result["estimatedTotal"] == float(cart.estimated_total)
 
 
 # ------------------------------------------------------------------
@@ -288,7 +288,7 @@ class TestParseOrderResponse:
         assert result.order_id == "ORD-12345"
         assert result.status == "confirmed"
         assert result.estimated_time == "Today 4-6pm"
-        assert result.total == 25.99
+        assert result.total == Decimal("25.99")
 
     def test_error_response(self) -> None:
         """Test error status returns None."""
@@ -1015,36 +1015,43 @@ class TestSubmissionDisabledGate:
 
 
 # ------------------------------------------------------------------
-# Tests: _safe_float
+# Tests: _safe_money
 # ------------------------------------------------------------------
 
 
-class TestSafeFloat:
-    """Tests for _safe_float."""
+class TestSafeMoney:
+    """Tests for _safe_money (see tests/test_money.py for more).
 
-    def test_valid_float(self) -> None:
-        """Test valid float value passes through."""
-        assert _safe_float(25.99, 0.0) == 25.99
+    ``_safe_money`` replaced the float-era ``_safe_float`` for issue
+    #81; the core Decimal semantics (string/None/garbage/NaN/quantize)
+    are covered in ``tests/test_money.py`` — these cases keep the
+    float-input, int-input, and empty-string coverage the old
+    ``_safe_float`` tests provided.
+    """
 
-    def test_valid_int(self) -> None:
-        """Test integer value converts to float."""
-        assert _safe_float(10, 0.0) == 10.0
+    def test_valid_float_becomes_exact_decimal(self) -> None:
+        """Test a float value converts to its exact decimal reading."""
+        assert _safe_money(25.99, Decimal("0")) == Decimal("25.99")
 
-    def test_valid_string(self) -> None:
-        """Test numeric string converts to float."""
-        assert _safe_float("12.50", 0.0) == 12.50
+    def test_valid_int_becomes_decimal(self) -> None:
+        """Test an integer value converts to a cents-quantized Decimal."""
+        assert _safe_money(10, Decimal("0")) == Decimal("10.00")
+
+    def test_valid_string_becomes_decimal(self) -> None:
+        """Test a numeric string converts to a Decimal."""
+        assert _safe_money("12.50", Decimal("0")) == Decimal("12.50")
 
     def test_none_returns_fallback(self) -> None:
         """Test None returns fallback."""
-        assert _safe_float(None, 42.0) == 42.0
+        assert _safe_money(None, Decimal("42.00")) == Decimal("42.00")
 
     def test_invalid_string_returns_fallback(self) -> None:
         """Test non-numeric string returns fallback."""
-        assert _safe_float("N/A", 99.0) == 99.0
+        assert _safe_money("N/A", Decimal("99.00")) == Decimal("99.00")
 
     def test_empty_string_returns_fallback(self) -> None:
         """Test empty string returns fallback."""
-        assert _safe_float("", 5.0) == 5.0
+        assert _safe_money("", Decimal("5.00")) == Decimal("5.00")
 
 
 # ------------------------------------------------------------------

--- a/tests/test_product_search.py
+++ b/tests/test_product_search.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime, timedelta
+from decimal import Decimal
 from typing import Any
 from unittest.mock import patch
 
@@ -154,7 +155,7 @@ class TestParseSearchResults:
         assert len(result) == 1
         assert result[0].product_id == "00012345"
         assert result[0].name == "Whole Milk 1 Gallon"
-        assert result[0].price == 4.99
+        assert result[0].price == Decimal("4.99")
         assert result[0].size == "1 gal"
         assert result[0].in_stock is True
 
@@ -226,7 +227,7 @@ class TestParseSingleProduct:
         result = _parse_single_product(item)
 
         assert result is not None
-        assert result.price == 2.99
+        assert result.price == Decimal("2.99")
 
     def test_unit_price_parsed(self) -> None:
         """Test that unitPrice is parsed when present."""
@@ -240,7 +241,7 @@ class TestParseSingleProduct:
         result = _parse_single_product(item)
 
         assert result is not None
-        assert result.unit_price == 0.16
+        assert result.unit_price == Decimal("0.16")
 
 
 # ------------------------------------------------------------------
@@ -328,7 +329,7 @@ class TestSearchProducts:
 
         assert len(results) == 1
         assert results[0].product_id == "001"
-        assert results[0].price == 3.99
+        assert results[0].price == Decimal("3.99")
         client.close()
 
     @patch("grocery_butler.safeway_client.time.sleep")
@@ -412,7 +413,7 @@ class TestCacheOperations:
         assert cached is not None
         assert cached.product.product_id == "UPC001"
         assert cached.product.name == "Organic Whole Milk"
-        assert cached.product.price == 5.99
+        assert cached.product.price == Decimal("5.99")
         assert cached.is_pinned is False
         assert cached.times_selected == 1
 
@@ -595,7 +596,7 @@ class TestCacheOperations:
         cached = service.get_cached_mapping("whole milk")
 
         assert cached is not None
-        assert cached.product.price == 5.49
+        assert cached.product.price == Decimal("5.49")
         assert cached.product.size == "0.5 gal"
         assert cached.product.in_stock is False
 
@@ -630,7 +631,7 @@ class TestCacheOperations:
 
         assert cached is not None
         assert cached.is_pinned is True
-        assert cached.product.price == 5.79
+        assert cached.product.price == Decimal("5.79")
         assert cached.product.size == "0.5 gal"
         assert cached.product.in_stock is False
 
@@ -839,7 +840,7 @@ class TestReverifyProduct:
         result = service.reverify_product(cached)
 
         assert result.product_id == "P1"
-        assert result.price == 5.49
+        assert result.price == Decimal("5.49")
         assert result.size == "2 lb"
         assert result.in_stock is True
         client.close()
@@ -868,7 +869,7 @@ class TestReverifyProduct:
         result = service.reverify_product(cached)
 
         assert result.product_id == "P1"
-        assert result.price == 3.99
+        assert result.price == Decimal("3.99")
         assert result.size == "1 lb"
         assert result.in_stock is False
         client.close()
@@ -968,7 +969,7 @@ class TestRowToCachedMapping:
             assert result.ingredient_description == "milk"
             assert result.product.product_id == "UPC1"
             assert result.product.name == "Test Milk"
-            assert result.product.price == 3.99
+            assert result.product.price == Decimal("3.99")
             assert result.product.size == "1 gal"
             assert result.product.in_stock is False
             assert result.is_pinned is True


### PR DESCRIPTION
## Summary

Fixes the launch-readiness audit finding that money was binary floats end-to-end: `SafewayProduct.price: float`, per-item costs via `round(price * qty, 2)`, subtotals via float sums, and a float-derived `estimatedTotal` POSTed to Safeway.

- **New `Money` type** (`grocery_butler/models.py`): `Annotated[Decimal, BeforeValidator(_coerce_money), PlainSerializer(float, when_used="json")]` applied to every monetary field (`price`, `unit_price`, `estimated_cost`, `fee`, `subtotal`, `estimated_total`, `estimated_price`). Coercion goes through `Decimal(str(v))` for exactness, rejects `bool`, and rejects non-finite values — preserving the issue #73 `allow_inf_nan=False` semantics.
- **Cents arithmetic**: every money-producing site in `cart_builder.py` and `order_service.py` quantizes with the shared `CENTS` quantum and `ROUND_HALF_UP`, including the substitution pricing path, which previously would have silently used Decimal's context-default banker's rounding (`round(Decimal, 2)` -> ROUND_HALF_EVEN).
- **Wire contract unchanged**: money serializes to plain JSON numbers (not Pydantic's default Decimal-as-string), pinned by tests. `_build_order_payload` converts `estimatedTotal` to `float` at the JSON boundary; the two Claude-prompt `json.dumps` sites convert likewise.
- **Persistence**: `db/adapter.py` binds `Decimal` params as `str` for sqlite3 (scoped to the adapter, not a global `register_adapter`; psycopg2 already handles `Decimal`), and the product-cache read path reconstructs exact cent-level Decimals via `Decimal(str(...))`. Pre-existing float-written rows read back identically.
- **`_safe_float` -> `_safe_money`** in `order_service.py`: finiteness-checked (a `"NaN"` string constructs a valid non-finite Decimal, so catching `InvalidOperation` alone is insufficient), cents-quantized, falls back to the cart's server-computed total. `OrderConfirmation.total` is now `Decimal`.

## Test plan

- New `tests/test_money.py` (38 tests): half-up rounding regressions through both the primary and substitution pricing paths (`$1.005 -> $1.01`), exact penny-drift subtotal sums, Decimal type pins on all money fields, JSON-number wire-contract pins, issue #73 non-finite/bool rejection, `Money | None` handling, coercion fidelity, sqlite cache round-trip, `_safe_money`, and `_parse_order_response` totals.
- New `_adapt_sqlite_params` unit tests in `tests/test_adapter.py`, including a real-SQLite REAL-column round-trip.
- Existing float-literal equality pins across 6 test modules updated to `Decimal("...")` (Decimal-vs-float equality is exact-value comparison, so e.g. `Decimal("8.99") == 8.99` is deliberately false).
- `./scripts/check-all.sh` passes 7/7 locally: 1771 tests, coverage 96%+, mypy strict, ruff, bandit, complexity, docstrings.

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)